### PR TITLE
Fix eth call diff

### DIFF
--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -271,23 +271,20 @@ macro_rules! impl_runtime_apis_plus_common {
 					let is_transactional = false;
 					let validate = true;
 
+					// Estimated encoded transaction size must be based on the heaviest transaction
+					// type (EIP1559Transaction) to be compatible with all transaction types.
 					let mut estimated_transaction_len = data.len() +
-						// to: 20
-						// from: 20
-						// value: 32
-						// gas_limit: 32
+						// chain_id 8 bytes
 						// nonce: 32
-						// 1 byte transaction action variant
-						// chain id 8 bytes
+						// max_priority_fee_per_gas: 32
+						// max_fee_per_gas: 32
+						// gas_limit: 32
+						// action: 21 (enum varianrt + call address)
+						// value: 32
+						// access_list: 1 (empty vec size)
 						// 65 bytes signature
-						210;
+						255;
 
-					if max_fee_per_gas.is_some() {
-						estimated_transaction_len += 32;
-					}
-					if max_priority_fee_per_gas.is_some() {
-						estimated_transaction_len += 32;
-					}
 					if access_list.is_some() {
 						estimated_transaction_len += access_list.encoded_size();
 					}

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -274,6 +274,9 @@ macro_rules! impl_runtime_apis_plus_common {
 					// Estimated encoded transaction size must be based on the heaviest transaction
 					// type (EIP1559Transaction) to be compatible with all transaction types.
 					let mut estimated_transaction_len = data.len() +
+						// pallet ethereum index: 1
+						// transact call index: 1
+						// Transaction enum variant: 1
 						// chain_id 8 bytes
 						// nonce: 32
 						// max_priority_fee_per_gas: 32
@@ -283,7 +286,7 @@ macro_rules! impl_runtime_apis_plus_common {
 						// value: 32
 						// access_list: 1 (empty vec size)
 						// 65 bytes signature
-						255;
+						258;
 
 					if access_list.is_some() {
 						estimated_transaction_len += access_list.encoded_size();

--- a/tests/tests/test-gas/test-gas-foreign-asset.ts
+++ b/tests/tests/test-gas/test-gas-foreign-asset.ts
@@ -1,30 +1,19 @@
 import "@moonbeam-network/api-augment";
 
-import { KeyringPair } from "@polkadot/keyring/types";
-import { ParaId } from "@polkadot/types/interfaces";
-import { BN, hexToU8a, numberToHex, stringToHex, u8aToHex } from "@polkadot/util";
+import { BN, hexToU8a, u8aToHex } from "@polkadot/util";
 import { blake2AsU8a, xxhashAsU8a } from "@polkadot/util-crypto";
 import { expect } from "chai";
 
-import { ALITH_ADDRESS, alith, baltathar, generateKeyringPair } from "../../util/accounts";
-import { PARA_2000_SOURCE_LOCATION, RELAY_SOURCE_LOCATION } from "../../util/assets";
-import {
-  registerForeignAsset,
-  injectHrmpMessageAndSeal,
-  RawXcmMessage,
-  XcmFragment,
-  weightMessage,
-} from "../../util/xcm";
-import { customWeb3Request, web3EthCall } from "../../util/providers";
+import { ALITH_ADDRESS, alith, baltathar } from "../../util/accounts";
+import { RELAY_SOURCE_LOCATION } from "../../util/assets";
+import { registerForeignAsset } from "../../util/xcm";
 
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
 
-import { expectOk } from "../../util/expect";
 import { getCompiled } from "../../util/contracts";
 import { ethers } from "ethers";
 import {
   ALITH_TRANSACTION_TEMPLATE,
-  CHARLETH_TRANSACTION_TEMPLATE,
   createTransaction,
 } from "../../util/transactions";
 import { DUMMY_REVERT_BYTECODE } from "../../util/constants";
@@ -56,18 +45,6 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     expect(events[1].event.method.toString()).to.eq("UnitsPerSecondChanged");
     expect(events[5].event.method.toString()).to.eq("ExtrinsicSuccess");
     expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
-
-    // const { result } = await context.createBlock(
-    //   await createTransaction(context, {
-    //     ...CHARLETH_TRANSACTION_TEMPLATE,
-    //     to: ADDRESS_ERC20,
-    //     data: ERC20_INTERFACE.encodeFunctionData("approve", [alith.address, 100000000]),
-    //   })
-    // );
-
-    // const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
-    // console.log("Zero approve gas used", receipt.gasUsed);
-    // expect(receipt.status).to.equal(true);
 
     // ADD BALANCE TO ALITH
     const assetId = context.polkadotApi.createType("u128", ASSET_ID);
@@ -141,7 +118,6 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     let gasEst = await context.web3.eth.estimateGas({
       from: alith.address,
       data: ERC20_INTERFACE.encodeFunctionData("approve", [baltathar.address, 0]),
-      // gasPrice: "0x0",
       to: ADDRESS_ERC20,
     });
 

--- a/tests/tests/test-gas/test-gas-foreign-asset.ts
+++ b/tests/tests/test-gas/test-gas-foreign-asset.ts
@@ -112,7 +112,6 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     );
 
     const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
-    console.log("First approve gas used", receipt.gasUsed);
     expect(receipt.status).to.equal(true);
 
     let gasEst = await context.web3.eth.estimateGas({
@@ -120,8 +119,6 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
       data: ERC20_INTERFACE.encodeFunctionData("approve", [baltathar.address, 0]),
       to: ADDRESS_ERC20,
     });
-
-    console.log("Revoke gas estimate", gasEst);
 
     const { result: result2 } = await context.createBlock(
       await createTransaction(context, {
@@ -133,7 +130,6 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     );
 
     const receipt2 = await context.web3.eth.getTransactionReceipt(result2.hash);
-    console.log("Revoke gas used", receipt2.gasUsed);
     expect(receipt2.status).to.equal(true);
   });
 });

--- a/tests/tests/test-gas/test-gas-foreign-asset.ts
+++ b/tests/tests/test-gas/test-gas-foreign-asset.ts
@@ -1,0 +1,163 @@
+import "@moonbeam-network/api-augment";
+
+import { KeyringPair } from "@polkadot/keyring/types";
+import { ParaId } from "@polkadot/types/interfaces";
+import { BN, hexToU8a, numberToHex, stringToHex, u8aToHex } from "@polkadot/util";
+import { blake2AsU8a, xxhashAsU8a } from "@polkadot/util-crypto";
+import { expect } from "chai";
+
+import { ALITH_ADDRESS, alith, baltathar, generateKeyringPair } from "../../util/accounts";
+import { PARA_2000_SOURCE_LOCATION, RELAY_SOURCE_LOCATION } from "../../util/assets";
+import {
+  registerForeignAsset,
+  injectHrmpMessageAndSeal,
+  RawXcmMessage,
+  XcmFragment,
+  weightMessage,
+} from "../../util/xcm";
+import { customWeb3Request, web3EthCall } from "../../util/providers";
+
+import { describeDevMoonbeam } from "../../util/setup-dev-tests";
+
+import { expectOk } from "../../util/expect";
+import { getCompiled } from "../../util/contracts";
+import { ethers } from "ethers";
+import {
+  ALITH_TRANSACTION_TEMPLATE,
+  CHARLETH_TRANSACTION_TEMPLATE,
+  createTransaction,
+} from "../../util/transactions";
+import { DUMMY_REVERT_BYTECODE } from "../../util/constants";
+
+const palletId = "0x6D6f646c617373746d6E67720000000000000000";
+
+const assetMetadata = {
+  name: "FOREIGN",
+  symbol: "FOREIGN",
+  decimals: new BN(10),
+  isFrozen: false,
+};
+
+const ADDRESS_ERC20 = "0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080";
+const ASSET_ID = new BN("42259045809535163221576417993425387648");
+const ERC20_CONTRACT = getCompiled("ERC20Instance");
+const ERC20_INTERFACE = new ethers.utils.Interface(ERC20_CONTRACT.contract.abi);
+const UNITS_PER_SEC = 33068783068;
+
+describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
+  before("Should Register an asset and set unit per sec", async function () {
+    // registerForeignAsset
+    const { registeredAssetId, events, registeredAsset } = await registerForeignAsset(
+      context,
+      RELAY_SOURCE_LOCATION,
+      assetMetadata,
+      UNITS_PER_SEC
+    );
+    expect(events[1].event.method.toString()).to.eq("UnitsPerSecondChanged");
+    expect(events[5].event.method.toString()).to.eq("ExtrinsicSuccess");
+    expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+
+    // const { result } = await context.createBlock(
+    //   await createTransaction(context, {
+    //     ...CHARLETH_TRANSACTION_TEMPLATE,
+    //     to: ADDRESS_ERC20,
+    //     data: ERC20_INTERFACE.encodeFunctionData("approve", [alith.address, 100000000]),
+    //   })
+    // );
+
+    // const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
+    // console.log("Zero approve gas used", receipt.gasUsed);
+    // expect(receipt.status).to.equal(true);
+
+    // ADD BALANCE TO ALITH
+    const assetId = context.polkadotApi.createType("u128", ASSET_ID);
+    // Get keys to modify balance
+    let module = xxhashAsU8a(new TextEncoder().encode("Assets"), 128);
+    let account_key = xxhashAsU8a(new TextEncoder().encode("Account"), 128);
+    let blake2concatAssetId = new Uint8Array([
+      ...blake2AsU8a(assetId.toU8a(), 128),
+      ...assetId.toU8a(),
+    ]);
+
+    let blake2concatAccount = new Uint8Array([
+      ...blake2AsU8a(hexToU8a(ALITH_ADDRESS), 128),
+      ...hexToU8a(ALITH_ADDRESS),
+    ]);
+    let overallAccountKey = new Uint8Array([
+      ...module,
+      ...account_key,
+      ...blake2concatAssetId,
+      ...blake2concatAccount,
+    ]);
+
+    // Get keys to modify total supply & dummyCode (TODO: remove once dummy code inserted by node)
+    let assetKey = xxhashAsU8a(new TextEncoder().encode("Asset"), 128);
+    let overallAssetKey = new Uint8Array([...module, ...assetKey, ...blake2concatAssetId]);
+    let evmCodeAssetKey = context.polkadotApi.query.evm.accountCodes.key(
+      "0xFfFFfFff" + assetId.toHex().slice(2)
+    );
+
+    const balance = new BN("100000000000000");
+    const assetBalance = context.polkadotApi.createType("PalletAssetsAssetAccount", {
+      balance: balance,
+    });
+    const assetDetails = context.polkadotApi.createType("PalletAssetsAssetDetails", {
+      supply: balance,
+    });
+
+    await context.createBlock(
+      context.polkadotApi.tx.sudo
+        .sudo(
+          context.polkadotApi.tx.system.setStorage([
+            [u8aToHex(overallAccountKey), u8aToHex(assetBalance.toU8a())],
+            [u8aToHex(overallAssetKey), u8aToHex(assetDetails.toU8a())],
+            [
+              evmCodeAssetKey,
+              `0x${((DUMMY_REVERT_BYTECODE.length - 2) * 2)
+                .toString(16)
+                .padStart(2)}${DUMMY_REVERT_BYTECODE.slice(2)}`,
+            ],
+          ])
+        )
+        .signAsync(alith)
+    );
+  });
+
+  it("should succeed when modifying approve", async function () {
+    context.ethTransactionType = "EIP1559";
+
+    const { result } = await context.createBlock(
+      await createTransaction(context, {
+        ...ALITH_TRANSACTION_TEMPLATE,
+        to: ADDRESS_ERC20,
+        data: ERC20_INTERFACE.encodeFunctionData("approve", [baltathar.address, 100000000]),
+      })
+    );
+
+    const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
+    console.log("First approve gas used", receipt.gasUsed);
+    expect(receipt.status).to.equal(true);
+
+    let gasEst = await context.web3.eth.estimateGas({
+      from: alith.address,
+      data: ERC20_INTERFACE.encodeFunctionData("approve", [baltathar.address, 0]),
+      // gasPrice: "0x0",
+      to: ADDRESS_ERC20,
+    });
+
+    console.log("Revoke gas estimate", gasEst);
+
+    const { result: result2 } = await context.createBlock(
+      await createTransaction(context, {
+        ...ALITH_TRANSACTION_TEMPLATE,
+        to: ADDRESS_ERC20,
+        data: ERC20_INTERFACE.encodeFunctionData("approve", [baltathar.address, 0]),
+        gas: gasEst,
+      })
+    );
+
+    const receipt2 = await context.web3.eth.getTransactionReceipt(result2.hash);
+    console.log("Revoke gas used", receipt2.gasUsed);
+    expect(receipt2.status).to.equal(true);
+  });
+});

