### PR TITLE
Potential staking optimization: avoid decoding Vecs (#2414)

### DIFF
--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -63,6 +63,11 @@ where
 		Self(sorted_delegations)
 	}
 
+	/// Retrieves the length of an instance of [AutoCompoundingDelegations] storage.
+	pub fn get_storage_len(candidate: &T::AccountId) -> usize {
+		<AutoCompoundingDelegationsStorage<T>>::decode_len(candidate).unwrap_or_default()
+	}
+
 	/// Retrieves an instance of [AutoCompoundingDelegations] storage as [AutoCompoundDelegations].
 	pub fn get_storage(candidate: &T::AccountId) -> Self {
 		Self(<AutoCompoundingDelegationsStorage<T>>::get(candidate))
@@ -203,15 +208,12 @@ where
 			Error::<T>::TooLowCandidateDelegationCountToDelegate
 		);
 
-		// set auto-compound config if the percent is non-zero
-		let mut auto_compounding_state = None;
 		if !auto_compound.is_zero() {
-			let acs = Self::get_storage(&candidate);
 			ensure!(
-				acs.len() <= candidate_auto_compounding_delegation_count_hint,
+				Self::get_storage_len(&candidate) as u32
+					<= candidate_auto_compounding_delegation_count_hint,
 				<Error<T>>::TooLowCandidateAutoCompoundingDelegationCountToDelegate,
 			);
-			auto_compounding_state = Some(acs);
 		}
 
 		// add delegation to candidate
@@ -235,7 +237,9 @@ where
 		};
 		let new_total_locked = <Total<T>>::get().saturating_add(net_total_increase);
 
-		if let Some(mut auto_compounding_state) = auto_compounding_state {
+		// set auto-compound config if the percent is non-zero
+		if !auto_compound.is_zero() {
+			let mut auto_compounding_state = Self::get_storage(&candidate);
 			auto_compounding_state.set_for_delegator(delegator.clone(), auto_compound.clone())?;
 			auto_compounding_state.set_storage(&candidate);
 		}

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -63,8 +63,7 @@ where
 		Self(sorted_delegations)
 	}
 
-	/// Retrieves the length of an instance of [AutoCompoundingDelegations] storage.
-	pub fn get_storage_len(candidate: &T::AccountId) -> usize {
+	pub fn get_auto_compounding_delegation_count(candidate: &T::AccountId) -> usize {
 		<AutoCompoundingDelegationsStorage<T>>::decode_len(candidate).unwrap_or_default()
 	}
 
@@ -210,7 +209,7 @@ where
 
 		if !auto_compound.is_zero() {
 			ensure!(
-				Self::get_storage_len(&candidate) as u32
+				Self::get_auto_compounding_delegation_count(&candidate) as u32
 					<= candidate_auto_compounding_delegation_count_hint,
 				<Error<T>>::TooLowCandidateAutoCompoundingDelegationCountToDelegate,
 			);

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -2029,6 +2029,8 @@ benchmarks! {
 	delegate_with_auto_compound_worst {
 		// We assume that the delegation bumps the bottom-most delegator, which has its scheduled requests
 		// from a maxed delegation requests
+		use crate::auto_compound::AutoCompoundDelegations;
+
 		let mut seed = Seed::new();
 		let mut candidate_count = 1u32;
 		let prime_candidate = create_account::<T>(

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -2029,8 +2029,6 @@ benchmarks! {
 	delegate_with_auto_compound_worst {
 		// We assume that the delegation bumps the bottom-most delegator, which has its scheduled requests
 		// from a maxed delegation requests
-		use crate::auto_compound::AutoCompoundDelegations;
-
 		let mut seed = Seed::new();
 		let mut candidate_count = 1u32;
 		let prime_candidate = create_account::<T>(

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1512,11 +1512,11 @@ pub mod pallet {
 			candidate: T::AccountId,
 		) -> DispatchResultWithPostInfo {
 			let state = <CandidateInfo<T>>::get(&candidate).ok_or(Error::<T>::CandidateDNE)?;
-			let ac_state = <AutoCompoundingDelegations<T>>::get(&candidate);
+			let actual_auto_compound_delegation_count =
+				<AutoCompoundingDelegations<T>>::decode_len(&candidate).unwrap_or_default() as u32;
 
 			// TODO use these to return actual weight used via `execute_leave_candidates_ideal`
 			let actual_delegation_count = state.delegation_count;
-			let actual_auto_compound_delegation_count = ac_state.len() as u32;
 			let actual_weight = T::WeightInfo::execute_leave_candidates_ideal(
 				actual_delegation_count,
 				actual_auto_compound_delegation_count,
@@ -1788,7 +1788,8 @@ pub mod pallet {
 				let num_delegators = state.delegations.len();
 				let mut num_paid_delegations = 0u32;
 				let mut num_auto_compounding = 0u32;
-				let num_scheduled_requests = <DelegationScheduledRequests<T>>::get(&collator).len();
+				let num_scheduled_requests =
+					<DelegationScheduledRequests<T>>::decode_len(&collator).unwrap_or_default();
 				if state.delegations.is_empty() {
 					// solo collator with no delegators
 					extra_weight = extra_weight
@@ -2057,7 +2058,7 @@ pub mod pallet {
 			);
 
 			let actual_weight = T::WeightInfo::delegator_bond_more(
-				<DelegationScheduledRequests<T>>::get(&candidate).len() as u32,
+				<DelegationScheduledRequests<T>>::decode_len(&candidate).unwrap_or_default() as u32,
 			);
 			let in_top = state
 				.increase_delegation::<T>(candidate.clone(), more)


### PR DESCRIPTION
Use `decode_len` to improve performance in `pallet-parachain-staking`.

[PR 2414](https://opslayer.atlassian.net/browse/MOON-2414)