### PR TITLE
Allow XCM Transfers paying with DOT in AssetHub

### DIFF
--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -64,8 +64,6 @@ use sp_std::{
 	prelude::*,
 };
 
-use orml_traits::parameter_type_with_key;
-
 use crate::governance::referenda::GeneralAdminOrRoot;
 
 parameter_types! {
@@ -549,12 +547,6 @@ parameter_types! {
 
 }
 
-parameter_type_with_key! {
-	pub ParachainMinFee: |_location: MultiLocation| -> Option<u128> {
-		Some(u128::MAX)
-	};
-}
-
 impl orml_xtokens::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
@@ -568,7 +560,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type MinXcmFee = ParachainMinFee;
+	type MinXcmFee = orml_xcm_support::DisabledParachainFee;
 	type MultiLocationsFilter = Everything;
 	type ReserveProvider = AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 }

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -540,8 +540,12 @@ parameter_types! {
 }
 
 parameter_type_with_key! {
-	pub ParachainMinFee: |_location: MultiLocation| -> Option<u128> {
-		Some(u128::MAX)
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
+		match (location.parents, location.first_interior()) {
+			// Polkadot AssetHub fee
+			(1, Some(Parachain(1000u32))) => Some(50_000_000u128),
+			_ => None,
+		}
 	};
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/mod.rs
+++ b/runtime/moonbeam/tests/xcm_mock/mod.rs
@@ -34,6 +34,7 @@ use std::{collections::BTreeMap, str::FromStr};
 
 pub const PARAALICE: [u8; 20] = [1u8; 20];
 pub const RELAYALICE: AccountId32 = AccountId32::new([0u8; 32]);
+pub const RELAYBOB: AccountId32 = AccountId32::new([2u8; 32]);
 
 pub fn para_a_account() -> AccountId32 {
 	ParaId::from(1).into_account_truncating()
@@ -188,7 +189,10 @@ pub fn statemint_ext(para_id: u32) -> sp_io::TestExternalities {
 		.unwrap();
 
 	pallet_balances::GenesisConfig::<Runtime> {
-		balances: vec![(RELAYALICE.into(), INITIAL_BALANCE)],
+		balances: vec![
+			(RELAYALICE.into(), INITIAL_BALANCE),
+			(RELAYBOB.into(), INITIAL_BALANCE),
+		],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -458,8 +458,11 @@ parameter_types! {
 }
 
 parameter_type_with_key! {
-	pub ParachainMinFee: |_location: MultiLocation| -> Option<u128> {
-		Some(u128::MAX)
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
+		match (location.parents, location.first_interior()) {
+			(1, Some(Parachain(4u32))) => Some(50u128),
+			_ => None,
+		}
 	};
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
@@ -166,6 +166,14 @@ pub type XcmBarrier = (
 	>,
 );
 
+parameter_types! {
+	pub Kusama: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(KsmLocation::get()) });
+	pub Statemine: MultiLocation = Parachain(4).into();
+	pub KusamaForStatemine: (MultiAssetFilter, MultiLocation) = (Kusama::get(), Statemine::get());
+}
+
+pub type TrustedTeleporters = xcm_builder::Case<KusamaForStatemine>;
+
 pub struct XcmConfig;
 impl Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
@@ -173,7 +181,7 @@ impl Config for XcmConfig {
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = LocalOriginConverter;
 	type IsReserve = ();
-	type IsTeleporter = ();
+	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = XcmBarrier;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, RuntimeCall, MaxInstructions>;

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -2527,6 +2527,209 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_glmr() 
 }
 
 #[test]
+fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
+	MockNet::reset();
+
+	// Relay asset
+	let relay_location = parachain::AssetType::Xcm(MultiLocation::parent());
+	let source_relay_id: parachain::AssetId = relay_location.clone().into();
+
+	let relay_asset_metadata = parachain::AssetMetadata {
+		name: b"RelayToken".to_vec(),
+		symbol: b"Relay".to_vec(),
+		decimals: 12,
+	};
+
+	// Statemint asset
+	let statemint_asset = MultiLocation::new(
+		1,
+		X3(Parachain(4u32), PalletInstance(5u8), GeneralIndex(10u128)),
+	);
+	let statemint_location_asset = parachain::AssetType::Xcm(statemint_asset);
+	let source_statemint_asset_id: parachain::AssetId = statemint_location_asset.clone().into();
+
+	let asset_metadata_statemint_asset = parachain::AssetMetadata {
+		name: b"USDC".to_vec(),
+		symbol: b"USDC".to_vec(),
+		decimals: 12,
+	};
+
+	let dest_para = MultiLocation::new(1, X1(Parachain(1)));
+
+	let sov = xcm_builder::SiblingParachainConvertsVia::<
+		polkadot_parachain::primitives::Sibling,
+		statemint_like::AccountId,
+	>::convert_ref(dest_para)
+	.unwrap();
+
+	ParaA::execute_with(|| {
+		assert_ok!(AssetManager::register_foreign_asset(
+			parachain::RuntimeOrigin::root(),
+			relay_location.clone(),
+			relay_asset_metadata,
+			1u128,
+			true
+		));
+		assert_ok!(AssetManager::set_asset_units_per_second(
+			parachain::RuntimeOrigin::root(),
+			relay_location,
+			0u128,
+			0
+		));
+
+		assert_ok!(AssetManager::register_foreign_asset(
+			parachain::RuntimeOrigin::root(),
+			statemint_location_asset.clone(),
+			asset_metadata_statemint_asset,
+			1u128,
+			true
+		));
+		assert_ok!(AssetManager::set_asset_units_per_second(
+			parachain::RuntimeOrigin::root(),
+			statemint_location_asset,
+			0u128,
+			1
+		));
+	});
+
+	let parachain_beneficiary_from_relay: MultiLocation = Junction::AccountKey20 {
+		network: None,
+		key: PARAALICE,
+	}
+	.into();
+
+	// Send relay chain asset to Alice in Parachain A
+	Relay::execute_with(|| {
+		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
+			relay_chain::RuntimeOrigin::signed(RELAYALICE),
+			Box::new(Parachain(1).into()),
+			Box::new(
+				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
+					.clone()
+					.into()
+			),
+			Box::new((Here, 200).into()),
+			0,
+		));
+	});
+
+	Statemint::execute_with(|| {
+		// Set new prefix
+		statemint_like::PrefixChanger::set_prefix(
+			PalletInstance(<StatemintAssets as PalletInfoAccess>::index() as u8).into(),
+		);
+
+		assert_ok!(StatemintAssets::create(
+			statemint_like::RuntimeOrigin::signed(RELAYALICE),
+			10,
+			RELAYALICE,
+			1
+		));
+
+		assert_ok!(StatemintAssets::mint(
+			statemint_like::RuntimeOrigin::signed(RELAYALICE),
+			10,
+			RELAYALICE,
+			300000000000000
+		));
+
+		// Send some native statemint tokens to sovereign for fees.
+		// We can't pay fees with USDC as the asset is minted as non-sufficient.
+		assert_ok!(StatemintBalances::transfer(
+			statemint_like::RuntimeOrigin::signed(RELAYALICE),
+			sov,
+			100000000000000
+		));
+
+		// Send statemint USDC asset to Alice in Parachain A
+		let parachain_beneficiary_from_statemint: MultiLocation = AccountKey20 {
+			network: None,
+			key: PARAALICE,
+		}
+		.into();
+
+		// Send with new prefix
+		assert_ok!(StatemintChainPalletXcm::reserve_transfer_assets(
+			statemint_like::RuntimeOrigin::signed(RELAYALICE),
+			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
+			Box::new(
+				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
+					.clone()
+					.into()
+			),
+			Box::new(
+				(
+					X2(
+						xcm::latest::prelude::PalletInstance(
+							<StatemintAssets as PalletInfoAccess>::index() as u8
+						),
+						GeneralIndex(10),
+					),
+					125
+				)
+					.into()
+			),
+			0,
+		));
+	});
+
+	let statemint_beneficiary = MultiLocation {
+		parents: 1,
+		interior: X2(
+			Parachain(4),
+			AccountId32 {
+				network: None,
+				id: RELAYBOB.into(),
+			},
+		),
+	};
+
+	ParaA::execute_with(|| {
+		// Alice has received 125 USDC
+		assert_eq!(
+			Assets::balance(source_statemint_asset_id, &PARAALICE.into()),
+			125
+		);
+
+		// Alice has received 200 Relay assets
+		assert_eq!(Assets::balance(source_relay_id, &PARAALICE.into()), 200);
+	});
+
+	// Transfer USDC from Parachain A to Statemint using Relay asset as fee
+	ParaA::execute_with(|| {
+		assert_ok!(XTokens::transfer_multicurrencies(
+			parachain::RuntimeOrigin::signed(PARAALICE.into()),
+			vec![
+				(
+					parachain::CurrencyId::ForeignAsset(source_statemint_asset_id),
+					100
+				),
+				(parachain::CurrencyId::ForeignAsset(source_relay_id), 100)
+			],
+			1,
+			Box::new(VersionedMultiLocation::V3(statemint_beneficiary)),
+			WeightLimit::Limited(Weight::from_parts(80_000_000u64, 100_000u64))
+		));
+	});
+
+	ParaA::execute_with(|| {
+		// Alice has 100 USDC less
+		assert_eq!(
+			Assets::balance(source_statemint_asset_id, &PARAALICE.into()),
+			25
+		);
+
+		// Alice has 100 relay asset less
+		assert_eq!(Assets::balance(source_relay_id, &PARAALICE.into()), 100);
+	});
+
+	Statemint::execute_with(|| {
+		// Check that BOB received 10 USDC on statemint
+		assert_eq!(StatemintAssets::account_balances(RELAYBOB), vec![(10, 100)]);
+	});
+}
+
+#[test]
 fn transact_through_signed_multilocation() {
 	MockNet::reset();
 	let mut ancestry = MultiLocation::parent();

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -553,8 +553,12 @@ parameter_types! {
 }
 
 parameter_type_with_key! {
-	pub ParachainMinFee: |_location: MultiLocation| -> Option<u128> {
-		Some(u128::MAX)
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
+		match (location.parents, location.first_interior()) {
+			// Kusama AssetHub fee
+			(1, Some(Parachain(1000u32))) => Some(50_000_000u128),
+			_ => None,
+		}
 	};
 }
 

--- a/runtime/moonriver/tests/xcm_mock/mod.rs
+++ b/runtime/moonriver/tests/xcm_mock/mod.rs
@@ -34,6 +34,7 @@ use std::{collections::BTreeMap, str::FromStr};
 
 pub const PARAALICE: [u8; 20] = [1u8; 20];
 pub const RELAYALICE: AccountId32 = AccountId32::new([0u8; 32]);
+pub const RELAYBOB: AccountId32 = AccountId32::new([2u8; 32]);
 
 pub fn para_a_account() -> AccountId32 {
 	ParaId::from(1).into_account_truncating()
@@ -188,7 +189,10 @@ pub fn statemine_ext(para_id: u32) -> sp_io::TestExternalities {
 		.unwrap();
 
 	pallet_balances::GenesisConfig::<Runtime> {
-		balances: vec![(RELAYALICE.into(), INITIAL_BALANCE)],
+		balances: vec![
+			(RELAYALICE.into(), INITIAL_BALANCE),
+			(RELAYBOB.into(), INITIAL_BALANCE),
+		],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -471,8 +471,11 @@ parameter_types! {
 }
 
 parameter_type_with_key! {
-	pub ParachainMinFee: |_location: MultiLocation| -> Option<u128> {
-		Some(u128::MAX)
+	pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
+		match (location.parents, location.first_interior()) {
+			(1, Some(Parachain(4u32))) => Some(50u128),
+			_ => None,
+		}
 	};
 }
 

--- a/runtime/moonriver/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonriver/tests/xcm_mock/relay_chain.rs
@@ -166,6 +166,14 @@ pub type XcmBarrier = (
 	>,
 );
 
+parameter_types! {
+	pub Kusama: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(KsmLocation::get()) });
+	pub Statemine: MultiLocation = Parachain(4).into();
+	pub KusamaForStatemine: (MultiAssetFilter, MultiLocation) = (Kusama::get(), Statemine::get());
+}
+
+pub type TrustedTeleporters = xcm_builder::Case<KusamaForStatemine>;
+
 pub struct XcmConfig;
 impl Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
@@ -173,7 +181,7 @@ impl Config for XcmConfig {
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = LocalOriginConverter;
 	type IsReserve = ();
-	type IsTeleporter = ();
+	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = XcmBarrier;
 	type Weigher = FixedWeightBounds<BaseXcmWeight, RuntimeCall, MaxInstructions>;

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -2838,6 +2838,209 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_dev() {
 }
 
 #[test]
+fn send_statemint_asset_from_para_a_to_statemine_with_relay_fee() {
+	MockNet::reset();
+
+	// Relay asset
+	let relay_location = parachain::AssetType::Xcm(MultiLocation::parent());
+	let source_relay_id: parachain::AssetId = relay_location.clone().into();
+
+	let relay_asset_metadata = parachain::AssetMetadata {
+		name: b"RelayToken".to_vec(),
+		symbol: b"Relay".to_vec(),
+		decimals: 12,
+	};
+
+	// Statemine asset
+	let statemine_asset = MultiLocation::new(
+		1,
+		X3(Parachain(4u32), PalletInstance(5u8), GeneralIndex(10u128)),
+	);
+	let statemine_location_asset = parachain::AssetType::Xcm(statemine_asset);
+	let source_statemine_asset_id: parachain::AssetId = statemine_location_asset.clone().into();
+
+	let asset_metadata_statemine_asset = parachain::AssetMetadata {
+		name: b"USDC".to_vec(),
+		symbol: b"USDC".to_vec(),
+		decimals: 12,
+	};
+
+	let dest_para = MultiLocation::new(1, X1(Parachain(1)));
+
+	let sov = xcm_builder::SiblingParachainConvertsVia::<
+		polkadot_parachain::primitives::Sibling,
+		statemine_like::AccountId,
+	>::convert_ref(dest_para)
+	.unwrap();
+
+	ParaA::execute_with(|| {
+		assert_ok!(AssetManager::register_foreign_asset(
+			parachain::RuntimeOrigin::root(),
+			relay_location.clone(),
+			relay_asset_metadata,
+			1u128,
+			true
+		));
+		assert_ok!(AssetManager::set_asset_units_per_second(
+			parachain::RuntimeOrigin::root(),
+			relay_location,
+			0u128,
+			0
+		));
+
+		assert_ok!(AssetManager::register_foreign_asset(
+			parachain::RuntimeOrigin::root(),
+			statemine_location_asset.clone(),
+			asset_metadata_statemine_asset,
+			1u128,
+			true
+		));
+		assert_ok!(AssetManager::set_asset_units_per_second(
+			parachain::RuntimeOrigin::root(),
+			statemine_location_asset,
+			0u128,
+			1
+		));
+	});
+
+	let parachain_beneficiary_from_relay: MultiLocation = Junction::AccountKey20 {
+		network: None,
+		key: PARAALICE,
+	}
+	.into();
+
+	// Send relay chain asset to Alice in Parachain A
+	Relay::execute_with(|| {
+		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
+			relay_chain::RuntimeOrigin::signed(RELAYALICE),
+			Box::new(Parachain(1).into()),
+			Box::new(
+				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
+					.clone()
+					.into()
+			),
+			Box::new((Here, 200).into()),
+			0,
+		));
+	});
+
+	Statemine::execute_with(|| {
+		// Set new prefix
+		statemine_like::PrefixChanger::set_prefix(
+			PalletInstance(<StatemineAssets as PalletInfoAccess>::index() as u8).into(),
+		);
+
+		assert_ok!(StatemineAssets::create(
+			statemine_like::RuntimeOrigin::signed(RELAYALICE),
+			10,
+			RELAYALICE,
+			1
+		));
+
+		assert_ok!(StatemineAssets::mint(
+			statemine_like::RuntimeOrigin::signed(RELAYALICE),
+			10,
+			RELAYALICE,
+			300000000000000
+		));
+
+		// Send some native statemine tokens to sovereign for fees.
+		// We can't pay fees with USDC as the asset is minted as non-sufficient.
+		assert_ok!(StatemineBalances::transfer(
+			statemine_like::RuntimeOrigin::signed(RELAYALICE),
+			sov,
+			100000000000000
+		));
+
+		// Send statemine USDC asset to Alice in Parachain A
+		let parachain_beneficiary_from_statemint: MultiLocation = AccountKey20 {
+			network: None,
+			key: PARAALICE,
+		}
+		.into();
+
+		// Send with new prefix
+		assert_ok!(StatemineChainPalletXcm::reserve_transfer_assets(
+			statemine_like::RuntimeOrigin::signed(RELAYALICE),
+			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
+			Box::new(
+				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
+					.clone()
+					.into()
+			),
+			Box::new(
+				(
+					X2(
+						xcm::latest::prelude::PalletInstance(
+							<StatemineAssets as PalletInfoAccess>::index() as u8
+						),
+						GeneralIndex(10),
+					),
+					125
+				)
+					.into()
+			),
+			0,
+		));
+	});
+
+	let statemine_beneficiary = MultiLocation {
+		parents: 1,
+		interior: X2(
+			Parachain(4),
+			AccountId32 {
+				network: None,
+				id: RELAYBOB.into(),
+			},
+		),
+	};
+
+	ParaA::execute_with(|| {
+		// Alice has received 125 USDC
+		assert_eq!(
+			Assets::balance(source_statemine_asset_id, &PARAALICE.into()),
+			125
+		);
+
+		// Alice has received 200 Relay assets
+		assert_eq!(Assets::balance(source_relay_id, &PARAALICE.into()), 200);
+	});
+
+	// Transfer USDC from Parachain A to Statemine using Relay asset as fee
+	ParaA::execute_with(|| {
+		assert_ok!(XTokens::transfer_multicurrencies(
+			parachain::RuntimeOrigin::signed(PARAALICE.into()),
+			vec![
+				(
+					parachain::CurrencyId::ForeignAsset(source_statemine_asset_id),
+					100
+				),
+				(parachain::CurrencyId::ForeignAsset(source_relay_id), 100)
+			],
+			1,
+			Box::new(VersionedMultiLocation::V3(statemine_beneficiary)),
+			WeightLimit::Limited(Weight::from_parts(80_000_000u64, 100_000u64))
+		));
+	});
+
+	ParaA::execute_with(|| {
+		// Alice has 100 USDC less
+		assert_eq!(
+			Assets::balance(source_statemine_asset_id, &PARAALICE.into()),
+			25
+		);
+
+		// Alice has 100 relay asset less
+		assert_eq!(Assets::balance(source_relay_id, &PARAALICE.into()), 100);
+	});
+
+	Statemine::execute_with(|| {
+		// Check that BOB received 10 USDC on statemine
+		assert_eq!(StatemineAssets::account_balances(RELAYBOB), vec![(10, 100)]);
+	});
+}
+
+#[test]
 fn transact_through_signed_multilocation() {
 	MockNet::reset();
 	let mut ancestry = MultiLocation::parent();


### PR DESCRIPTION
### What does it do?

Enables multicurrencies related transfers that contain assets that don't share the same reserve. To give an example, we now can send USDC from Moonbeam to AssetHub using the relay token DOT as fee. This was not possible with the old configuration, due to `ParachainMinFee` was set to `u128::MAX`, which prevent executing this functionality at the moment of checking if the provided fee is enough according the destination chain's minimum required fee.

### What important points reviewers should know?

In both **_Moonriver_** and **_Moonbeam_** chains, the new minimum fee for their corresponding Kusama and Polkadot AssetHub chains, is set to `50_000_000`. This is a safe estimate that other parachains use (Acala in the example below).

![image](https://github.com/moonbeam-foundation/moonbeam/assets/71607254/c1ce596c-aa14-4ab0-bb37-73ffedb0a6b8)