### PR TITLE
GMP Fee Support

### DIFF
--- a/precompiles/gmp/src/lib.rs
+++ b/precompiles/gmp/src/lib.rs
@@ -189,6 +189,7 @@ where
 				dest: Box::new(action.destination),
 				dest_weight_limit: WeightLimit::Unlimited,
 			},
+			VersionedUserAction::V2(action_with_fee) => todo!(),
 		};
 
 		log::debug!(target: "gmp-precompile", "sending xcm {:?}", call);

--- a/precompiles/gmp/src/types.rs
+++ b/precompiles/gmp/src/types.rs
@@ -22,6 +22,12 @@ use sp_core::{H256, U256};
 use sp_std::vec::Vec;
 use xcm::VersionedMultiLocation;
 
+// Enumuration of all actions
+#[derive(Encode, Decode, Debug)]
+pub enum Action {
+	XcmRouting(XcmRoutingUserAction),
+}
+
 // A user action which will attempt to route the transferred assets to the account/chain specified
 // by the given MultiLocation. Recall that a MultiLocation can contain both a chain and an account
 // on that chain, as this one should.
@@ -30,12 +36,34 @@ pub struct XcmRoutingUserAction {
 	pub destination: VersionedMultiLocation,
 }
 
-// A simple versioning wrapper around the initial XcmRoutingUserAction use-case. This should make
-// future breaking changes easy to add in a backwards-compatible way.
+// Enumeration of all fee types
+#[derive(Encode, Decode, Debug)]
+pub enum Fee {
+	NativeFee(NativeFee),
+}
+
+// A fee paid in native currency
+#[derive(Encode, Decode, Debug)]
+pub struct NativeFee {
+	fee: u128, // TODO: use balance type?
+}
+
+// The outermost payload for the GMP precompile.
 #[derive(Encode, Decode, Debug)]
 #[non_exhaustive]
 pub enum VersionedUserAction {
+	// Original VersionedUserAction which supported no fee and only one fixed action.
 	V1(XcmRoutingUserAction),
+	// V2 VersionedUserAction which supports different UserActions and Fees.
+	V2(ActionWithFee),
+}
+
+// An action with an attached fee. The fee should be able to be taken from the funds associated
+// with the action itself, e.g. deducted from the overall amount of a bridged transfer.
+#[derive(Encode, Decode, Debug)]
+pub struct ActionWithFee {
+	pub action: Action,
+	pub fee: Fee,
 }
 
 // Struct representing a Wormhole VM


### PR DESCRIPTION
### What does it do?

This is an attempt to add a fee to the GMP payload. It creates a rather complicated structure for the payload where each element is wrapped in an enum for maximum forward- and backward-compatibility.

The original payload looked like:
```
VersionedUserAction::V1 (enum variant)
    XcmRoutingUserAction (struct)
        destination: VersionedMultiLocation
```

### Proposed additions in this current PR:

Regardless of what change we make, the above is still supported, but the newly added `ActionWithFee` payload would look like:
```
VersionedUserAction::V2 (enum variant)
    ActionWithFee (struct)
        action: Action (enum)
            XcmRouting (enum variant)
                XcmRoutingUserAction (struct)
                    destination: VersionedMultiLocation
        fee: Fee (enum)
            NativeFee (enum variant)
                NativeFee (struct)
                    fee: u128
```

Some improvements could be made to the naming to avoid some duplication/confusion, but I'm more interested in feedback on the overall structure. It strikes me as overkill, but I can also justify it in that it maximizes future-proofing.

### Alternative, simpler / flatter:

A simpler approach could be:

```rust
pub struct XcmRoutingUserActionWithFee {
    pub destination: VersionedMultiLocation,
    pub fee: u128,
}

// and then a new VersionedUserAction variant:

pub enum VersionedUserAction {
    // ...
    V2(XcmRoutingUserActionWithFee),
}
```

Which would look like:

```
VersionedUserAction::V2 (enum variant)
    XcmRoutingUserActionWithFee (struct)
        destination: VersionedMultiLocation,
        fee: u128,
```

### Looking for Feedback

Obviously there's a trade-off in these two approaches. The developer-experience could be pretty painful with the complicated approach, but it could also be worse if we stick with a simple solution now and make it more complicated later.