### PR TITLE
Disable creation of local XC-20s

### DIFF
--- a/runtime/moonbase/src/asset_config.rs
+++ b/runtime/moonbase/src/asset_config.rs
@@ -122,7 +122,7 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Balance = Balance;
 	type AssetId = AssetId;
 	type Currency = Balances;
-	type ForceOrigin = AssetsForceOrigin;
+	type ForceOrigin = EnsureNever<AccountId>;
 	type AssetDeposit = AssetDeposit;
 	type MetadataDepositBase = MetadataDepositBase;
 	type MetadataDepositPerByte = MetadataDepositPerByte;

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -122,7 +122,7 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Balance = Balance;
 	type AssetId = AssetId;
 	type Currency = Balances;
-	type ForceOrigin = AssetsForceOrigin;
+	type ForceOrigin = EnsureNever<AccountId>;
 	type AssetDeposit = AssetDeposit;
 	type MetadataDepositBase = MetadataDepositBase;
 	type MetadataDepositPerByte = MetadataDepositPerByte;

--- a/runtime/moonriver/src/asset_config.rs
+++ b/runtime/moonriver/src/asset_config.rs
@@ -122,7 +122,7 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Balance = Balance;
 	type AssetId = AssetId;
 	type Currency = Balances;
-	type ForceOrigin = AssetsForceOrigin;
+	type ForceOrigin = EnsureNever<AccountId>;
 	type AssetDeposit = AssetDeposit;
 	type MetadataDepositBase = MetadataDepositBase;
 	type MetadataDepositPerByte = MetadataDepositPerByte;


### PR DESCRIPTION
### What does it do?
Substrate local XC-20 assets have been deprecated in favor of EVM ERC20 XCM tokens. This is the first of multiple PRs to deprecate `localAssets` in Moonbeam.
Sets the `ForceOrigin` of `LocalAsset` config to `Never`. 
### What important points reviewers should know?
Even though local assets are meant to be registered through `assetManager.registerLocalAsset`, setting the `localAssets` config origin to never is enough to make that extrinsic fail, effectually disabling the creation of new local XC20s, as shown with a dev env:
![image](https://github.com/moonbeam-foundation/moonbeam/assets/52399794/47603e25-b5b5-41bc-adbb-a3268505a4b2)

### Is there something left for follow-up PRs?
Existing local XC20s in Moonbeam are not actively used. After the assets has been destroyed (through governance), follow-up PRs should be made to remove the `localAssets` pallet from the runtime

