### PR TITLE
fix incorrect eth parent hashes on moonbase

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -801,19 +801,25 @@ where
 
 		let keystore = params.keystore_container.keystore();
 		move |deny_unsafe, subscription_task_executor| {
-			let mut forced_parent_hashes = BTreeMap::new();
-			// Fixes for https://github.com/paritytech/frontier/pull/570
-			// #1648995
-			forced_parent_hashes.insert(
-				H256::from_str(
-					"0x4f38af62c0ce9f2c66c38135b24cf900b4bd7e4044700aa85522358e1365f734",
-				)
-				.expect("must be valid hash"),
-				H256::from_str(
-					"0x0d0fd88778aec08b3a83ce36387dbf130f6f304fc91e9a44c9605eaf8a80ce5d",
-				)
-				.expect("must be valid hash"),
-			);
+			#[cfg(feature = "moonbase-native")]
+			let forced_parent_hashes = {
+				let mut forced_parent_hashes = BTreeMap::new();
+				// Fixes for https://github.com/paritytech/frontier/pull/570
+				// #1648995
+				forced_parent_hashes.insert(
+					H256::from_str(
+						"0x4f38af62c0ce9f2c66c38135b24cf900b4bd7e4044700aa85522358e1365f734",
+					)
+					.expect("must be valid hash"),
+					H256::from_str(
+						"0x0d0fd88778aec08b3a83ce36387dbf130f6f304fc91e9a44c9605eaf8a80ce5d",
+					)
+					.expect("must be valid hash"),
+				);
+				Some(forced_parent_hashes)
+			};
+			#[cfg(not(feature = "moonbase-native"))]
+			let forced_parent_hashes = None;
 
 			let deps = rpc::FullDeps {
 				backend: backend.clone(),
@@ -837,7 +843,7 @@ where
 				xcm_senders: None,
 				block_data_cache: block_data_cache.clone(),
 				overrides: overrides.clone(),
-				forced_parent_hashes: Some(forced_parent_hashes),
+				forced_parent_hashes,
 			};
 			let pending_consensus_data_provider = Box::new(PendingConsensusDataProvider::new(
 				client.clone(),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -808,7 +808,7 @@ where
 				// #1648995
 				forced_parent_hashes.insert(
 					H256::from_str(
-						"0x4f38af62c0ce9f2c66c38135b24cf900b4bd7e4044700aa85522358e1365f734",
+						"0xa352fee3eef9c554a31ec0612af887796a920613358abf3353727760ea14207b",
 					)
 					.expect("must be valid hash"),
 					H256::from_str(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -79,6 +79,7 @@ use sp_api::{ConstructRuntimeApi, ProvideRuntimeApi};
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_core::{ByteArray, H256};
 use sp_keystore::{Keystore, KeystorePtr};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{collections::BTreeMap, path::Path, sync::Mutex, time::Duration};
 use substrate_prometheus_endpoint::Registry;
@@ -800,6 +801,20 @@ where
 
 		let keystore = params.keystore_container.keystore();
 		move |deny_unsafe, subscription_task_executor| {
+			let mut forced_parent_hashes = BTreeMap::new();
+			// Fixes for https://github.com/paritytech/frontier/pull/570
+			// #1648995
+			forced_parent_hashes.insert(
+				H256::from_str(
+					"0x4f38af62c0ce9f2c66c38135b24cf900b4bd7e4044700aa85522358e1365f734",
+				)
+				.expect("must be valid hash"),
+				H256::from_str(
+					"0x0d0fd88778aec08b3a83ce36387dbf130f6f304fc91e9a44c9605eaf8a80ce5d",
+				)
+				.expect("must be valid hash"),
+			);
+
 			let deps = rpc::FullDeps {
 				backend: backend.clone(),
 				client: client.clone(),
@@ -822,7 +837,7 @@ where
 				xcm_senders: None,
 				block_data_cache: block_data_cache.clone(),
 				overrides: overrides.clone(),
-				forced_parent_hashes: None,
+				forced_parent_hashes: Some(forced_parent_hashes),
 			};
 			let pending_consensus_data_provider = Box::new(PendingConsensusDataProvider::new(
 				client.clone(),


### PR DESCRIPTION
### What does it do?
Fixes incorrect eth parent hash for the block `1648995` on moonbase that is retrieving via RPC. No other blocks were found with the same issue.

### What important points reviewers should know?
This isn't being applied for `--dev` mode. 

See context:
* https://github.com/paritytech/frontier/pull/570
* https://github.com/paritytech/frontier/pull/1044
* https://github.com/moonbeam-foundation/moonbeam/pull/2276
