### PR TITLE
Remove the minimum bond requirement for the orbitor pool collator

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -988,8 +988,12 @@ pub mod pallet {
 			bond: BalanceOf<T>,
 			candidate_count: u32,
 		) -> DispatchResultWithPostInfo {
+			ensure!(
+				bond >= T::MinCandidateStk::get(),
+				Error::<T>::CandidateBondBelowMin
+			);
 			let acc = ensure_signed(origin.clone())?;
-			Self::join_candidates_inner(acc, bond, candidate_count, false)
+			Self::join_candidates_inner(acc, bond, candidate_count)
 		}
 
 		/// Request to leave the set of candidates. If successful, the account is immediately
@@ -1448,7 +1452,7 @@ pub mod pallet {
 			candidate_count: u32,
 		) -> DispatchResultWithPostInfo {
 			T::MonetaryGovernanceOrigin::ensure_origin(origin.clone())?;
-			Self::join_candidates_inner(acc, bond, candidate_count, true)
+			Self::join_candidates_inner(acc, bond, candidate_count)
 		}
 	}
 
@@ -1480,14 +1484,9 @@ pub mod pallet {
 			acc: T::AccountId,
 			bond: BalanceOf<T>,
 			candidate_count: u32,
-			skip_bond_check: bool,
 		) -> DispatchResultWithPostInfo {
 			ensure!(!Self::is_candidate(&acc), Error::<T>::CandidateExists);
 			ensure!(!Self::is_delegator(&acc), Error::<T>::DelegatorExists);
-			ensure!(
-				skip_bond_check || bond >= T::MinCandidateStk::get(),
-				Error::<T>::CandidateBondBelowMin
-			);
 			let mut candidates = <CandidatePool<T>>::get();
 			let old_count = candidates.0.len() as u32;
 			ensure!(

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1447,12 +1447,12 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::join_candidates(*candidate_count))]
 		pub fn force_join_candidates(
 			origin: OriginFor<T>,
-			acc: T::AccountId,
+			account: T::AccountId,
 			bond: BalanceOf<T>,
 			candidate_count: u32,
 		) -> DispatchResultWithPostInfo {
 			T::MonetaryGovernanceOrigin::ensure_origin(origin.clone())?;
-			Self::join_candidates_inner(acc, bond, candidate_count)
+			Self::join_candidates_inner(account, bond, candidate_count)
 		}
 	}
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -988,11 +988,11 @@ pub mod pallet {
 			bond: BalanceOf<T>,
 			candidate_count: u32,
 		) -> DispatchResultWithPostInfo {
+			let acc = ensure_signed(origin.clone())?;
 			ensure!(
 				bond >= T::MinCandidateStk::get(),
 				Error::<T>::CandidateBondBelowMin
 			);
-			let acc = ensure_signed(origin.clone())?;
 			Self::join_candidates_inner(acc, bond, candidate_count)
 		}
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1470,9 +1470,8 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		pub fn set_candidate_bond_to_zero(acc: &T::AccountId) -> DispatchResultWithPostInfo {
 			ensure!(Self::is_candidate(&acc), Error::<T>::CandidateDNE);
-			let actual_weight = T::WeightInfo::set_candidate_bond_to_zero(
-				<CandidatePool<T>>::get().0.len() as u32,
-			);
+			let actual_weight =
+				T::WeightInfo::set_candidate_bond_to_zero(<CandidatePool<T>>::get().0.len() as u32);
 			let mut state = <CandidateInfo<T>>::get(&acc).ok_or(Error::<T>::CandidateDNE)?;
 			state.bond_less::<T>(acc.clone(), state.bond);
 			<CandidateInfo<T>>::insert(&acc, state);

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1468,6 +1468,17 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		pub fn set_candidate_bond_to_zero(acc: &T::AccountId) -> DispatchResultWithPostInfo {
+			ensure!(Self::is_candidate(&acc), Error::<T>::CandidateDNE);
+			let actual_weight = T::WeightInfo::set_candidate_bond_to_zero(
+				<CandidatePool<T>>::get().0.len() as u32,
+			);
+			let mut state = <CandidateInfo<T>>::get(&acc).ok_or(Error::<T>::CandidateDNE)?;
+			state.bond_less::<T>(acc.clone(), state.bond);
+			<CandidateInfo<T>>::insert(&acc, state);
+			Ok(Some(actual_weight).into())
+		}
+
 		pub fn is_delegator(acc: &T::AccountId) -> bool {
 			<DelegatorState<T>>::get(acc).is_some()
 		}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -988,11 +988,12 @@ pub mod pallet {
 			bond: BalanceOf<T>,
 			candidate_count: u32,
 		) -> DispatchResultWithPostInfo {
-			let acc = ensure_signed(origin)?;
+			let acc = ensure_signed(origin.clone())?;
+			let is_governance_origin = T::MonetaryGovernanceOrigin::ensure_origin(origin).is_ok();
 			ensure!(!Self::is_candidate(&acc), Error::<T>::CandidateExists);
 			ensure!(!Self::is_delegator(&acc), Error::<T>::DelegatorExists);
 			ensure!(
-				bond >= T::MinCandidateStk::get(),
+				is_governance_origin || bond >= T::MinCandidateStk::get(),
 				Error::<T>::CandidateBondBelowMin
 			);
 			let mut candidates = <CandidatePool<T>>::get();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -989,11 +989,11 @@ pub mod pallet {
 			candidate_count: u32,
 		) -> DispatchResultWithPostInfo {
 			let acc = ensure_signed(origin.clone())?;
-			let is_governance_origin = T::MonetaryGovernanceOrigin::ensure_origin(origin).is_ok();
 			ensure!(!Self::is_candidate(&acc), Error::<T>::CandidateExists);
 			ensure!(!Self::is_delegator(&acc), Error::<T>::DelegatorExists);
 			ensure!(
-				is_governance_origin || bond >= T::MinCandidateStk::get(),
+				bond >= T::MinCandidateStk::get()
+					|| T::MonetaryGovernanceOrigin::ensure_origin(origin).is_ok(),
 				Error::<T>::CandidateBondBelowMin
 			);
 			let mut candidates = <CandidatePool<T>>::get();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -988,7 +988,7 @@ pub mod pallet {
 			bond: BalanceOf<T>,
 			candidate_count: u32,
 		) -> DispatchResultWithPostInfo {
-			let acc = ensure_signed(origin.clone())?;
+			let acc = ensure_signed(origin)?;
 			ensure!(
 				bond >= T::MinCandidateStk::get(),
 				Error::<T>::CandidateBondBelowMin
@@ -1470,8 +1470,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		pub fn set_candidate_bond_to_zero(acc: &T::AccountId) -> DispatchResultWithPostInfo {
 			ensure!(Self::is_candidate(&acc), Error::<T>::CandidateDNE);
-			let actual_weight =
-				T::WeightInfo::set_candidate_bond_to_zero(<CandidatePool<T>>::get().0.len() as u32);
+			let actual_weight = T::WeightInfo::set_candidate_bond_to_zero(T::MaxCandidates::get());
 			let mut state = <CandidateInfo<T>>::get(&acc).ok_or(Error::<T>::CandidateDNE)?;
 			state.bond_less::<T>(acc.clone(), state.bond);
 			<CandidateInfo<T>>::insert(&acc, state);
@@ -1606,8 +1605,7 @@ pub mod pallet {
 			more: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
 			let mut state = <CandidateInfo<T>>::get(&collator).ok_or(Error::<T>::CandidateDNE)?;
-			let actual_weight =
-				T::WeightInfo::candidate_bond_more(<CandidatePool<T>>::get().0.len() as u32);
+			let actual_weight = T::WeightInfo::candidate_bond_more(T::MaxCandidates::get());
 
 			state
 				.bond_more::<T>(collator.clone(), more)
@@ -1627,9 +1625,7 @@ pub mod pallet {
 			candidate: T::AccountId,
 		) -> DispatchResultWithPostInfo {
 			let mut state = <CandidateInfo<T>>::get(&candidate).ok_or(Error::<T>::CandidateDNE)?;
-			let actual_weight = T::WeightInfo::execute_candidate_bond_less(
-				<CandidatePool<T>>::get().0.len() as u32,
-			);
+			let actual_weight = T::WeightInfo::execute_candidate_bond_less(T::MaxCandidates::get());
 
 			state
 				.execute_bond_less::<T>(candidate.clone())

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -810,6 +810,26 @@ fn cannot_join_candidates_without_min_bond() {
 }
 
 #[test]
+fn can_force_join_candidates_without_min_bond() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 10)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ParachainStaking::force_join_candidates(
+				RuntimeOrigin::root(),
+				1,
+				9,
+				100u32
+			));
+			assert_events_eq!(Event::JoinedCollatorCandidates {
+				account: 1,
+				amount_locked: 9u128,
+				new_total_amt_locked: 9u128,
+			});
+		});
+}
+
+#[test]
 fn cannot_join_candidates_with_more_than_available_balance() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 500)])

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -477,15 +477,15 @@ impl<
 			);
 		}
 		self.total_counted = self.total_counted.saturating_sub(amount);
