### PR TITLE
[MOON-2552] fix: only add PoV weight of Self::mint_and_compound() the first time it is called

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2059,7 +2059,7 @@ pub mod pallet {
 			// returned will be an over-estimate since the read was already performed on the first
 			// call and subsequent calls do not increase PoV size further.
 			if already_called_for_delegator {
-				actual_weight.set_proof_size(0);
+				actual_weight = actual_weight.set_proof_size(0);
 			}
 
 			let in_top = state

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2055,7 +2055,6 @@ pub mod pallet {
 				<DelegationScheduledRequests<T>>::get(&candidate).len() as u32,
 			);
 
-			// Hotfix for MOON-2552
 			// If we have called delegator_bond_more for this deletagor before, the weight
 			// returned will be an over-estimate since the read was already performed on the first
 			// call and subsequent calls do not increase PoV size further.

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2040,7 +2040,7 @@ pub mod pallet {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
 			more: BalanceOf<T>,
-			already_called_for_delegator: bool,
+			already_called_for_candidate: bool,
 		) -> Result<
 			(bool, Weight),
 			DispatchErrorWithPostInfo<frame_support::dispatch::PostDispatchInfo>,
@@ -2051,14 +2051,14 @@ pub mod pallet {
 				Error::<T>::PendingDelegationRevoke
 			);
 
-			let actual_weight = T::WeightInfo::delegator_bond_more(
+			let mut actual_weight = T::WeightInfo::delegator_bond_more(
 				<DelegationScheduledRequests<T>>::get(&candidate).len() as u32,
 			);
 
-			// If we have called delegator_bond_more for this deletagor before, the weight
+			// If we have called delegator_bond_more for this candidate before, the weight
 			// returned will be an over-estimate since the read was already performed on the first
 			// call and subsequent calls do not increase PoV size further.
-			if already_called_for_delegator {
+			if already_called_for_candidate {
 				actual_weight = actual_weight.set_proof_size(0);
 			}
 
@@ -2101,7 +2101,7 @@ pub mod pallet {
 		/// delegator and tries to compound a specified percent of it back towards the delegation.
 		/// If a scheduled delegation revoke exists, then the amount is only minted, and nothing is
 		/// compounded. Emits the [Compounded] event.
-		/// already_called_for_delegator: bool is used to indicate if this function has already been
+		/// already_called_for_candidate: bool is used to indicate if this function has already been
 		/// called for a given delegator by the callee. This is used to avoid over-estimating
 		/// weight, since subsequent calls to this function will not increase the pov size.
 		pub fn mint_and_compound(
@@ -2109,7 +2109,7 @@ pub mod pallet {
 			compound_percent: Percent,
 			candidate: T::AccountId,
 			delegator: T::AccountId,
-			already_called_for_delegator: bool,
+			already_called_for_candidate: bool,
 		) -> Weight {
 			let mut weight = T::WeightInfo::mint_collator_reward();
 			if let Ok(amount_transferred) =
@@ -2129,7 +2129,7 @@ pub mod pallet {
 					delegator.clone(),
 					candidate.clone(),
 					compound_amount.clone(),
-					already_called_for_delegator,
+					already_called_for_candidate,
 				) {
 					Err(err) => {
 						log::debug!(

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2051,16 +2051,15 @@ pub mod pallet {
 				Error::<T>::PendingDelegationRevoke
 			);
 
-			let mut actual_weight = T::WeightInfo::delegator_bond_more(
-				<DelegationScheduledRequests<T>>::get(&candidate).len() as u32,
-			);
-
 			// If we have called delegator_bond_more for this candidate before, the weight
 			// returned will be an over-estimate since the read was already performed on the first
 			// call and subsequent calls do not increase PoV size further.
-			if already_called_for_candidate {
-				actual_weight = actual_weight.set_proof_size(0);
-			}
+			let actual_weight =
+				T::WeightInfo::delegator_bond_more(if already_called_for_candidate {
+					0
+				} else {
+					<DelegationScheduledRequests<T>>::get(&candidate).len() as u32
+				});
 
 			let in_top = state
 				.increase_delegation::<T>(candidate.clone(), more)


### PR DESCRIPTION
alternative to https://github.com/moonbeam-foundation/moonbeam/pull/2458

### What does it do?
add `already_called_for_delegator: bool` argument to `delegation_bond_more_without_event()` and `mint_and_compound`, skip adding PoV size if it is `true`

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
