### PR TITLE
CLI flag to disable Prometheus metrics moonbeam prefix

### DIFF
--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -108,4 +108,5 @@ pub struct RpcConfig {
 	pub relay_chain_rpc_urls: Vec<url::Url>,
 	pub tracing_raw_max_memory_usage: usize,
 	pub frontier_backend_config: FrontierBackendConfig,
+	pub no_prometheus_prefix: bool,
 }

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -230,6 +230,10 @@ pub struct RunCmd {
 	/// telemetry, if telemetry is enabled.
 	#[clap(long)]
 	pub no_hardware_benchmarks: bool,
+
+	/// Removes moonbeam prefix from Prometheus metrics
+	#[clap(long)]
+	pub no_prometheus_prefix: bool,
 }
 
 impl RunCmd {
@@ -254,6 +258,7 @@ impl RunCmd {
 					cache_size: self.frontier_sql_backend_cache_size,
 				},
 			},
+			no_prometheus_prefix: self.no_prometheus_prefix,
 		}
 	}
 }


### PR DESCRIPTION
### What does it do?
Adds an optional flag `no_prometheus_prefix` to avoid adding `moonbeam_` prefix to the node's Prometheus metrics

Addresses #2432 