### PR TITLE
Mute Nodle monitoring

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -152,6 +152,7 @@ export const ForeignChainsEndpoints = [
       {
         name: "Nodle",
         paraId: 2026,
+        mutedUntil: 1693553400000,
       },
       {
         name: "Bifrost",

--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -152,7 +152,7 @@ export const ForeignChainsEndpoints = [
       {
         name: "Nodle",
         paraId: 2026,
-        mutedUntil: 1693553400000,
+        mutedUntil: 1695454200000,
       },
       {
         name: "Bifrost",

--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -152,7 +152,7 @@ export const ForeignChainsEndpoints = [
       {
         name: "Nodle",
         paraId: 2026,
-        mutedUntil: 1695454200000,
+        mutedUntil: 1695454200000, // 23/09/2023 08:30:00 UTC
       },
       {
         name: "Bifrost",


### PR DESCRIPTION
### What does it do?
Mutes the Nodle chain monitoring on our smoke tests until their chain is [un-bricked](https://polkadot.subsquare.io/referenda/132).

The time picked is `23rd September 2023` which is to account for the time taken for the **root** governance proposal to go through.

### What value does it bring to the blockchain users?
Improved monitoring of live chain state