### PR TITLE
Fix tracing tests and update workflow to run more tests 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,7 +361,6 @@ jobs:
           timeout: 30000
 
   typescript-tracing-tests:
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
     runs-on:
       labels: bare-metal
     needs: ["set-tags", "build"]
@@ -490,10 +489,7 @@ jobs:
     needs: ["set-tags", "build"]
     strategy:
       matrix:
-        #chain: ["moonbase", "moonriver", "moonbeam"]
-        # TODO: moonbase is temporary disabled due to a known issue, must be re-enabled
-        # https://github.com/AcalaNetwork/chopsticks/issues/407
-        chain: ["moonriver", "moonbeam"]
+        chain: ["moonbase", "moonriver", "moonbeam"]
     env:
       GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
       DEBUG_COLORS: 1

--- a/test/suites/tracing-tests/test-trace-filter.ts
+++ b/test/suites/tracing-tests/test-trace-filter.ts
@@ -53,7 +53,7 @@ describeSuite({
         expect(response[0].action).to.include({
           creationMethod: "create",
           from: ALITH_ADDRESS.toLocaleLowerCase(),
-          gas: "0x9a679",
+          gas: "0x9caba",
           value: "0x0",
         });
         expect(response[0].result).to.include({
@@ -87,7 +87,7 @@ describeSuite({
         expect(response.length).to.equal(1);
         expect(response[0].action.creationMethod).to.equal("create");
         expect(response[0].action.from).to.equal(ALITH_ADDRESS.toLocaleLowerCase());
-        expect(response[0].action.gas).to.equal("0x10df");
+        expect(response[0].action.gas).to.equal("0x104b");
         expect(response[0].action.init).to.be.a("string");
         expect(response[0].action.value).to.equal("0x0");
         expect(response[0].blockHash).to.be.a("string");

--- a/test/suites/tracing-tests/test-trace-filter.ts
+++ b/test/suites/tracing-tests/test-trace-filter.ts
@@ -53,7 +53,7 @@ describeSuite({
         expect(response[0].action).to.include({
           creationMethod: "create",
           from: ALITH_ADDRESS.toLocaleLowerCase(),
-          gas: "0x9caba",
+          gas: "0x9a679",
           value: "0x0",
         });
         expect(response[0].result).to.include({
@@ -87,7 +87,7 @@ describeSuite({
         expect(response.length).to.equal(1);
         expect(response[0].action.creationMethod).to.equal("create");
         expect(response[0].action.from).to.equal(ALITH_ADDRESS.toLocaleLowerCase());
-        expect(response[0].action.gas).to.equal("0x104b");
+        expect(response[0].action.gas).to.equal("0x10df");
         expect(response[0].action.init).to.be.a("string");
         expect(response[0].action.value).to.equal("0x0");
         expect(response[0].blockHash).to.be.a("string");

--- a/test/suites/tracing-tests/test-trace-gas.ts
+++ b/test/suites/tracing-tests/test-trace-gas.ts
@@ -15,9 +15,9 @@ describeSuite({
       blockNumber?: number;
       expectedGas: string;
     }[] = [
-      { count: 0, expectedGas: "0x53da" },
-      { count: 100, expectedGas: "0x14422" },
-      { count: 1000, expectedGas: "0x67192" },
+      { count: 0, expectedGas: "0x53dd" },
+      { count: 100, expectedGas: "0x144ed" },
+      { count: 1000, expectedGas: "0x67965" },
     ];
 
     let looperAddress: `0x${string}`;
@@ -50,7 +50,7 @@ describeSuite({
 
     it({
       id: "T01",
-      title: "should return 21630 gasUsed for 0 loop",
+      title: "should return 21469 gasUsed for 0 loop",
       test: async function () {
         const trace = await customDevRpcRequest("trace_filter", [
           {
@@ -66,7 +66,7 @@ describeSuite({
 
     it({
       id: "T02",
-      title: "should return 245542 gasUsed for 100 loop",
+      title: "should return 82978 gasUsed for 100 loop",
       test: async function () {
         const trace = await customDevRpcRequest("trace_filter", [
           {
@@ -83,7 +83,7 @@ describeSuite({
 
     it({
       id: "T03",
-      title: "should return 2068654 gasUsed for 1000 loop",
+      title: "should return 422290 gasUsed for 1000 loop",
       test: async function () {
         const trace = await customDevRpcRequest("trace_filter", [
           {

--- a/test/suites/tracing-tests/test-trace-gas.ts
+++ b/test/suites/tracing-tests/test-trace-gas.ts
@@ -15,9 +15,9 @@ describeSuite({
       blockNumber?: number;
       expectedGas: string;
     }[] = [
-      { count: 0, expectedGas: "0x53dd" },
-      { count: 100, expectedGas: "0x144ed" },
-      { count: 1000, expectedGas: "0x67965" },
+      { count: 0, expectedGas: "0x53da" },
+      { count: 100, expectedGas: "0x14422" },
+      { count: 1000, expectedGas: "0x67192" },
     ];
 
     let looperAddress: `0x${string}`;
@@ -50,7 +50,7 @@ describeSuite({
 
     it({
       id: "T01",
-      title: "should return 21469 gasUsed for 0 loop",
+      title: "should return 21466 gasUsed for 0 loop",
       test: async function () {
         const trace = await customDevRpcRequest("trace_filter", [
           {


### PR DESCRIPTION
### What does it do?

The solc version upgrade to v0.8.21 produces different gas consumption, this PR updates the gas consumption according to solc v0.8.21 output. 

Tracing tests are enabled by default (instead only when the A10 label is selected), re-enable the runtime upgrade tests for moonbase runtime 