-		if self.is_active() {
-			Pallet::<T>::update_active(who.clone(), self.total_counted.into());
-		}
 		let event = Event::CandidateBondedLess {
-			candidate: who.into(),
+			candidate: who.clone(),
 			amount: amount.into(),
 			new_bond: self.bond.into(),
 		};
 		// update candidate pool value because it must change if self bond changes
+		if self.is_active() {
+			Pallet::<T>::update_active(who, self.total_counted.into());
+		}
 		Pallet::<T>::deposit_event(event);
 	}
 

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -458,6 +458,37 @@ impl<
 		});
 		Ok(())
 	}
+
+	pub fn bond_less<T: Config>(&mut self, who: T::AccountId, amount: Balance)
+	where
+		BalanceOf<T>: From<Balance>,
+	{
+		let new_total_staked = <Total<T>>::get().saturating_sub(amount.into());
+		<Total<T>>::put(new_total_staked);
+		self.bond = self.bond.saturating_sub(amount);
+		if self.bond.is_zero() {
+			T::Currency::remove_lock(COLLATOR_LOCK_ID, &who);
+		} else {
+			T::Currency::set_lock(
+				COLLATOR_LOCK_ID,
+				&who,
+				self.bond.into(),
+				WithdrawReasons::all(),
+			);
+		}
+		self.total_counted = self.total_counted.saturating_sub(amount);
+		if self.is_active() {
+			Pallet::<T>::update_active(who.clone(), self.total_counted.into());
+		}
+		let event = Event::CandidateBondedLess {
+			candidate: who.into(),
+			amount: amount.into(),
+			new_bond: self.bond.into(),
+		};
+		// update candidate pool value because it must change if self bond changes
+		Pallet::<T>::deposit_event(event);
+	}
+
 	/// Schedule executable decrease of collator candidate self bond
 	/// Returns the round at which the collator can execute the pending request
 	pub fn schedule_bond_less<T: Config>(
@@ -498,32 +529,12 @@ impl<
 			request.when_executable <= <Round<T>>::get().current,
 			Error::<T>::PendingCandidateRequestNotDueYet
 		);
