### PR TITLE
Fix maintenance filter test

### DIFF
--- a/test/suites/dev/test-maintenance/test-maintenance-filter.ts
+++ b/test/suites/dev/test-maintenance/test-maintenance-filter.ts
@@ -213,7 +213,9 @@ describeSuite({
                   0,
                   fee as any,
                   "",
-                  transactWeights as any
+                  transactWeights as any,
+                  //@ts-ignore
+                  false
                 )
                 .signAsync(baltathar)
             )


### PR DESCRIPTION
Adds the extra argument for a proper call to `transactThroughDerivative()` after the xcm-transactor pallet modification introduced in https://github.com/moonbeam-foundation/moonbeam/pull/2338.

Also adds a `@ts-ignore` to remove the lint warning.