--- a/tests/tests/test-gas/test-gas-foreign-asset.ts
+++ b/tests/tests/test-gas/test-gas-foreign-asset.ts
@@ -12,10 +12,7 @@ import { describeDevMoonbeam } from "../../util/setup-dev-tests";
 
 import { getCompiled } from "../../util/contracts";
 import { ethers } from "ethers";
-import {
-  ALITH_TRANSACTION_TEMPLATE,
-  createTransaction,
-} from "../../util/transactions";
+import { ALITH_TRANSACTION_TEMPLATE, createTransaction } from "../../util/transactions";
 import { DUMMY_REVERT_BYTECODE } from "../../util/constants";
 
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";


### PR DESCRIPTION
### What does it do?

Fix a discrepancy bug between eth_call and on-chain tx execution.
The bug is caused by the fact that the PoV consumed by the ethereum transaction is counted differently in the estimation context than in the on-chain context.
The discrepancy is due to the fact that estimation queries generally not provide values for fields `max_fee_per_gas` and `max_priority_fee_per_gas` whereas the on-chain transaction provides values for these fields.

The solution is to consider that these fields are always supplied to estimate the size of the on-chain transaction, this implies over-estimation of 45 gas (negligible for fees) only for legacy transactions and only if the "pov gas" is greater than the used gas.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
