### PR TITLE
Attempt to use V3 and XcmVersionedMultiLocation in GMP tests

### DIFF
--- a/test/suites/dev/test-precompile/test-precompile-wormhole.ts
+++ b/test/suites/dev/test-precompile/test-precompile-wormhole.ts
@@ -107,7 +107,7 @@ describeSuite({
 
     // destination used for xtoken transfers
     const versionedMultiLocation = {
-      v1: {
+      V3: {
         parents: 1,
         interior: {
           X1: {
@@ -311,7 +311,7 @@ describeSuite({
         // create payload
         const destination = context
           .polkadotJs()
-          .registry.createType("VersionedMultiLocation", versionedMultiLocation);
+          .registry.createType("XcmVersionedMultiLocation", versionedMultiLocation);
 
         const userAction = new XcmRoutingUserAction({ destination });
         const versionedUserAction = new VersionedUserAction({ V1: userAction });
@@ -347,7 +347,7 @@ describeSuite({
         // create payload
         const destination = context
           .polkadotJs()
-          .registry.createType("VersionedMultiLocation", versionedMultiLocation);
+          .registry.createType("XcmVersionedMultiLocation", versionedMultiLocation);
 
         const whAmount = 999n;
         const realAmount = whAmount * WH_IMPLICIT_MULTIPLIER;
@@ -388,7 +388,7 @@ describeSuite({
         // create payload
         const destination = context
           .polkadotJs()
-          .registry.createType("VersionedMultiLocation", versionedMultiLocation);
+          .registry.createType("XcmVersionedMultiLocation", versionedMultiLocation);
 
         const whAmount = 100n;
         const realAmount = whAmount * WH_IMPLICIT_MULTIPLIER;
@@ -427,7 +427,7 @@ describeSuite({
         // create payload
         const destination = context
           .polkadotJs()
-          .registry.createType("VersionedMultiLocation", versionedMultiLocation);
+          .registry.createType("XcmVersionedMultiLocation", versionedMultiLocation);
 
         const whAmount = 100n;
         const realAmount = whAmount * WH_IMPLICIT_MULTIPLIER;
@@ -472,11 +472,11 @@ class VersionedUserAction extends Enum {
 }
 class XcmRoutingUserAction extends Struct {
   constructor(value?: any) {
-    super(registry, { destination: "VersionedMultiLocation" }, value);
+    super(registry, { destination: "XcmVersionedMultiLocation" }, value);
   }
 }
 class XcmRoutingUserActionWithFee extends Struct {
   constructor(value?: any) {
-    super(registry, { destination: "VersionedMultiLocation", fee: "U256" }, value);
+    super(registry, { destination: "XcmVersionedMultiLocation", fee: "U256" }, value);
   }
 }


### PR DESCRIPTION
### What does it do?

Attempts to use V3 of `VersionedMultiLocation` as seen here: https://github.com/jboetticher/mrl-example/blob/22221d1cd200fc08b00aacf1aeb7097a9212a6a4/src/MoonbeamRoutedLiquidityPayloads.ts#L33

There must be something different in @jboetticher's environment than our test env here because polkadotjs doesn't know what `XcmVersionedMultiLocation` is, error:

```
Error: Struct: failed on destination: Type:: DoNotConstruct: Cannot construct unknown type XcmVersionedMultiLocation
```

More context: https://github.com/polkadot-js/api/issues/5655