-		let new_total_staked = <Total<T>>::get().saturating_sub(request.amount.into());
-		<Total<T>>::put(new_total_staked);
-		// Arithmetic assumptions are self.bond > less && self.bond - less > CollatorMinBond
-		// (assumptions enforced by `schedule_bond_less`; if storage corrupts, must re-verify)
-		self.bond = self.bond.saturating_sub(request.amount);
-		T::Currency::set_lock(
-			COLLATOR_LOCK_ID,
-			&who.clone(),
-			self.bond.into(),
-			WithdrawReasons::all(),
-		);
-		self.total_counted = self.total_counted.saturating_sub(request.amount);
-		let event = Event::CandidateBondedLess {
-			candidate: who.clone().into(),
-			amount: request.amount.into(),
-			new_bond: self.bond.into(),
-		};
+		self.bond_less::<T>(who.clone(), request.amount);
 		// reset s.t. no pending request
 		self.request = None;
-		// update candidate pool value because it must change if self bond changes
-		if self.is_active() {
-			Pallet::<T>::update_active(who.into(), self.total_counted.into());
-		}
-		Pallet::<T>::deposit_event(event);
 		Ok(())
 	}
+
 	/// Cancel candidate bond less request
 	pub fn cancel_bond_less<T: Config>(&mut self, who: T::AccountId) -> DispatchResult
 	where

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -70,6 +70,7 @@ pub trait WeightInfo {
 	fn schedule_candidate_bond_less() -> Weight;
 	fn execute_candidate_bond_less(x: u32, ) -> Weight;
 	fn cancel_candidate_bond_less() -> Weight;
+	fn set_candidate_bond_to_zero(x: u32, ) -> Weight;
 	fn delegate(x: u32, y: u32, ) -> Weight;
 	fn schedule_revoke_delegation(x: u32, ) -> Weight;
 	fn delegator_bond_more(x: u32, ) -> Weight;
@@ -414,6 +415,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(19_491_000, 3656)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	fn set_candidate_bond_to_zero(x: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1322 + x * (42 ±0)`
+		//  Estimated: `4752 + x * (43 ±0)`
+		// Minimum execution time: 71_996_000 picoseconds.
+		Weight::from_parts(80_620_929, 4752)
+			// Standard Error: 1_363
+			.saturating_add(Weight::from_parts(94_580, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(5_u64))
+			.saturating_add(Weight::from_parts(0, 43).saturating_mul(x.into()))
 	}
 	/// Storage: System Account (r:1 w:1)
 	/// Proof: System Account (max_values: None, max_size: Some(116), added: 2591, mode: MaxEncodedLen)
@@ -1222,6 +1235,18 @@ impl WeightInfo for () {
 		Weight::from_parts(19_491_000, 3656)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	fn set_candidate_bond_to_zero(x: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1322 + x * (42 ±0)`
+		//  Estimated: `4752 + x * (43 ±0)`
+		// Minimum execution time: 71_996_000 picoseconds.
+		Weight::from_parts(80_620_929, 4752)
+			// Standard Error: 1_363
+			.saturating_add(Weight::from_parts(94_580, 0).saturating_mul(x.into()))
+			.saturating_add(RocksDbWeight::get().reads(6_u64))
+			.saturating_add(RocksDbWeight::get().writes(5_u64))
+			.saturating_add(Weight::from_parts(0, 43).saturating_mul(x.into()))
 	}
 	/// Storage: System Account (r:1 w:1)
 	/// Proof: System Account (max_values: None, max_size: Some(116), added: 2591, mode: MaxEncodedLen)

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -26,6 +26,9 @@ use frame_support::{
 };
 use pallet_author_slot_filter::Config as AuthorSlotFilterConfig;
 use pallet_migrations::{GetMigrations, Migration};
+use pallet_moonbeam_orbiters::CollatorsPool;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::traits::Zero;
 use sp_std::{marker::PhantomData, prelude::*};
 
 pub struct PreimageMigrationHashToBoundedCall<T>(PhantomData<T>);
@@ -111,6 +114,46 @@ impl<T: pallet_xcm_transactor::Config> Migration for PopulateRelayIndices<T> {
 	}
 }
 
