### PR TITLE
[MOON-2552] fix: only add PoV weight of Self::mint_and_compound() on first iteration

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1842,8 +1842,9 @@ pub mod pallet {
 							// repeatedly in a loop since only the first call will increase PoV, the
 							// rest will simply re-read the same data.
 							//
-							// todo: refactor mint_and_compound such that it does not re-read each
-							// time it is called
+							// todo: refactor mint_and_compound such that it does not rely on bond_more for 
+							// each auto-compound which re-read the collator delegations and performs
+							// a sort each time.
 							if i == 0 {
 								// in the first iteration of loop, add full weight
 								extra_weight = extra_weight.saturating_add(weight);


### PR DESCRIPTION
### What does it do?
weight calculation `pay_one_collator_reward` overestimates PoV size of calling `Self::mint_and_compound` due to re-reading of same list in a loop.

hotfix by only adding PoV size on first iteration of `state.delegations` loop

### What important points reviewers should know?

### Is there something left for follow-up PRs?
refactor mint_and_compound such that it does not re-read list each call

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
