### PR TITLE
do not install protoc on bare-metal runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: bare-metal
 
     steps:
-      - name: Install tooling
-        run: |
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
+      # The protobuf compiler should be pre-installed on bare-metal
+      #- name: Install tooling
+      #  run: sudo apt-get install -y protobuf-compiler
+      - name: Check tooling
+        run: protoc --version  
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       #- name: Install tooling
       #  run: sudo apt-get install -y protobuf-compiler
       - name: Check tooling
-        run: protoc --version  
+        run: protoc --version
       - name: Checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
### What does it do?

On `bare-metal` CI runners, the runner user cannot install new software using `sudo`, and the protobuf compiler must be pre-installed