+pub struct RemoveMinBondForOrbiterCollators<T>(pub PhantomData<T>);
+impl<T> Migration for RemoveMinBondForOrbiterCollators<T>
+where
+	T: pallet_moonbeam_orbiters::Config,
+	T: pallet_parachain_staking::Config,
+	T: frame_system::Config,
+{
+	fn friendly_name(&self) -> &str {
+		"MM_RemoveMinBondForOldOrbiterCollators"
+	}
+
+	fn migrate(&self, _available_weight: Weight) -> Weight {
+		let mut weight = Weight::zero();
+		CollatorsPool::<T>::iter_keys().for_each(|collator| {
+			log::info!("Setting the bond for collator {:?} to zero", collator);
+			weight += <pallet_parachain_staking::Pallet<T>>::set_candidate_bond_to_zero(&collator)
+				.expect("failed to set collator bond to 0")
+				.actual_weight
+				.expect("failed to get weight");
+		});
+		weight
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
+		Ok(vec![])
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(&self, _state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		CollatorsPool::<T>::iter_keys().for_each(|collator| {
+			log::info!("Checking collator: {:?}", collator);
+			let state = <pallet_parachain_staking::Pallet<T>>::candidate_info(&collator)
+				.expect("collator should have candidate info");
+			assert!(state.bond.is_zero(), "collator bond should be zero");
+		});
+		Ok(())
+	}
+}
+
 pub struct ReferendaMigrations<Runtime, Council, Tech>(PhantomData<(Runtime, Council, Tech)>);
 
 impl<Runtime, Council, Tech> GetMigrations for ReferendaMigrations<Runtime, Council, Tech>
@@ -147,6 +190,7 @@ where
 	Runtime: pallet_asset_manager::Config,
 	<Runtime as pallet_asset_manager::Config>::ForeignAssetType: From<xcm::v3::MultiLocation>,
 	Runtime: pallet_xcm_transactor::Config,
+	Runtime: pallet_moonbeam_orbiters::Config,
 {
 	fn get_migrations() -> Vec<Box<dyn Migration>> {
 		// let migration_author_mapping_twox_to_blake = AuthorMappingTwoXToBlake::<Runtime> {
@@ -212,6 +256,8 @@ where
 		//	PalletAssetManagerMigrateXcmV2ToV3::<Runtime>(Default::default());
 		//let xcm_transactor_to_xcm_v3 =
 		//	PalletXcmTransactorMigrateXcmV2ToV3::<Runtime>(Default::default());
+		let remove_min_bond_for_old_orbiter_collators =
+			RemoveMinBondForOrbiterCollators::<Runtime>(Default::default());
 		vec![
 			// completed in runtime 800
 			// Box::new(migration_author_mapping_twox_to_blake),
@@ -258,6 +304,7 @@ where
 			//Box::new(preimage_migration_hash_to_bounded_call),
 			//Box::new(asset_manager_to_xcm_v3),
 			//Box::new(xcm_transactor_to_xcm_v3),
+			Box::new(remove_min_bond_for_old_orbiter_collators),
 		]
 	}
 }

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -122,7 +122,7 @@ where
 	T: frame_system::Config,
 {
 	fn friendly_name(&self) -> &str {
-		"MM_RemoveMinBondForOldOrbiterCollators"
+		"MM_RemoveMinBondForOrbiterCollators"
 	}
 
 	fn migrate(&self, _available_weight: Weight) -> Weight {

--- a/runtime/common/src/weights/pallet_parachain_staking.rs
+++ b/runtime/common/src/weights/pallet_parachain_staking.rs
@@ -384,6 +384,19 @@ impl<T: frame_system::Config> pallet_parachain_staking::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	fn set_candidate_bond_to_zero(x: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1322 + x * (42 ±0)`
+		//  Estimated: `4752 + x * (43 ±0)`
+		// Minimum execution time: 34_969_000 picoseconds.
+		Weight::from_parts(43_183_234, 0)
+			.saturating_add(Weight::from_parts(0, 4752))
+			// Standard Error: 1_377
+			.saturating_add(Weight::from_parts(105_890, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(6))
+			.saturating_add(T::DbWeight::get().writes(5))
+			.saturating_add(Weight::from_parts(0, 43).saturating_mul(x.into()))
+	}
 	/// Storage: System Account (r:1 w:1)
 	/// Proof: System Account (max_values: None, max_size: Some(116), added: 2591, mode: MaxEncodedLen)
 	/// Storage: ParachainStaking DelegatorState (r:1 w:1)

--- a/test/suites/dev/test-staking/test-candidate-force-join.ts
+++ b/test/suites/dev/test-staking/test-candidate-force-join.ts
@@ -1,0 +1,87 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, expect } from "@moonwall/cli";
+import { MIN_GLMR_STAKING, alith, ethan, faith } from "@moonwall/util";
+
+describeSuite({
+  id: "D2992",
+  title: "Staking - Candidate Force Join - bond less than min",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    it({
+      id: "T01",
+      title: "should succeed",
+      test: async () => {
+        const minCandidateStk = context.polkadotJs().consts.parachainStaking.minCandidateStk;
+        const block = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.sudo.sudo(
+              context
+                .polkadotJs()
+                .tx.parachainStaking.forceJoinCandidates(ethan.address, minCandidateStk.subn(10), 1)
+            )
+            .signAsync(alith)
+        );
+        expect(block.result!.successful).to.be.true;
+      },
+    });
+
+    it({
+      id: "T02",
+      title: "should fail",
+      test: async () => {
+        const block = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.sudo.sudo(
+              context
+                .polkadotJs()
+                .tx.parachainStaking.forceJoinCandidates(ethan.address, MIN_GLMR_STAKING, 1)
+            )
+            .signAsync(alith),
+          {
+            allowFailures: true,
+            expectEvents: [context.polkadotJs().events.sudo.Sudid],
+          }
+        );
+
+        const { events } = block.result!;
+        const event = events.find((event) => {
+          const module = event.event.data[0].toPrimitive().err?.module;
+          const parachainStaking = 12;
+          const candidateExists = "0x06000000";
+          return module?.index === parachainStaking && module?.error === candidateExists;
+        });
+        expect(event).not.to.be.undefined;
+      },
+    });
+
+    it({
+      id: "T03",
+      title: "should fail",
+      test: async () => {
+        const block = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.sudo.sudo(
+              context
+                .polkadotJs()
+                .tx.parachainStaking.forceJoinCandidates(faith.address, MIN_GLMR_STAKING, 0)
+            )
+            .signAsync(alith)
+        );
+        const { events } = block.result!;
+        const event = events.find((event) => {
+          const module = event.event.data[0].toPrimitive().err?.module;
+          const parachainStaking = 12;
+          const tooLowCandidateCountWeightHintJoinCandidates = "0x1b000000";
+          return (
+            module?.index === parachainStaking &&
+            module?.error === tooLowCandidateCountWeightHintJoinCandidates
+          );
+        });
+        expect(event).not.to.be.undefined;
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests10-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests10-bondless-collator.ts
@@ -1,0 +1,62 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+
+describeSuite({
+  id: "D2999",
+  title:
+    "Staking - Delegation Scheduled Requests with bondless collator - execute bond less exact round",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    const LESS_AMOUNT = 10n;
+    let psTx: any;
+    let psQuery: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock([
+        sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+        psTx.delegate(alith.address, MIN_GLMR_DELEGATOR + LESS_AMOUNT, 0, 0).signAsync(ethan),
+      ]);
+      await createBlock(
+        psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR + LESS_AMOUNT, 0, 1).signAsync(ethan)
+      );
+      await createBlock(
+        psTx.scheduleDelegatorBondLess(baltathar.address, LESS_AMOUNT).signAsync(ethan)
+      );
+
+      // jump to exact executable Round
+      const delegationRequests = await psQuery.delegationScheduledRequests(baltathar.address);
+      await jumpToRound(context, delegationRequests[0].whenExecutable.toNumber());
+    });
+
+    it({
+      id: "T01",
+      title: "should succeed",
+      test: async () => {
+        await createBlock(
+          psTx.executeDelegationRequest(ethan.address, baltathar.address).signAsync(ethan)
+        );
+        const delegatorState = await psQuery.delegatorState(ethan.address);
+        const delegationRequestsAfter = await psQuery.delegationScheduledRequests(
+          baltathar.address
+        );
+        expect(delegatorState.unwrap().delegations[0].owner.toString()).toBe(baltathar.address);
+        expect(delegatorState.unwrap().delegations[0].amount.toBigInt()).toBe(MIN_GLMR_DELEGATOR);
+        expect(delegatorState.unwrap().delegations[1].owner.toString()).toBe(alith.address);
+        expect(delegatorState.unwrap().delegations[1].amount.toBigInt()).toBe(
+          MIN_GLMR_DELEGATOR + LESS_AMOUNT
+        );
+        expect(delegationRequestsAfter.isEmpty).toBe(true);
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests10-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests10-bondless-collator.ts
@@ -6,7 +6,8 @@ import { jumpToRound } from "../../../helpers/block.js";
 describeSuite({
   id: "D2999",
   title:
-    "Staking - Delegation Scheduled Requests with bondless collator - execute bond less exact round",
+    "Staking - Delegation Scheduled Requests with bondless collator \
+    - execute bond less exact round",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
     const LESS_AMOUNT = 10n;

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
@@ -1,0 +1,67 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+
+describeSuite({
+  id: "D3000",
+  title:
+    "Staking - Delegation Scheduled Requests with bondless collator - execute bond less after round delay",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    const LESS_AMOUNT = 10n;
+    let psTx: any;
+    let psQuery: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock(
+        [
+          sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+          psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR + LESS_AMOUNT, 0, 0).signAsync(ethan),
+        ],
+        { allowFailures: false }
+      );
+      await createBlock(
+        psTx.delegate(alith.address, MIN_GLMR_DELEGATOR + LESS_AMOUNT, 0, 1).signAsync(ethan),
+        { allowFailures: false }
+      );
+      await createBlock(
+        psTx.scheduleDelegatorBondLess(baltathar.address, LESS_AMOUNT).signAsync(ethan),
+        { allowFailures: false }
+      );
+
+      // jump to exact executable Round
+      const delegationRequests = await psQuery.delegationScheduledRequests(baltathar.address);
+      await jumpToRound(context, delegationRequests[0].whenExecutable.toNumber() + 5);
+    });
+
+    it({
+      id: "T01",
+      title: "should succeed",
+      test: async () => {
+        await createBlock(
+          psTx.executeDelegationRequest(ethan.address, baltathar.address).signAsync(ethan)
+        );
+        const delegatorState = await psQuery.delegatorState(ethan.address);
+        const delegationRequestsAfter = await psQuery.delegationScheduledRequests(
+          baltathar.address
+        );
+        expect(delegatorState.unwrap().delegations[0].owner.toString()).toBe(baltathar.address);
+        expect(delegatorState.unwrap().delegations[0].amount.toBigInt()).toBe(MIN_GLMR_DELEGATOR);
+        expect(delegatorState.unwrap().delegations[1].owner.toString()).toBe(alith.address);
+        expect(delegatorState.unwrap().delegations[1].amount.toBigInt()).toBe(
+          MIN_GLMR_DELEGATOR + LESS_AMOUNT
+        );
+        expect(delegationRequestsAfter.isEmpty).toBe(true);
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
@@ -6,7 +6,8 @@ import { jumpToRound } from "../../../helpers/block.js";
 describeSuite({
   id: "D3000",
   title:
-    "Staking - Delegation Scheduled Requests with bondless collator - execute bond less after round delay",
+    "Staking - Delegation Scheduled Requests with bondless collator \
+    - execute bond less after round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
     const LESS_AMOUNT = 10n;

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
@@ -1,6 +1,6 @@
 import "@moonbeam-network/api-augment";
 import { describeSuite, beforeAll, expect } from "@moonwall/cli";
-import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../helpers/block.js";
 
 describeSuite({

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests12-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests12-bondless-collator.ts
@@ -1,0 +1,83 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+
+describeSuite({
+  id: "D3001",
+  title: "Staking - Delegation Scheduled Requests with bondless collator - collator leave",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    let whenExecutable: number;
+    let psTx: any;
+    let psQuery: any;
+    let psConst: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      psConst = context.polkadotJs().consts.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock([
+        sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+        psTx.delegate(alith.address, MIN_GLMR_DELEGATOR + 10n, 0, 0).signAsync(ethan),
+      ]);
+
+      await createBlock([
+        psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR + 10n, 0, 1).signAsync(ethan),
+      ]);
+      await createBlock([psTx.scheduleDelegatorBondLess(alith.address, 10n).signAsync(ethan)]);
+
+      await createBlock([
+        psTx.scheduleDelegatorBondLess(baltathar.address, 10n).signAsync(ethan),
+        psTx.scheduleLeaveCandidates(2).signAsync(baltathar),
+      ]);
+
+      const currentRound = (await psQuery.round()).current.toNumber();
+      const roundDelay = psConst.revokeDelegationDelay.toNumber();
+      whenExecutable = currentRound + roundDelay;
+
+      const collatorState = await psQuery.candidateInfo(baltathar.address);
+      await jumpToRound(context, collatorState.unwrap().status.asLeaving.toNumber());
+    });
+
+    it({
+      id: "T01",
+      title: "should remove complete storage item",
+      test: async () => {
+        const delegationRequestsBefore = await psQuery.delegationScheduledRequests(
+          baltathar.address
+        );
+        expect(delegationRequestsBefore.toJSON()).to.not.be.empty;
+
+        await createBlock(psTx.executeLeaveCandidates(baltathar.address, 1).signAsync(ethan));
+
+        const delegationRequestsBaltatharAfter = await psQuery.delegationScheduledRequests(
+          baltathar.address
+        );
+        const delegationRequestsAlithAfter = await psQuery.delegationScheduledRequests(
+          alith.address
+        );
+        expect(delegationRequestsAlithAfter.toJSON()).to.deep.equal([
+          {
+            delegator: ethan.address,
+            whenExecutable,
+            action: {
+              decrease: 10,
+            },
+          },
+        ]);
+        expect(delegationRequestsBaltatharAfter.toJSON()).to.be.empty;
+        const delagationRequestsKeys = await psQuery.delegationScheduledRequests.keys();
+        expect(delagationRequestsKeys.map((k) => k.args[0].toString())).to.deep.equal([
+          alith.address,
+        ]);
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
@@ -1,8 +1,7 @@
 import "@moonbeam-network/api-augment";
 import { describeSuite, beforeAll, expect } from "@moonwall/cli";
-import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../helpers/block.js";
-import { toHex } from "viem";
 
 describeSuite({
   id: "D2993",

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
@@ -1,0 +1,54 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+import { toHex } from "viem";
+
+describeSuite({
+  id: "D2993",
+  title:
+    "Staking - Delegation Scheduled Requests with bondless collator - execute revoke exact round delay",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    let psTx: any;
+    let psQuery: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock([
+        sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+        psTx.delegate(alith.address, MIN_GLMR_DELEGATOR, 0, 0).signAsync(ethan),
+      ]);
+      await createBlock(
+        psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR, 0, 1).signAsync(ethan)
+      );
+      await createBlock(psTx.scheduleRevokeDelegation(alith.address).signAsync(ethan));
+
+      const delegationRequests = await psQuery.delegationScheduledRequests(alith.address);
+      await jumpToRound(context, delegationRequests[0].whenExecutable.toNumber());
+    });
+
+    it({
+      id: "T01",
+      title: "should succeed",
+      test: async () => {
+        await createBlock(
+          psTx.executeDelegationRequest(ethan.address, alith.address).signAsync(ethan)
+        );
+        const delegatorState = await psQuery.delegatorState(ethan.address);
+        console.log("delegatorState = ", JSON.stringify(delegatorState));
+        const delegationRequestsAfter = await psQuery.delegationScheduledRequests(alith.address);
+        expect(delegatorState.unwrap().delegations[0].owner.toString()).toBe(baltathar.address);
+        expect(delegatorState.unwrap().delegations[0].amount.toBigInt()).toBe(MIN_GLMR_DELEGATOR);
+        expect(delegationRequestsAfter.isEmpty).toBe(true);
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
@@ -7,7 +7,8 @@ import { toHex } from "viem";
 describeSuite({
   id: "D2993",
   title:
-    "Staking - Delegation Scheduled Requests with bondless collator - execute revoke exact round delay",
+    "Staking - Delegation Scheduled Requests with bondless collator \
+    - execute revoke exact round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
     let psTx: any;

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
@@ -1,6 +1,6 @@
 import "@moonbeam-network/api-augment";
 import { describeSuite, beforeAll, expect } from "@moonwall/cli";
-import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../helpers/block.js";
 
 describeSuite({

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
@@ -6,7 +6,8 @@ import { jumpToRound } from "../../../helpers/block.js";
 describeSuite({
   id: "D2994",
   title:
-    "Staking - Delegation Scheduled Requests with bondless collator - execute revoke after round delay",
+    "Staking - Delegation Scheduled Requests with bondless collator \
+    - execute revoke after round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
     let psTx: any;

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
@@ -1,0 +1,53 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+
+describeSuite({
+  id: "D2994",
+  title:
+    "Staking - Delegation Scheduled Requests with bondless collator - execute revoke after round delay",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    let psTx: any;
+    let psQuery: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock([
+        sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+        psTx.delegate(alith.address, MIN_GLMR_DELEGATOR, 0, 0).signAsync(ethan),
+      ]);
+      await createBlock(
+        psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR, 0, 1).signAsync(ethan)
+      );
+      await createBlock(psTx.scheduleRevokeDelegation(alith.address).signAsync(ethan));
+
+      // jump to exact executable Round
+      const delegationRequests = await psQuery.delegationScheduledRequests(alith.address);
+      await jumpToRound(context, delegationRequests[0].whenExecutable.toNumber() + 5);
+    });
+
+    it({
+      id: "T01",
+      title: "should succeed",
+      test: async () => {
+        await createBlock(
+          psTx.executeDelegationRequest(ethan.address, alith.address).signAsync(ethan)
+        );
+        const delegatorState = await psQuery.delegatorState(ethan.address);
+        const delegationRequestsAfter = await psQuery.delegationScheduledRequests(alith.address);
+        expect(delegatorState.unwrap().delegations[0].amount.toBigInt()).toBe(MIN_GLMR_DELEGATOR);
+        expect(delegatorState.unwrap().delegations[0].owner.toString()).toBe(baltathar.address);
+        expect(delegationRequestsAfter.toJSON()).to.be.empty;
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests6-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests6-bondless-collator.ts
@@ -1,0 +1,51 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+
+describeSuite({
+  id: "D2995",
+  title:
+    "Staking - Delegation Scheduled Requests with bondless collator - execute revoke on last delegation",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    let psTx: any;
+    let psQuery: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock([
+        sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+        psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR, 0, 0).signAsync(ethan),
+      ]);
+
+      await createBlock(psTx.scheduleRevokeDelegation(baltathar.address).signAsync(ethan));
+
+      const delegationRequests = await psQuery.delegationScheduledRequests(baltathar.address);
+      await jumpToRound(context, delegationRequests[0].whenExecutable.toNumber());
+    });
+
+    it({
+      id: "T01",
+      title: "should succeed and leave as delegator",
+      test: async () => {
+        await createBlock(
+          psTx.executeDelegationRequest(ethan.address, baltathar.address).signAsync(ethan)
+        );
+        const delegatorState = await psQuery.delegatorState(ethan.address);
+        const delegationRequestsAfter = await psQuery.delegationScheduledRequests(
+          baltathar.address
+        );
+        expect(delegatorState.isNone).to.be.true; // last delegation revoked, so delegator left
+        expect(delegationRequestsAfter.isEmpty).toBe(true);
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests6-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests6-bondless-collator.ts
@@ -6,7 +6,8 @@ import { jumpToRound } from "../../../helpers/block.js";
 describeSuite({
   id: "D2995",
   title:
-    "Staking - Delegation Scheduled Requests with bondless collator - execute revoke on last delegation",
+    "Staking - Delegation Scheduled Requests with bondless collator \
+    - execute revoke on last delegation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
     let psTx: any;

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests7-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests7-bondless-collator.ts
@@ -1,0 +1,58 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
+
+describeSuite({
+  id: "D2996",
+  title: "Staking - Delegation Scheduled Requests with bondless collator - schedule bond less",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    const LESS_AMOUNT = 10n;
+    let psTx: any;
+    let psQuery: any;
+    let psConst: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      psConst = context.polkadotJs().consts.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock(
+        [
+          sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+          psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR + LESS_AMOUNT, 0, 0).signAsync(ethan),
+        ],
+        { allowFailures: false }
+      );
+    });
+
+    it({
+      id: "T01",
+      title: "should succeed",
+      test: async () => {
+        const currentRound = (await psQuery.round()).current.toNumber();
+
+        await createBlock(
+          psTx.scheduleDelegatorBondLess(baltathar.address, LESS_AMOUNT).signAsync(ethan),
+          { allowFailures: false }
+        );
+
+        const delegationRequestsAfter = await psQuery.delegationScheduledRequests(
+          baltathar.address
+        );
+        const roundDelay = psConst.revokeDelegationDelay.toNumber();
+        expect(delegationRequestsAfter[0].delegator.toString()).toBe(ethan.address);
+        expect(delegationRequestsAfter[0].whenExecutable.toNumber()).toBe(
+          currentRound + roundDelay
+        );
+        expect(delegationRequestsAfter[0].action.isDecrease).toBe(true);
+        expect(delegationRequestsAfter[0].action.asDecrease.toNumber()).toBe(Number(LESS_AMOUNT));
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests8-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests8-bondless-collator.ts
@@ -1,7 +1,6 @@
 import "@moonbeam-network/api-augment";
 import { describeSuite, beforeAll, expect } from "@moonwall/cli";
-import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
-import { jumpToRound } from "../../../helpers/block.js";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
   id: "D2997",

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests8-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests8-bondless-collator.ts
@@ -1,0 +1,62 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+
+describeSuite({
+  id: "D2997",
+  title:
+    "Staking - Delegation Scheduled Requests with bondless collator - cancel scheduled bond less",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    const LESS_AMOUNT = 10n;
+    let psTx: any;
+    let psQuery: any;
+    let psConst: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      psConst = context.polkadotJs().consts.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock(
+        [
+          sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+          psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR + LESS_AMOUNT, 0, 0).signAsync(ethan),
+        ],
+        { allowFailures: false }
+      );
+
+      await createBlock(
+        psTx.scheduleDelegatorBondLess(baltathar.address, LESS_AMOUNT).signAsync(ethan)
+      );
+    });
+
+    it({
+      id: "T01",
+      title: "should succeed",
+      test: async () => {
+        const currentRound = (await psQuery.round()).current.toNumber();
+        const delegationRequests = await psQuery.delegationScheduledRequests(baltathar.address);
+        const roundDelay = psConst.revokeDelegationDelay.toNumber();
+
+        expect(delegationRequests[0].delegator.toString()).toBe(ethan.address);
+        expect(delegationRequests[0].whenExecutable.toNumber()).toBe(currentRound + roundDelay);
+        expect(delegationRequests[0].action.isDecrease).toBe(true);
+        expect(delegationRequests[0].action.asDecrease.toNumber()).toBe(Number(LESS_AMOUNT));
+
+        await createBlock(psTx.cancelDelegationRequest(baltathar.address).signAsync(ethan));
+
+        const delegationRequestsAfterCancel = await psQuery.delegationScheduledRequests(
+          baltathar.address
+        );
+        expect(delegationRequestsAfterCancel.isEmpty).toBe(true);
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests9-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests9-bondless-collator.ts
@@ -1,0 +1,53 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, beforeAll, expect } from "@moonwall/cli";
+import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { jumpToRound } from "../../../helpers/block.js";
+
+describeSuite({
+  id: "D2998",
+  title: "Staking - Delegation Scheduled Requests with bondless collator - execute bond less early",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    const LESS_AMOUNT = 10n;
+    let psTx: any;
+    let psQuery: any;
+    let sudo: any;
+    let createBlock: any;
+
+    beforeAll(async () => {
+      psTx = context.polkadotJs().tx.parachainStaking;
+      psQuery = context.polkadotJs().query.parachainStaking;
+      sudo = context.polkadotJs().tx.sudo.sudo;
+      createBlock = context.createBlock;
+
+      await createBlock(sudo(psTx.forceJoinCandidates(baltathar.address, 0, 1)).signAsync(alith));
+      await createBlock(
+        [
+          sudo(psTx.setBlocksPerRound(10)).signAsync(alith),
+          psTx.delegate(baltathar.address, MIN_GLMR_DELEGATOR + LESS_AMOUNT, 0, 0).signAsync(ethan),
+        ],
+        { allowFailures: false }
+      );
+
+      await createBlock(
+        psTx.scheduleDelegatorBondLess(baltathar.address, LESS_AMOUNT).signAsync(ethan),
+        { allowFailures: false }
+      );
+
+      // jump to a round before the actual executable Round
+      const delegationRequests = await psQuery.delegationScheduledRequests(baltathar.address);
+      await jumpToRound(context, delegationRequests[0].whenExecutable.toNumber() - 1);
+    });
+
+    it({
+      id: "T01",
+      title: "should fail",
+      test: async () => {
+        const block = await createBlock(
+          psTx.executeDelegationRequest(ethan.address, baltathar.address).signAsync(ethan)
+        );
+        expect(block.result!.error!.name).to.equal("PendingDelegationRequestNotDueYet");
+      },
+    });
+  },
+});

--- a/test/suites/dev/test-staking/test-delegation-scheduled-requests9-bondless-collator.ts
+++ b/test/suites/dev/test-staking/test-delegation-scheduled-requests9-bondless-collator.ts
@@ -1,6 +1,6 @@
 import "@moonbeam-network/api-augment";
 import { describeSuite, beforeAll, expect } from "@moonwall/cli";
-import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
+import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../helpers/block.js";
 
 describeSuite({


### PR DESCRIPTION
### What does it do?

Removes the minimum bond requirement for the orbiter collators.

This will enable payouts to be even for future orbiter program expansions.

### What important points reviewers should know?

It adds:
- a new extrinsic called `force_join_candidates` which enables the monetary governance origin to add new a orbiter collator without a bond.
- a migration to set the bonds of the existing orbiter collators to `0`.

