### PR TITLE
(Do Not Merge) Perm runtime 2402

### DIFF
--- a/runtime/moonbase/src/governance/referenda.rs
+++ b/runtime/moonbase/src/governance/referenda.rs
@@ -37,7 +37,7 @@ impl pallet_conviction_voting::Config for Runtime {
 	type Polls = Referenda;
 	type MaxTurnout = frame_support::traits::TotalIssuanceOf<Balances, Self::AccountId>;
 	// Maximum number of concurrent votes an account may have
-	type MaxVotes = ConstU32<30>;
+	type MaxVotes = ConstU32<20>;
 	// Minimum period of vote locking
 	type VoteLockingPeriod = VoteLockingPeriod;
 }

--- a/runtime/moonbase/src/governance/referenda.rs
+++ b/runtime/moonbase/src/governance/referenda.rs
@@ -37,7 +37,7 @@ impl pallet_conviction_voting::Config for Runtime {
 	type Polls = Referenda;
 	type MaxTurnout = frame_support::traits::TotalIssuanceOf<Balances, Self::AccountId>;
 	// Maximum number of concurrent votes an account may have
-	type MaxVotes = ConstU32<512>;
+	type MaxVotes = ConstU32<30>;
 	// Minimum period of vote locking
 	type VoteLockingPeriod = VoteLockingPeriod;
 }

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -179,7 +179,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 4,
-	spec_version: 2401,
+	spec_version: 2402,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/governance/referenda.rs
+++ b/runtime/moonbeam/src/governance/referenda.rs
@@ -37,7 +37,7 @@ impl pallet_conviction_voting::Config for Runtime {
 	type Polls = Referenda;
 	type MaxTurnout = frame_support::traits::TotalIssuanceOf<Balances, Self::AccountId>;
 	// Maximum number of concurrent votes an account may have
-	type MaxVotes = ConstU32<30>;
+	type MaxVotes = ConstU32<20>;
 	// Minimum period of vote locking
 	type VoteLockingPeriod = VoteLockingPeriod;
 }

--- a/runtime/moonbeam/src/governance/referenda.rs
+++ b/runtime/moonbeam/src/governance/referenda.rs
@@ -37,7 +37,7 @@ impl pallet_conviction_voting::Config for Runtime {
 	type Polls = Referenda;
 	type MaxTurnout = frame_support::traits::TotalIssuanceOf<Balances, Self::AccountId>;
 	// Maximum number of concurrent votes an account may have
-	type MaxVotes = ConstU32<512>;
+	type MaxVotes = ConstU32<30>;
 	// Minimum period of vote locking
 	type VoteLockingPeriod = VoteLockingPeriod;
 }

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 2401,
+	spec_version: 2402,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/governance/referenda.rs
+++ b/runtime/moonriver/src/governance/referenda.rs
@@ -37,7 +37,7 @@ impl pallet_conviction_voting::Config for Runtime {
 	type Polls = Referenda;
 	type MaxTurnout = frame_support::traits::TotalIssuanceOf<Balances, Self::AccountId>;
 	// Maximum number of concurrent votes an account may have
-	type MaxVotes = ConstU32<30>;
+	type MaxVotes = ConstU32<20>;
 	// Minimum period of vote locking
 	type VoteLockingPeriod = VoteLockingPeriod;
 }

--- a/runtime/moonriver/src/governance/referenda.rs
+++ b/runtime/moonriver/src/governance/referenda.rs
@@ -37,7 +37,7 @@ impl pallet_conviction_voting::Config for Runtime {
 	type Polls = Referenda;
 	type MaxTurnout = frame_support::traits::TotalIssuanceOf<Balances, Self::AccountId>;
 	// Maximum number of concurrent votes an account may have
-	type MaxVotes = ConstU32<512>;
+	type MaxVotes = ConstU32<30>;
 	// Minimum period of vote locking
 	type VoteLockingPeriod = VoteLockingPeriod;
 }

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -175,7 +175,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 2401,
+	spec_version: 2402,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
We lower the MaxVotes from 512 to 20 so the Weight hint (which has a proof_size of: `MaxVotes  * 110917 + 176657`) can fit in a Block