### PR TITLE
Enable importing new blocks as best in dev mode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -132,10 +132,10 @@ jobs:
           timeout: 10000
           moonbeam-binary: build/moonbeam
           force-pass: true
-      - name: "Run Moonwall Dev Tests"
-        uses: ./.github/workflow-templates/dev-tests
-        with:
-          moonwall_environment: dev_moonbase
+      # - name: "Run Moonwall Dev Tests"
+      #   uses: ./.github/workflow-templates/dev-tests
+      #   with:
+      #     moonwall_environment: dev_moonbase
 
       - name: Retrieve coverage
         id: coverage

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -120,7 +120,9 @@ pub type HostFunctions = (
 
 /// Block Import Pipeline used.
 pub enum BlockImportPipeline<T, E> {
+	/// Used in dev mode to import new blocks as best blocks.
 	Dev(T),
+	/// Used in parachain mode.
 	Parachain(E),
 }
 
@@ -1055,7 +1057,7 @@ where
 		transaction_pool,
 		other:
 			(
-				block_import,
+				block_import_pipeline,
 				filter_pool,
 				mut telemetry,
 				_telemetry_worker_handle,
@@ -1064,7 +1066,7 @@ where
 			),
 	} = new_partial::<RuntimeApi, Executor>(&mut config, &rpc_config, true)?;
 
-	let block_import = if let BlockImportPipeline::Dev(block_import) = block_import {
+	let block_import = if let BlockImportPipeline::Dev(block_import) = block_import_pipeline {
 		block_import
 	} else {
 		return Err(ServiceError::Other(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -487,12 +487,6 @@ fn set_prometheus_registry(config: &mut Configuration) -> Result<(), ServiceErro
 	Ok(())
 }
 
-/// Builds the PartialComponents for a parachain. Uses `ParachainBlockImport` as the block import.
-///
-/// Use this function if you don't actually need the full service, but just the partial in order to
-/// be able to perform chain operations.
-#[allow(clippy::type_complexity)]
-
 /// Builds the PartialComponents for a parachain or development service
 ///
 /// Use this function if you don't actually need the full service, but just the partial in order to

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -559,7 +559,7 @@ where
 		)
 	} else {
 		let parachain_block_import =
-			ParachainBlockImport::new(frontier_block_import.clone(), backend.clone());
+			ParachainBlockImport::new(frontier_block_import, backend.clone());
 		(
 			nimbus_consensus::import_queue(
 				client.clone(),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -118,8 +118,8 @@ pub type HostFunctions = (
 	moonbeam_primitives_ext::moonbeam_ext::HostFunctions,
 );
 
-/// A Block import that is used to set the fork choice strategy to custom::true in dev mode. This
-/// is used to allow to import blocks as new best blocks.
+/// A Block import that is used to set the fork choice strategy to Longest Chain in dev mode. This
+/// is used to allow to import blocks as new best blocks in the longest chain.
 pub struct MaybeNewBestBlockImport<BI> {
 	dev_service: bool,
 	inner: BI,
@@ -163,7 +163,7 @@ where
 		mut params: sc_consensus::BlockImportParams<Block, Self::Transaction>,
 	) -> Result<sc_consensus::ImportResult, Self::Error> {
 		if self.dev_service {
-			params.fork_choice = Some(sc_consensus::ForkChoiceStrategy::Custom(true));
+			params.fork_choice = Some(sc_consensus::ForkChoiceStrategy::LongestChain);
 		}
 		self.inner.import_block(params).await
 	}
@@ -695,7 +695,7 @@ where
 
 	let params = new_partial(&mut parachain_config, &rpc_config, false)?;
 	let (
-		_frontier_block_import,
+		_block_import,
 		filter_pool,
 		mut telemetry,
 		telemetry_worker_handle,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -435,6 +435,10 @@ fn set_prometheus_registry(config: &mut Configuration) -> Result<(), ServiceErro
 	Ok(())
 }
 
+/// Builds the PartialComponents for a parachain. Uses `ParachainBlockImport` as the block import.
+///
+/// Use this function if you don't actually need the full service, but just the partial in order to
+/// be able to perform chain operations.
 #[allow(clippy::type_complexity)]
 pub fn new_partial<RuntimeApi, Executor>(
 	config: &mut Configuration,
@@ -496,6 +500,7 @@ where
 	})
 }
 
+/// Builds the PartialComponents in dev mode. Uses `FrontierBlockImport` as the block import.
 #[allow(clippy::type_complexity)]
 pub fn new_partial_dev<RuntimeApi, Executor>(
 	config: &mut Configuration,


### PR DESCRIPTION
### What does it do?
The recent update (#2470) to the Cumulus block import feature was intended to resolve the sibling issue. However, this update has had an impact on Block Import when used in dev mode. Specifically, the use of ParachainBlockImport to determine the best block based on the relay chain is not applicable in dev mode. In dev mode, where no relay chain is utilized, manually created blocks will not be automatically imported as the best blocks by default, impacting certain test use cases.

To address this, the proposed change is to utilize FrontierBlockImport in dev mode, enabling the import of newly created unfinalized blocks as the best blocks.


Also, we are disabling code coverage for TypeScript-based tests due to the slow launch of the node, which has caused it to be broken.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
