### PR TITLE
Introduce Tinkernet multisig XCM configs to Moonbase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "invarch-xcm-builder"
 version = "0.1.0"
-source = "git+https://github.com/InvArch/InvArch-XCM-Builder?branch=polkadot-v0.9.40#65c59b740a44fc4e947b586ac654e6a5d96ce28e"
+source = "git+https://github.com/InvArch/InvArch-XCM-Builder?rev=65c59b740a44fc4e947b586ac654e6a5d96ce28e#65c59b740a44fc4e947b586ac654e6a5d96ce28e"
 dependencies = [
  "frame-support",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4120,6 +4120,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "invarch-xcm-builder"
+version = "0.1.0"
+source = "git+https://github.com/InvArch/InvArch-XCM-Builder?branch=polkadot-v0.9.40#65c59b740a44fc4e947b586ac654e6a5d96ce28e"
+dependencies = [
+ "frame-support",
+ "log",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5406,6 +5420,7 @@ dependencies = [
  "frame-try-runtime",
  "hex",
  "hex-literal",
+ "invarch-xcm-builder",
  "log",
  "moonbeam-core-primitives",
  "moonbeam-evm-tracer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonb
 
 # InvArch (wasm)
 # Only needed until the configs get merged into xcm-builder: https://github.com/paritytech/polkadot/pull/7165
-invarch-xcm-builder = { git = "https://github.com/InvArch/InvArch-XCM-Builder", branch = "polkadot-v0.9.40", default-features = false }
+invarch-xcm-builder = { git = "https://github.com/InvArch/InvArch-XCM-Builder", rev = "65c59b740a44fc4e947b586ac654e6a5d96ce28e", default-features = false }
 
 # Other (wasm)
 affix = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,6 +313,10 @@ rococo-runtime = { git = "https://github.com/purestake/polkadot", branch = "moon
 westend-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.40" }
 xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.40" }
 
+# InvArch (wasm)
+# Only needed until the configs get merged into xcm-builder: https://github.com/paritytech/polkadot/pull/7165
+invarch-xcm-builder = { git = "https://github.com/InvArch/InvArch-XCM-Builder", branch = "polkadot-v0.9.40", default-features = false }
+
 # Other (wasm)
 affix = "0.1.2"
 async-trait = { version = "0.1.42" }
@@ -369,6 +373,16 @@ evm = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a31
 evm-core = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
 evm-gasometer = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
 evm-runtime = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
+
+# Patches for invarch-xcm-builder
+[patch."https://github.com/paritytech/substrate"]
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.40" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.40" }
+
+[patch."https://github.com/paritytech/polkadot"]
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.40" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.40" }
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
 # that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -156,6 +156,9 @@ frame-benchmarking = { workspace = true, optional = true }
 frame-system-benchmarking = { workspace = true, optional = true }
 frame-try-runtime = { workspace = true, optional = true }
 
+# InvArch XCM configs
+invarch-xcm-builder = { workspace = true }
+
 [dev-dependencies]
 ethereum = { workspace = true }
 hex = { workspace = true, features = [ "std" ] }

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -112,6 +112,8 @@ pub type LocationToAccountId = (
 	AccountKey20Aliases<RelayNetwork, AccountId>,
 	// Generate remote accounts according to polkadot standards
 	xcm_builder::ForeignChainAliasAccount<AccountId>,
+	// Mapping Tinkernet multisig to the correctly derived AccountId32.
+	invarch_xcm_builder::TinkernetMultisigAsAccountId<AccountId>,
 );
 
 /// Wrapper type around `LocationToAccountId` to convert an `AccountId` to type `H160`.
@@ -219,6 +221,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognised.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
+	// Derives signed AccountId32 origins for Tinkernet multisigs.
+	invarch_xcm_builder::DeriveOriginFromTinkernetMultisig<RuntimeOrigin>,
 	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
 	pallet_xcm::XcmPassthrough<RuntimeOrigin>,
 	// Xcm Origins defined by a Multilocation of type AccountKey20 can be converted to a 20 byte-


### PR DESCRIPTION
This PR adds the XCM configs necessary to allow Tinkernet multisigs to transact on Moonbase.

Tinkernet multisigs have the following MultiLocation pattern:
```rust
MultiLocation {
    parents: _, // ancestry depends on the point of reference. 0 if from parent, 1 if from sibling.
    interior: Junctions::X3(
        Junction::Parachain(2125), // Tinkernet ParaId in Kusama/Rococo.
        Junction::PalletInstance(71), // Pallet INV4, from which the multisigs originate.
        Junction::GeneralIndex(_) // Index from which the multisig account is derived.
    )
}
```

The following are the configs added by this PR to give the multisigs accounts and origins in Moonbase:

### In LocationToAccountId
```rust
invarch_xcm_builder::TinkernetMultisigAsAccountId<AccountId>,
```
This MultiLocation converter derives an AccountId for locations matching the one described above, it does so by using the same exact derivation function used in Tinkernet, this is important to make sure the multisigs maintain the same address across all chains, providing the best UX possible.
Because this derivation happens in Moonbase, it means the whole process is trustless and removes any possibility of account impersonation!

### In XcmOriginToTransactDispatchOrigin
```rust
invarch_xcm_builder::DeriveOriginFromTinkernetMultisig<RuntimeOrigin>,
```
Same as explained above, except here we need to derive the AccountId and wrap it with a RawOrigin::Signed origin so this account can use the `Transact` XCM instruction and thus call extrinsics in the Moonbase runtime's pallets.

**Obs:** These XCM configs are being pulled from a [dependency](https://github.com/InvArch/InvArch-XCM-Builder), however this is only a temporary measure, as there is an [open PR](https://github.com/paritytech/polkadot/pull/7165) to merge them into paritytech/polkadot under the xcm-builder crate, which this runtime is already dependent on.