### PR TITLE
Increase erc20 xcm gas cost

### DIFF
--- a/pallets/erc20-xcm-bridge/src/erc20_matcher.rs
+++ b/pallets/erc20-xcm-bridge/src/erc20_matcher.rs
@@ -35,8 +35,7 @@ impl<Erc20MultilocationPrefix: Get<MultiLocation>> MatchesFungibles<H160, U256>
 		};
 		let contract_address = Self::matches_erc20_multilocation(id)
 			.map_err(|_| MatchError::AssetIdConversionFailed)?;
-		let amount =
-			U256::try_from(*amount).map_err(|_| MatchError::AmountToBalanceConversionFailed)?;
+		let amount = U256::from(*amount);
 
 		Ok((contract_address, amount))
 	}
@@ -111,6 +110,28 @@ mod tests {
 				location, 100u128
 			))),
 			(H160([0; 20]), U256([100, 0, 0, 0]))
+		);
+	}
+
+	#[test]
+	fn should_match_valid_erc20_location_with_amount_greater_than_u64() {
+		let location = MultiLocation {
+			parents: 0,
+			interior: Junctions::X2(
+				PalletInstance(42u8),
+				AccountKey20 {
+					key: [0; 20],
+					network: None,
+				},
+			),
+		};
+
+		assert_ok!(
+			Erc20Matcher::<Erc20MultilocationPrefix>::matches_fungibles(&MultiAsset::from((
+				location,
+				100000000000000000u128
+			))),
+			(H160([0; 20]), U256::from(100000000000000000u128))
 		);
 	}
 

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -659,7 +659,7 @@ parameter_types! {
 
 	// To be able to support almost all erc20 implementations,
 	// we provide a sufficiently hight gas limit.
-	pub Erc20XcmBridgeTransferGasLimit: u64 = 80_000;
+	pub Erc20XcmBridgeTransferGasLimit: u64 = 200_000;
 }
 
 impl pallet_erc20_xcm_bridge::Config for Runtime {

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -649,7 +649,7 @@ parameter_types! {
 
 	// To be able to support almost all erc20 implementations,
 	// we provide a sufficiently hight gas limit.
-	pub Erc20XcmBridgeTransferGasLimit: u64 = 80_000;
+	pub Erc20XcmBridgeTransferGasLimit: u64 = 200_000;
 }
 
 impl pallet_erc20_xcm_bridge::Config for Runtime {

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -661,7 +661,7 @@ parameter_types! {
 
 	// To be able to support almost all erc20 implementations,
 	// we provide a sufficiently hight gas limit.
-	pub Erc20XcmBridgeTransferGasLimit: u64 = 80_000;
+	pub Erc20XcmBridgeTransferGasLimit: u64 = 200_000;
 }
 
 impl pallet_erc20_xcm_bridge::Config for Runtime {

--- a/tests/tests/test-precompile/test-precompile-wormhole.ts
+++ b/tests/tests/test-precompile/test-precompile-wormhole.ts
@@ -290,7 +290,7 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
     const result = await context.createBlock(
       createTransaction(context, {
         to: PRECOMPILE_GMP_ADDRESS,
-        gas: 500_000,
+        gas: 600_000,
         data,
       })
     );


### PR DESCRIPTION
### What does it do?

The cost of an erc20-xcm transfer is necessarily static, as XCM does not support dynamic costs for assets transfer.

Historically, we fixed the constant to 80,000 , we based our decision on the fact that the ERC20 standard implementation of openzepellin use only around 33 000 gas, we therefore considered at the time that 80 000 was already a very large number, we realize that we need more gas.

But with the introduction of the GMP precompile, which uses wormhole wrapped contracts with ercv20-xcm, we realize that we need more gas (around 140 000).

Until we find a solution in the medium term to make the cost dynamic, this PR increases the constant to 200 000 (the same value used by Acala).

#### breaking changes

Increase the fees of erc20-xcm

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
