### PR TITLE
Fix basic clippy warnings

### DIFF
--- a/client/evm-tracing/src/formatters/blockscout.rs
+++ b/client/evm-tracing/src/formatters/blockscout.rs
@@ -34,7 +34,7 @@ impl super::ResponseFormatter for Formatter {
 		if let Some(entry) = listener.entries.last() {
 			return Some(TransactionTrace::CallList(
 				entry
-					.into_iter()
+					.iter()
 					.map(|(_, value)| Call::Blockscout(value.clone()))
 					.collect(),
 			));

--- a/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/client/evm-tracing/src/formatters/call_tracer.rs
@@ -179,7 +179,7 @@ impl super::ResponseFormatter for Formatter {
 							}
 							return false;
 						};
-						if b_len > a_len || (a_len == b_len && sibling_greater_than(&a, &b)) {
+						if b_len > a_len || (a_len == b_len && sibling_greater_than(a, b)) {
 							Ordering::Less
 						} else {
 							Ordering::Greater

--- a/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/client/evm-tracing/src/formatters/call_tracer.rs
@@ -42,7 +42,7 @@ impl super::ResponseFormatter for Formatter {
 		let mut traces = Vec::new();
 		for entry in listener.entries.iter() {
 			let mut result: Vec<Call> = entry
-				.into_iter()
+				.iter()
 				.map(|(_, it)| {
 					let from = it.from;
 					let trace_address = it.trace_address.clone();

--- a/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/client/evm-tracing/src/formatters/call_tracer.rs
@@ -177,7 +177,7 @@ impl super::ResponseFormatter for Formatter {
 									continue;
 								}
 							}
-							return false;
+							false
 						};
 						if b_len > a_len || (a_len == b_len && sibling_greater_than(a, b)) {
 							Ordering::Less
@@ -245,7 +245,7 @@ impl super::ResponseFormatter for Formatter {
 		if traces.is_empty() {
 			return None;
 		}
-		return Some(traces);
+		Some(traces)
 	}
 }
 

--- a/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/client/evm-tracing/src/formatters/call_tracer.rs
@@ -51,9 +51,9 @@ impl super::ResponseFormatter for Formatter {
 					let gas_used = it.gas_used;
 					let inner = it.inner.clone();
 					Call::CallTracer(CallTracerCall {
-						from: from,
-						gas: gas,
-						gas_used: gas_used,
+						from,
+						gas,
+						gas_used,
 						trace_address: Some(trace_address.clone()),
 						inner: match inner.clone() {
 							BlockscoutCallInner::Call {
@@ -93,7 +93,7 @@ impl super::ResponseFormatter for Formatter {
 									} => Some(created_contract_code),
 									CreateResult::Error { .. } => None,
 								},
-								value: value,
+								value,
 								call_type: "CREATE".as_bytes().to_vec(),
 							},
 							BlockscoutCallInner::SelfDestruct { balance, to } => {

--- a/client/evm-tracing/src/formatters/trace_filter.rs
+++ b/client/evm-tracing/src/formatters/trace_filter.rs
@@ -37,7 +37,7 @@ impl super::ResponseFormatter for Formatter {
 		let mut traces = Vec::new();
 		for (eth_tx_index, entry) in listener.entries.iter().enumerate() {
 			let mut tx_traces: Vec<_> = entry
-				.into_iter()
+				.iter()
 				.map(|(_, trace)| match trace.inner.clone() {
 					CallInner::Call {
 						input,

--- a/client/evm-tracing/src/listeners/call_list.rs
+++ b/client/evm-tracing/src/listeners/call_list.rs
@@ -395,7 +395,7 @@ impl Listener {
 					// instead of `context.caller`, since the latter will not have the correct
 					// value inside a DelegateCall.
 					let from = if let Some(parent_context) = self.context_stack.last() {
-						parent_context.to.clone()
+						parent_context.to
 					} else {
 						context.caller
 					};

--- a/client/rpc-core/types/src/lib.rs
+++ b/client/rpc-core/types/src/lib.rs
@@ -40,7 +40,7 @@ where
 	let buf = String::deserialize(deserializer)?;
 
 	let parsed = match buf.strip_prefix("0x") {
-		Some(buf) => u32::from_str_radix(&buf, 16),
+		Some(buf) => u32::from_str_radix(buf, 16),
 		None => u32::from_str_radix(&buf, 10),
 	};
 

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -242,7 +242,7 @@ where
 					hex_literal::hex!("94d9f08796f91eb13a2e82a6066882f7");
 				const BLOCKSCOUT_JS_CODE_HASH_V2: [u8; 16] =
 					hex_literal::hex!("89db13694675692951673a1e6e18ff02");
-				let hash = sp_io::hashing::twox_128(&tracer.as_bytes());
+				let hash = sp_io::hashing::twox_128(tracer.as_bytes());
 				let tracer =
 					if hash == BLOCKSCOUT_JS_CODE_HASH || hash == BLOCKSCOUT_JS_CODE_HASH_V2 {
 						Some(TracerInput::Blockscout)
@@ -504,7 +504,7 @@ where
 
 					if trace_api_version >= 4 {
 						let _result = api
-							.trace_transaction(parent_block_hash, exts, &transaction)
+							.trace_transaction(parent_block_hash, exts, transaction)
 							.map_err(|e| {
 								internal_err(format!(
 									"Runtime api access error (version {:?}): {:?}",
@@ -518,7 +518,7 @@ where
 							ethereum::TransactionV2::Legacy(tx) =>
 							{
 								#[allow(deprecated)]
-								api.trace_transaction_before_version_4(parent_block_hash, exts, &tx)
+								api.trace_transaction_before_version_4(parent_block_hash, exts, tx)
 									.map_err(|e| {
 										internal_err(format!(
 											"Runtime api access error (legacy): {:?}",

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -254,10 +254,10 @@ where
 				if let Some(tracer) = tracer {
 					Ok((tracer, single::TraceType::CallList))
 				} else {
-					return Err(internal_err(format!(
+					Err(internal_err(format!(
 						"javascript based tracing is not available (hash :{:?})",
 						hash
-					)));
+					)))
 				}
 			}
 			Some(params) => Ok((
@@ -381,7 +381,7 @@ where
 			Ok(moonbeam_rpc_primitives_debug::Response::Block)
 		};
 
-		return match trace_type {
+		match trace_type {
 			single::TraceType::CallList => {
 				let mut proxy = moonbeam_client_evm_tracing::listeners::CallList::default();
 				proxy.using(f)?;
@@ -404,7 +404,7 @@ where
 				by providing `{{'tracer': 'callTracer'}}` in the request)."
 					.to_string(),
 			)),
-		};
+		}
 	}
 
 	/// Replays a transaction in the Runtime at a given block height.

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -709,7 +709,7 @@ where
 					tracing::trace!("Pooled block {} is no longer requested.", block);
 					// Remove block from the cache. Drops the value,
 					// closing all the channels contained in it.
-					let _ = self.cached_blocks.remove(&block);
+					let _ = self.cached_blocks.remove(block);
 				}
 			}
 		}

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -244,7 +244,7 @@ where
 		self.clone()
 			.filter(filter)
 			.await
-			.map_err(|e| fc_rpc::internal_err(e))
+			.map_err(fc_rpc::internal_err)
 	}
 }
 

--- a/client/rpc/txpool/src/lib.rs
+++ b/client/rpc/txpool/src/lib.rs
@@ -117,7 +117,7 @@ where
 				TransactionV2::EIP1559(t) => t.nonce,
 			};
 			let from_address = match public_key(txn) {
-				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
+				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(pk).as_slice())),
 				Err(_e) => H160::default(),
 			};
 			pending
@@ -134,7 +134,7 @@ where
 				TransactionV2::EIP1559(t) => t.nonce,
 			};
 			let from_address = match public_key(txn) {
-				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
+				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(pk).as_slice())),
 				Err(_e) => H160::default(),
 			};
 			queued

--- a/client/vrf/src/lib.rs
+++ b/client/vrf/src/lib.rs
@@ -44,7 +44,7 @@ where
 	let last_vrf_output = runtime_api.get_last_vrf_output(parent).ok()??;
 	// first ? for runtime API, second ? for not VRF key associated with NimbusId
 	let key: VrfId = runtime_api.vrf_key_lookup(parent, nimbus_id).ok()??;
-	let vrf_pre_digest = sign_vrf(last_vrf_output, key, &keystore)?;
+	let vrf_pre_digest = sign_vrf(last_vrf_output, key, keystore)?;
 	Some(session_keys_primitives::digest::CompatibleDigestItem::vrf_pre_digest(vrf_pre_digest))
 }
 

--- a/node/cli-opt/src/account_key.rs
+++ b/node/cli-opt/src/account_key.rs
@@ -98,7 +98,7 @@ impl PublicKeyT for Secp256k1PublicKey {
 	}
 
 	fn derive_child(&self, other: PrivateKeyBytes) -> Result<Self, Bip32Error> {
-		let mut child = self.0.clone();
+		let mut child = self.0;
 		let secret = SecretKey::parse(&other).map_err(|_| return Bip32Error::Decode)?;
 		let _ = child.tweak_add_assign(&secret);
 		Ok(Self(child))
@@ -118,7 +118,7 @@ impl PrivateKeyT for Secp256k1SecretKey {
 	}
 
 	fn derive_child(&self, other: PrivateKeyBytes) -> Result<Self, Bip32Error> {
-		let mut child = self.0.clone();
+		let mut child = self.0;
 		let secret = SecretKey::parse(&other).map_err(|_| return Bip32Error::Decode)?;
 		let _ = child.tweak_add_assign(&secret);
 		Ok(Self(child))

--- a/node/cli-opt/src/account_key.rs
+++ b/node/cli-opt/src/account_key.rs
@@ -89,7 +89,7 @@ pub struct Secp256k1SecretKey(pub SecretKey);
 
 impl PublicKeyT for Secp256k1PublicKey {
 	fn from_bytes(bytes: PublicKeyBytes) -> Result<Self, Bip32Error> {
-		let public = PublicKey::parse_compressed(&bytes).map_err(|_| return Bip32Error::Decode)?;
+		let public = PublicKey::parse_compressed(&bytes).map_err(|_| Bip32Error::Decode)?;
 		Ok(Self(public))
 	}
 
@@ -99,7 +99,7 @@ impl PublicKeyT for Secp256k1PublicKey {
 
 	fn derive_child(&self, other: PrivateKeyBytes) -> Result<Self, Bip32Error> {
 		let mut child = self.0;
-		let secret = SecretKey::parse(&other).map_err(|_| return Bip32Error::Decode)?;
+		let secret = SecretKey::parse(&other).map_err(|_| Bip32Error::Decode)?;
 		let _ = child.tweak_add_assign(&secret);
 		Ok(Self(child))
 	}
@@ -109,7 +109,7 @@ impl PrivateKeyT for Secp256k1SecretKey {
 	type PublicKey = Secp256k1PublicKey;
 
 	fn from_bytes(bytes: &PrivateKeyBytes) -> Result<Self, Bip32Error> {
-		let secret = SecretKey::parse(bytes).map_err(|_| return Bip32Error::Decode)?;
+		let secret = SecretKey::parse(bytes).map_err(|_| Bip32Error::Decode)?;
 		Ok(Self(secret))
 	}
 
@@ -119,7 +119,7 @@ impl PrivateKeyT for Secp256k1SecretKey {
 
 	fn derive_child(&self, other: PrivateKeyBytes) -> Result<Self, Bip32Error> {
 		let mut child = self.0;
-		let secret = SecretKey::parse(&other).map_err(|_| return Bip32Error::Decode)?;
+		let secret = SecretKey::parse(&other).map_err(|_| Bip32Error::Decode)?;
 		let _ = child.tweak_add_assign(&secret);
 		Ok(Self(child))
 	}

--- a/node/cli-opt/src/account_key.rs
+++ b/node/cli-opt/src/account_key.rs
@@ -109,7 +109,7 @@ impl PrivateKeyT for Secp256k1SecretKey {
 	type PublicKey = Secp256k1PublicKey;
 
 	fn from_bytes(bytes: &PrivateKeyBytes) -> Result<Self, Bip32Error> {
-		let secret = SecretKey::parse(&bytes).map_err(|_| return Bip32Error::Decode)?;
+		let secret = SecretKey::parse(bytes).map_err(|_| return Bip32Error::Decode)?;
 		Ok(Self(secret))
 	}
 

--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -80,7 +80,9 @@ pub enum FrontierBackendType {
 }
 
 /// Defines the frontier backend configuration.
+#[derive(Default)]
 pub enum FrontierBackendConfig {
+	#[default]
 	KeyValue,
 	Sql {
 		pool_size: u32,
@@ -88,12 +90,6 @@ pub enum FrontierBackendConfig {
 		thread_count: u32,
 		cache_size: u64,
 	},
-}
-
-impl Default for FrontierBackendConfig {
-	fn default() -> FrontierBackendConfig {
-		FrontierBackendConfig::KeyValue
-	}
 }
 
 pub struct RpcConfig {

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -697,7 +697,7 @@ pub fn run() -> Result<()> {
 
 				let extension = chain_spec::Extensions::try_get(&*config.chain_spec);
 				let para_id = extension.map(|e| e.para_id);
-				let id = ParaId::from(cli.run.parachain_id.clone().or(para_id).unwrap_or(1000));
+				let id = ParaId::from(cli.run.parachain_id.or(para_id).unwrap_or(1000));
 
 				let rpc_config = cli.run.new_rpc_config();
 

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -84,7 +84,7 @@ fn load_spec(
 
 			let starts_with = |prefix: &str| {
 				path.file_name()
-					.and_then(|f| f.to_str().map(|s| s.starts_with(&prefix)))
+					.and_then(|f| f.to_str().map(|s| s.starts_with(prefix)))
 					.unwrap_or(false)
 			};
 
@@ -688,7 +688,7 @@ pub fn run() -> Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				let hwbench = if !cli.run.no_hardware_benchmarks {
 					config.database.path().map(|database_path| {
-						let _ = std::fs::create_dir_all(&database_path);
+						let _ = std::fs::create_dir_all(database_path);
 						sc_sysinfo::gather_hwbench(Some(database_path))
 					})
 				} else {

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -139,11 +139,11 @@ impl Cli {
 	fn runtime_version(spec: &Box<dyn sc_service::ChainSpec>) -> &'static RuntimeVersion {
 		match spec {
 			#[cfg(feature = "moonriver-native")]
-			spec if spec.is_moonriver() => return &moonbeam_service::moonriver_runtime::VERSION,
+			spec if spec.is_moonriver() => &moonbeam_service::moonriver_runtime::VERSION,
 			#[cfg(feature = "moonbeam-native")]
-			spec if spec.is_moonbeam() => return &moonbeam_service::moonbeam_runtime::VERSION,
+			spec if spec.is_moonbeam() => &moonbeam_service::moonbeam_runtime::VERSION,
 			#[cfg(feature = "moonbase-native")]
-			_ => return &moonbeam_service::moonbase_runtime::VERSION,
+			_ => &moonbeam_service::moonbase_runtime::VERSION,
 			#[cfg(not(feature = "moonbase-native"))]
 			_ => panic!("invalid chain spec"),
 		}
@@ -482,29 +482,23 @@ pub fn run() -> Result<()> {
 						let chain_spec = &runner.config().chain_spec;
 						match chain_spec {
 							#[cfg(feature = "moonriver-native")]
-							spec if spec.is_moonriver() => {
-								return runner.sync_run(|config| {
-									cmd.run::<moonbeam_service::moonriver_runtime::Block, moonbeam_service::HostFunctions>(
+							spec if spec.is_moonriver() => runner.sync_run(|config| {
+								cmd.run::<moonbeam_service::moonriver_runtime::Block, moonbeam_service::HostFunctions>(
 										config,
 									)
-								})
-							}
+							}),
 							#[cfg(feature = "moonbeam-native")]
-							spec if spec.is_moonbeam() => {
-								return runner.sync_run(|config| {
-									cmd.run::<moonbeam_service::moonbeam_runtime::Block, moonbeam_service::HostFunctions>(
+							spec if spec.is_moonbeam() => runner.sync_run(|config| {
+								cmd.run::<moonbeam_service::moonbeam_runtime::Block, moonbeam_service::HostFunctions>(
 										config,
 									)
-								})
-							}
+							}),
 							#[cfg(feature = "moonbase-native")]
-							_ => {
-								return runner.sync_run(|config| {
-									cmd.run::<moonbeam_service::moonbase_runtime::Block, moonbeam_service::HostFunctions>(
+							_ => runner.sync_run(|config| {
+								cmd.run::<moonbeam_service::moonbase_runtime::Block, moonbeam_service::HostFunctions>(
 										config,
 									)
-								})
-							}
+							}),
 							#[cfg(not(feature = "moonbase-native"))]
 							_ => panic!("invalid chain spec"),
 						}
@@ -525,38 +519,32 @@ pub fn run() -> Result<()> {
 					let rpc_config = cli.run.new_rpc_config();
 					match chain_spec {
 						#[cfg(feature = "moonriver-native")]
-						spec if spec.is_moonriver() => {
-							return runner.sync_run(|mut config| {
-								let params = moonbeam_service::new_partial::<
-									moonbeam_service::moonriver_runtime::RuntimeApi,
-									moonbeam_service::MoonriverExecutor,
-								>(&mut config, &rpc_config, false)?;
+						spec if spec.is_moonriver() => runner.sync_run(|mut config| {
+							let params = moonbeam_service::new_partial::<
+								moonbeam_service::moonriver_runtime::RuntimeApi,
+								moonbeam_service::MoonriverExecutor,
+							>(&mut config, &rpc_config, false)?;
 
-								cmd.run(params.client)
-							})
-						}
+							cmd.run(params.client)
+						}),
 						#[cfg(feature = "moonbeam-native")]
-						spec if spec.is_moonbeam() => {
-							return runner.sync_run(|mut config| {
-								let params = moonbeam_service::new_partial::<
-									moonbeam_service::moonbeam_runtime::RuntimeApi,
-									moonbeam_service::MoonbeamExecutor,
-								>(&mut config, &rpc_config, false)?;
+						spec if spec.is_moonbeam() => runner.sync_run(|mut config| {
+							let params = moonbeam_service::new_partial::<
+								moonbeam_service::moonbeam_runtime::RuntimeApi,
+								moonbeam_service::MoonbeamExecutor,
+							>(&mut config, &rpc_config, false)?;
 
-								cmd.run(params.client)
-							})
-						}
+							cmd.run(params.client)
+						}),
 						#[cfg(feature = "moonbase-native")]
-						_ => {
-							return runner.sync_run(|mut config| {
-								let params = moonbeam_service::new_partial::<
-									moonbeam_service::moonbase_runtime::RuntimeApi,
-									moonbeam_service::MoonbaseExecutor,
-								>(&mut config, &rpc_config, false)?;
+						_ => runner.sync_run(|mut config| {
+							let params = moonbeam_service::new_partial::<
+								moonbeam_service::moonbase_runtime::RuntimeApi,
+								moonbeam_service::MoonbaseExecutor,
+							>(&mut config, &rpc_config, false)?;
 
-								cmd.run(params.client)
-							})
-						}
+							cmd.run(params.client)
+						}),
 						#[cfg(not(feature = "moonbase-native"))]
 						_ => panic!("invalid chain spec"),
 					}
@@ -572,61 +560,53 @@ pub fn run() -> Result<()> {
 					let rpc_config = cli.run.new_rpc_config();
 					match chain_spec {
 						#[cfg(feature = "moonriver-native")]
-						spec if spec.is_moonriver() => {
-							return runner.sync_run(|mut config| {
-								let params = moonbeam_service::new_partial::<
-									moonbeam_service::moonriver_runtime::RuntimeApi,
-									moonbeam_service::MoonriverExecutor,
-								>(&mut config, &rpc_config, false)?;
+						spec if spec.is_moonriver() => runner.sync_run(|mut config| {
+							let params = moonbeam_service::new_partial::<
+								moonbeam_service::moonriver_runtime::RuntimeApi,
+								moonbeam_service::MoonriverExecutor,
+							>(&mut config, &rpc_config, false)?;
 
-								let db = params.backend.expose_db();
-								let storage = params.backend.expose_storage();
+							let db = params.backend.expose_db();
+							let storage = params.backend.expose_storage();
 
-								cmd.run(config, params.client, db, storage)
-							})
-						}
+							cmd.run(config, params.client, db, storage)
+						}),
 						#[cfg(feature = "moonbeam-native")]
-						spec if spec.is_moonbeam() => {
-							return runner.sync_run(|mut config| {
-								let params = moonbeam_service::new_partial::<
-									moonbeam_service::moonbeam_runtime::RuntimeApi,
-									moonbeam_service::MoonbeamExecutor,
-								>(&mut config, &rpc_config, false)?;
+						spec if spec.is_moonbeam() => runner.sync_run(|mut config| {
+							let params = moonbeam_service::new_partial::<
+								moonbeam_service::moonbeam_runtime::RuntimeApi,
+								moonbeam_service::MoonbeamExecutor,
+							>(&mut config, &rpc_config, false)?;
 
-								let db = params.backend.expose_db();
-								let storage = params.backend.expose_storage();
+							let db = params.backend.expose_db();
+							let storage = params.backend.expose_storage();
 
-								cmd.run(config, params.client, db, storage)
-							})
-						}
+							cmd.run(config, params.client, db, storage)
+						}),
 						#[cfg(feature = "moonbase-native")]
-						_ => {
-							return runner.sync_run(|mut config| {
-								let params = moonbeam_service::new_partial::<
-									moonbeam_service::moonbase_runtime::RuntimeApi,
-									moonbeam_service::MoonbaseExecutor,
-								>(&mut config, &rpc_config, false)?;
+						_ => runner.sync_run(|mut config| {
+							let params = moonbeam_service::new_partial::<
+								moonbeam_service::moonbase_runtime::RuntimeApi,
+								moonbeam_service::MoonbaseExecutor,
+							>(&mut config, &rpc_config, false)?;
 
-								let db = params.backend.expose_db();
-								let storage = params.backend.expose_storage();
+							let db = params.backend.expose_db();
+							let storage = params.backend.expose_storage();
 
-								cmd.run(config, params.client, db, storage)
-							})
-						}
+							cmd.run(config, params.client, db, storage)
+						}),
 						#[cfg(not(feature = "moonbase-native"))]
 						_ => panic!("invalid chain spec"),
 					}
 				}
 				BenchmarkCmd::Overhead(_) => Err("Unsupported benchmarking command".into()),
 				BenchmarkCmd::Extrinsic(_) => Err("Unsupported benchmarking command".into()),
-				BenchmarkCmd::Machine(cmd) => {
-					return runner.sync_run(|config| {
-						cmd.run(
-							&config,
-							frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE.clone(),
-						)
-					});
-				}
+				BenchmarkCmd::Machine(cmd) => runner.sync_run(|config| {
+					cmd.run(
+						&config,
+						frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE.clone(),
+					)
+				}),
 			}
 		}
 		Some(Subcommand::TryRuntime) => Err("The `try-runtime` subcommand has been migrated to a \

--- a/node/service/src/chain_spec/mod.rs
+++ b/node/service/src/chain_spec/mod.rs
@@ -123,7 +123,7 @@ pub fn get_account_id_from_pair(pair: ecdsa::Pair) -> Option<AccountId> {
 	let mut m = [0u8; 64];
 	m.copy_from_slice(&decompressed[1..65]);
 
-	Some(H160::from(H256::from_slice(Keccak256::digest(&m).as_slice())).into())
+	Some(H160::from(H256::from_slice(Keccak256::digest(m).as_slice())).into())
 }
 
 /// Function to generate accounts given a mnemonic and a number of child accounts to be generated

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1541,7 +1541,7 @@ mod tests {
 			.first()
 			.unwrap()
 			.get_label()
-			.into_iter()
+			.iter()
 			.find(|x| x.get_name() == "chain")
 			.cloned();
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -348,8 +348,8 @@ where
 						.to_str()
 						.expect("frontier sql path error"),
 					create_if_missing: true,
-					thread_count: thread_count,
-					cache_size: cache_size,
+					thread_count,
+					cache_size,
 				}),
 				pool_size,
 				std::num::NonZeroU32::new(num_ops_timeout),

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -262,7 +262,7 @@ where
 		};
 		let parachain_inherent_data = ParachainInherentData {
 			validation_data: vfp,
-			relay_chain_state: relay_chain_state,
+			relay_chain_state,
 			downward_messages: Default::default(),
 			horizontal_messages: Default::default(),
 		};

--- a/pallets/asset-manager/src/benchmarks.rs
+++ b/pallets/asset-manager/src/benchmarks.rs
@@ -167,7 +167,7 @@ benchmarks! {
 			caller.clone(),
 			owner.clone(),
 			true,
-			min_balance.clone()
+			min_balance
 	)
 	verify {
 		assert_eq!(Pallet::<T>::local_asset_counter(), current_local_counter+1);

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -145,7 +145,7 @@ pub mod pallet {
 		#[cfg(feature = "runtime-benchmarks")]
 		fn set_asset_type_asset_id(asset_type: T::ForeignAssetType, asset_id: T::AssetId) {
 			AssetTypeId::<T>::insert(&asset_type, asset_id);
-			AssetIdType::<T>::insert(&asset_id, asset_type);
+			AssetIdType::<T>::insert(asset_id, asset_type);
 		}
 	}
 
@@ -167,7 +167,7 @@ pub mod pallet {
 				supported_assets.insert(index, asset_type.clone());
 				SupportedFeePaymentAssets::<T>::put(supported_assets);
 			}
-			AssetTypeUnitsPerSecond::<T>::insert(&asset_type, &fee_per_second);
+			AssetTypeUnitsPerSecond::<T>::insert(&asset_type, fee_per_second);
 		}
 	}
 
@@ -333,7 +333,7 @@ pub mod pallet {
 
 			// Ensure such an assetId does not exist
 			ensure!(
-				AssetIdType::<T>::get(&asset_id).is_none(),
+				AssetIdType::<T>::get(asset_id).is_none(),
 				Error::<T>::AssetAlreadyExists
 			);
 			T::AssetRegistrar::create_foreign_asset(
@@ -345,8 +345,8 @@ pub mod pallet {
 			.map_err(|_| Error::<T>::ErrorCreatingAsset)?;
 
 			// Insert the association assetId->assetType
-			AssetIdType::<T>::insert(&asset_id, &asset);
-			AssetTypeId::<T>::insert(&asset, &asset_id);
+			AssetIdType::<T>::insert(asset_id, &asset);
+			AssetTypeId::<T>::insert(&asset, asset_id);
 
 			Self::deposit_event(Event::ForeignAssetRegistered {
 				asset_id,
@@ -388,7 +388,7 @@ pub mod pallet {
 				SupportedFeePaymentAssets::<T>::put(supported_assets);
 			}
 
-			AssetTypeUnitsPerSecond::<T>::insert(&asset_type, &units_per_second);
+			AssetTypeUnitsPerSecond::<T>::insert(&asset_type, units_per_second);
 
 			Self::deposit_event(Event::UnitsPerSecondChanged {
 				asset_type,
@@ -419,11 +419,11 @@ pub mod pallet {
 			);
 
 			let previous_asset_type =
-				AssetIdType::<T>::get(&asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
+				AssetIdType::<T>::get(asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
 
 			// Insert new asset type info
-			AssetIdType::<T>::insert(&asset_id, &new_asset_type);
-			AssetTypeId::<T>::insert(&new_asset_type, &asset_id);
+			AssetIdType::<T>::insert(asset_id, &new_asset_type);
+			AssetTypeId::<T>::insert(&new_asset_type, asset_id);
 
 			// Remove previous asset type info
 			AssetTypeId::<T>::remove(&previous_asset_type);
@@ -506,10 +506,10 @@ pub mod pallet {
 			);
 
 			let asset_type =
-				AssetIdType::<T>::get(&asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
+				AssetIdType::<T>::get(asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
 
 			// Remove from AssetIdType
-			AssetIdType::<T>::remove(&asset_id);
+			AssetIdType::<T>::remove(asset_id);
 			// Remove from AssetTypeId
 			AssetTypeId::<T>::remove(&asset_type);
 			// Remove previous asset type units per second
@@ -629,10 +629,10 @@ pub mod pallet {
 			);
 
 			let asset_type =
-				AssetIdType::<T>::get(&asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
+				AssetIdType::<T>::get(asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
 
 			// Remove from AssetIdType
-			AssetIdType::<T>::remove(&asset_id);
+			AssetIdType::<T>::remove(asset_id);
 			// Remove from AssetTypeId
 			AssetTypeId::<T>::remove(&asset_type);
 			// Remove previous asset type units per second

--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -208,15 +208,10 @@ impl Config for Test {
 	type WeightInfo = ();
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -26,7 +26,7 @@ fn registering_foreign_works() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true
 		));
@@ -86,7 +86,7 @@ fn test_asset_exists_error() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true
 		));
@@ -99,7 +99,7 @@ fn test_asset_exists_error() {
 			AssetManager::register_foreign_asset(
 				RuntimeOrigin::root(),
 				MockAssetType::MockAsset(1),
-				0u32.into(),
+				0u32,
 				1u32.into(),
 				true
 			),
@@ -114,7 +114,7 @@ fn test_root_can_change_units_per_second() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true
 		));
@@ -122,7 +122,7 @@ fn test_root_can_change_units_per_second() {
 		assert_ok!(AssetManager::set_asset_units_per_second(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			200u128.into(),
+			200u128,
 			0
 		));
 
@@ -153,7 +153,7 @@ fn test_regular_user_cannot_call_extrinsics() {
 			AssetManager::register_foreign_asset(
 				RuntimeOrigin::signed(1),
 				MockAssetType::MockAsset(1),
-				0u32.into(),
+				0u32,
 				1u32.into(),
 				true
 			),
@@ -164,7 +164,7 @@ fn test_regular_user_cannot_call_extrinsics() {
 			AssetManager::set_asset_units_per_second(
 				RuntimeOrigin::signed(1),
 				MockAssetType::MockAsset(1),
-				200u128.into(),
+				200u128,
 				0
 			),
 			sp_runtime::DispatchError::BadOrigin
@@ -188,7 +188,7 @@ fn test_root_can_change_asset_id_type() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true
 		));
@@ -196,7 +196,7 @@ fn test_root_can_change_asset_id_type() {
 		assert_ok!(AssetManager::set_asset_units_per_second(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			200u128.into(),
+			200u128,
 			0
 		));
 
@@ -253,7 +253,7 @@ fn test_change_units_per_second_after_setting_it_once() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true,
 		));
@@ -261,7 +261,7 @@ fn test_change_units_per_second_after_setting_it_once() {
 		assert_ok!(AssetManager::set_asset_units_per_second(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			200u128.into(),
+			200u128,
 			0
 		));
 
@@ -274,7 +274,7 @@ fn test_change_units_per_second_after_setting_it_once() {
 		assert_ok!(AssetManager::set_asset_units_per_second(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			100u128.into(),
+			100u128,
 			1
 		));
 
@@ -308,7 +308,7 @@ fn test_root_can_change_units_per_second_and_then_remove() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true,
 		));
@@ -316,7 +316,7 @@ fn test_root_can_change_units_per_second_and_then_remove() {
 		assert_ok!(AssetManager::set_asset_units_per_second(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			200u128.into(),
+			200u128,
 			0
 		));
 
@@ -359,7 +359,7 @@ fn test_weight_hint_error() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true,
 		));
@@ -367,7 +367,7 @@ fn test_weight_hint_error() {
 		assert_ok!(AssetManager::set_asset_units_per_second(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			200u128.into(),
+			200u128,
 			0
 		));
 
@@ -389,7 +389,7 @@ fn test_asset_id_non_existent_error() {
 			AssetManager::set_asset_units_per_second(
 				RuntimeOrigin::root(),
 				MockAssetType::MockAsset(1),
-				200u128.into(),
+				200u128,
 				0
 			),
 			Error::<Test>::AssetDoesNotExist
@@ -412,7 +412,7 @@ fn test_root_can_remove_asset_association() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true
 		));
@@ -420,7 +420,7 @@ fn test_root_can_remove_asset_association() {
 		assert_ok!(AssetManager::set_asset_units_per_second(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			200u128.into(),
+			200u128,
 			0
 		));
 
@@ -461,7 +461,7 @@ fn test_removing_without_asset_units_per_second_does_not_panic() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true
 		));
@@ -499,7 +499,7 @@ fn test_destroy_foreign_asset_also_removes_everything() {
 		assert_ok!(AssetManager::register_foreign_asset(
 			RuntimeOrigin::root(),
 			MockAssetType::MockAsset(1),
-			0u32.into(),
+			0u32,
 			1u32.into(),
 			true
 		));

--- a/pallets/erc20-xcm-bridge/src/lib.rs
+++ b/pallets/erc20-xcm-bridge/src/lib.rs
@@ -83,7 +83,7 @@ pub mod pallet {
 					// to throw a compile error as a warning that data type has changed.
 					// If that happens, a new check is needed to ensure that data has at least 18
 					// bytes (size of b"gas_limit:" + u64)
-					let data: &[u8; 32] = &data;
+					let data: &[u8; 32] = data;
 					if let Ok(content) = core::str::from_utf8(&data[0..10]) {
 						if content == "gas_limit:" {
 							let mut bytes: [u8; 8] = Default::default();
@@ -129,7 +129,7 @@ pub mod pallet {
 				false,
 				Some(weight_limit),
 				Some(0),
-				&<T as pallet_evm::Config>::config(),
+				<T as pallet_evm::Config>::config(),
 			)
 			.map_err(|_| Erc20TransferError::EvmCallFail)?;
 

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -417,7 +417,7 @@ pub mod pallet {
 
 			// Remove all AccountLookupOverride entries related to this collator
 			for orbiter in collator_pool.get_orbiters() {
-				AccountLookupOverride::<T>::remove(&orbiter);
+				AccountLookupOverride::<T>::remove(orbiter);
 			}
 			AccountLookupOverride::<T>::remove(&collator);
 

--- a/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
@@ -64,7 +64,7 @@ where
 {
 	fn withdraw_asset(assets: &MultiAssets) -> XCMWeight {
 		assets.inner().iter().fold(Weight::zero(), |acc, asset| {
-			acc.saturating_add(XcmFungibleWeight::<Runtime>::withdraw_asset(&asset))
+			acc.saturating_add(XcmFungibleWeight::<Runtime>::withdraw_asset(asset))
 		})
 	}
 	// Currently there is no trusted reserve
@@ -84,7 +84,7 @@ where
 	}
 	fn transfer_asset(assets: &MultiAssets, _dest: &MultiLocation) -> XCMWeight {
 		assets.inner().iter().fold(Weight::zero(), |acc, asset| {
-			acc.saturating_add(XcmFungibleWeight::<Runtime>::transfer_asset(&asset))
+			acc.saturating_add(XcmFungibleWeight::<Runtime>::transfer_asset(asset))
 		})
 	}
 	fn transfer_reserve_asset(
@@ -93,7 +93,7 @@ where
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
 		assets.inner().iter().fold(Weight::zero(), |acc, asset| {
-			acc.saturating_add(XcmFungibleWeight::<Runtime>::transfer_reserve_asset(&asset))
+			acc.saturating_add(XcmFungibleWeight::<Runtime>::transfer_reserve_asset(asset))
 		})
 	}
 	fn transact(

--- a/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
@@ -40,9 +40,7 @@ trait WeighMultiAssetsFilter {
 impl WeighMultiAssetsFilter for MultiAssetFilter {
 	fn weigh_multi_assets_filter(&self, weight: Weight) -> XCMWeight {
 		match self {
-			Self::Definite(assets) => {
-				weight.saturating_mul(assets.inner().into_iter().count() as u64)
-			}
+			Self::Definite(assets) => weight.saturating_mul(assets.inner().iter().count() as u64),
 			Self::Wild(AllCounted(count) | AllOfCounted { count, .. }) => {
 				weight.saturating_mul(min(MAX_ASSETS, *count) as u64)
 			}
@@ -53,7 +51,7 @@ impl WeighMultiAssetsFilter for MultiAssetFilter {
 
 impl WeighMultiAssets for MultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
-		weight.saturating_mul(self.inner().into_iter().count() as u64)
+		weight.saturating_mul(self.inner().iter().count() as u64)
 	}
 }
 

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -238,7 +238,7 @@ where
 		// set auto-compound config if the percent is non-zero
 		if !auto_compound.is_zero() {
 			let mut auto_compounding_state = Self::get_storage(&candidate);
-			auto_compounding_state.set_for_delegator(delegator.clone(), auto_compound.clone())?;
+			auto_compounding_state.set_for_delegator(delegator.clone(), auto_compound)?;
 			auto_compounding_state.set_storage(&candidate);
 		}
 

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -246,10 +246,10 @@ where
 		<CandidateInfo<T>>::insert(&candidate, candidate_state);
 		<DelegatorState<T>>::insert(&delegator, delegator_state);
 		<Pallet<T>>::deposit_event(Event::Delegation {
-			delegator: delegator,
+			delegator,
 			locked_amount: amount,
-			candidate: candidate,
-			delegator_position: delegator_position,
+			candidate,
+			delegator_position,
 			auto_compound,
 		});
 

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -316,7 +316,7 @@ where
 		let delegations_config = Self::get_storage(candidate);
 		delegations_config
 			.get_for_delegator(delegator)
-			.unwrap_or_else(|| Percent::zero())
+			.unwrap_or_else(Percent::zero)
 	}
 }
 

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -79,7 +79,7 @@ where
 	/// Retrieves the auto-compounding value for a delegation. The `delegations_config` must be a
 	/// sorted vector for binary_search to work.
 	pub fn get_for_delegator(&self, delegator: &T::AccountId) -> Option<Percent> {
-		match self.0.binary_search_by(|d| d.delegator.cmp(&delegator)) {
+		match self.0.binary_search_by(|d| d.delegator.cmp(delegator)) {
 			Ok(index) => Some(self.0[index].value),
 			Err(_) => None,
 		}
@@ -114,7 +114,7 @@ where
 	/// Returns `true` if the entry was removed, `false` otherwise. The `delegations_config` must be a
 	/// sorted vector for binary_search to work.
 	pub fn remove_for_delegator(&mut self, delegator: &T::AccountId) -> bool {
-		match self.0.binary_search_by(|d| d.delegator.cmp(&delegator)) {
+		match self.0.binary_search_by(|d| d.delegator.cmp(delegator)) {
 			Ok(index) => {
 				self.0.remove(index);
 				true
@@ -307,7 +307,7 @@ where
 	pub(crate) fn remove_auto_compound(candidate: &T::AccountId, delegator: &T::AccountId) {
 		let mut auto_compounding_state = Self::get_storage(candidate);
 		if auto_compounding_state.remove_for_delegator(delegator) {
-			auto_compounding_state.set_storage(&candidate);
+			auto_compounding_state.set_storage(candidate);
 		}
 	}
 
@@ -315,7 +315,7 @@ where
 	pub(crate) fn auto_compound(candidate: &T::AccountId, delegator: &T::AccountId) -> Percent {
 		let delegations_config = Self::get_storage(candidate);
 		delegations_config
-			.get_for_delegator(&delegator)
+			.get_for_delegator(delegator)
 			.unwrap_or_else(|| Percent::zero())
 	}
 }

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -1684,7 +1684,7 @@ benchmarks! {
 		let total_staked =  min_candidate_stk::<T>()
 			+ (Into::<BalanceOf<T>>::into(x) * initial_delegator_balance);
 		let round_for_payout = 5;
-		<DelayedPayouts<T>>::insert(&round_for_payout, DelayedPayout {
+		<DelayedPayouts<T>>::insert(round_for_payout, DelayedPayout {
 			round_issuance: 1000u32.into(),
 			total_staking_reward: total_staked,
 			collator_commission: Perbill::from_rational(1u32, 100u32),
@@ -1722,7 +1722,7 @@ benchmarks! {
 		} in &delegations
 		{
 			assert!(
-				T::Currency::free_balance(&owner) > initial_delegator_balance,
+				T::Currency::free_balance(owner) > initial_delegator_balance,
 				"delegator should have been paid in pay_one_collator_reward"
 			);
 		}
@@ -1773,7 +1773,7 @@ benchmarks! {
 		// directly and then call pay_one_collator_reward directly.
 
 		let round_for_payout = 5;
-		<DelayedPayouts<T>>::insert(&round_for_payout, DelayedPayout {
+		<DelayedPayouts<T>>::insert(round_for_payout, DelayedPayout {
 			// NOTE: round_issuance is not correct here, but it doesn't seem to cause problems
 			round_issuance: 1000u32.into(),
 			total_staking_reward: total_staked,
@@ -1815,7 +1815,7 @@ benchmarks! {
 		// nominators should have been paid
 		for delegator in &delegators {
 			assert!(
-				T::Currency::free_balance(&delegator) > initial_stake_amount,
+				T::Currency::free_balance(delegator) > initial_stake_amount,
 				"delegator should have been paid in pay_one_collator_reward"
 			);
 		}

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -1538,7 +1538,7 @@ benchmarks! {
 			ideal: Perbill::one(),
 			max: Perbill::one(),
 		};
-		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation.clone())?;
+		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation)?;
 		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 101u32)?;
 		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 100u32)?;
 
@@ -1584,7 +1584,7 @@ benchmarks! {
 			ideal: Perbill::one(),
 			max: Perbill::one(),
 		};
-		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation.clone())?;
+		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation)?;
 		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 101u32)?;
 		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 100u32)?;
 
@@ -1708,7 +1708,7 @@ benchmarks! {
 		{
 			<Pallet<T>>::mint_and_compound(
 				100u32.into(),
-				auto_compound.clone(),
+				*auto_compound,
 				prime_candidate.clone(),
 				owner.clone(),
 			);

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -1497,7 +1497,7 @@ benchmarks! {
 		assert!(
 			!Pallet::<T>::delegation_scheduled_requests(&collator)
 				.iter()
-				.any(|x| &x.delegator == &delegator)
+				.any(|x| x.delegator == delegator)
 		);
 	}
 

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -758,7 +758,7 @@ benchmarks! {
 		} else {
 			0u32.into()
 		};
-		let (caller, _) = create_funded_user::<T>("caller", USER_SEED, extra.into());
+		let (caller, _) = create_funded_user::<T>("caller", USER_SEED, extra);
 		// Delegation count
 		let mut del_del_count = 0u32;
 		// Nominate MaxDelegationsPerDelegators collator candidates
@@ -2187,7 +2187,7 @@ benchmarks! {
 		)?;
 		let original_free_balance = T::Currency::free_balance(&collator);
 	}: {
-		Pallet::<T>::mint_collator_reward(1u32.into(), collator.clone(), 50u32.into())
+		Pallet::<T>::mint_collator_reward(1u32, collator.clone(), 50u32.into())
 	}
 	verify {
 		assert_eq!(T::Currency::free_balance(&collator), original_free_balance + 50u32.into());

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -157,7 +157,7 @@ impl<T: Config> Pallet<T> {
 				error: <Error<T>>::DelegatorBondBelowMin.into(),
 			},
 		);
-		let new_amount: BalanceOf<T> = (bonded_amount - decrease_amount).into();
+		let new_amount: BalanceOf<T> = bonded_amount - decrease_amount;
 		ensure!(
 			new_amount >= T::MinDelegation::get(),
 			DispatchErrorWithPostInfo {
@@ -169,7 +169,7 @@ impl<T: Config> Pallet<T> {
 		// Net Total is total after pending orders are executed
 		let net_total = state.total().saturating_sub(state.less_total);
 		// Net Total is always >= MinDelegation
-		let max_subtracted_amount = net_total.saturating_sub(T::MinDelegation::get().into());
+		let max_subtracted_amount = net_total.saturating_sub(T::MinDelegation::get());
 		ensure!(
 			decrease_amount <= max_subtracted_amount,
 			DispatchErrorWithPostInfo {
@@ -277,7 +277,7 @@ impl<T: Config> Pallet<T> {
 					true
 				} else {
 					ensure!(
-						state.total().saturating_sub(T::MinDelegation::get().into()) >= amount,
+						state.total().saturating_sub(T::MinDelegation::get()) >= amount,
 						DispatchErrorWithPostInfo {
 							post_info: Some(actual_weight).into(),
 							error: <Error<T>>::DelegatorBondBelowMin.into(),
@@ -331,7 +331,7 @@ impl<T: Config> Pallet<T> {
 				for bond in &mut state.delegations.0 {
 					if bond.owner == collator {
 						return if bond.amount > amount {
-							let amount_before: BalanceOf<T> = bond.amount.into();
+							let amount_before: BalanceOf<T> = bond.amount;
 							bond.amount = bond.amount.saturating_sub(amount);
 							let mut collator_info = <CandidateInfo<T>>::get(&collator)
 								.ok_or(<Error<T>>::CandidateDNE)
@@ -342,7 +342,7 @@ impl<T: Config> Pallet<T> {
 
 							state
 								.total_sub_if::<T, _>(amount, |total| {
-									let new_total: BalanceOf<T> = total.into();
+									let new_total: BalanceOf<T> = total;
 									ensure!(
 										new_total >= T::MinDelegation::get(),
 										<Error<T>>::DelegationBelowMin

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -230,9 +230,9 @@ mod tests {
 		};
 		mock_round_issuance_range(u32::MAX.into(), mock_annual_to_round(schedule, u32::MAX));
 		mock_round_issuance_range(u64::MAX.into(), mock_annual_to_round(schedule, u32::MAX));
-		mock_round_issuance_range(u128::MAX.into(), mock_annual_to_round(schedule, u32::MAX));
+		mock_round_issuance_range(u128::MAX, mock_annual_to_round(schedule, u32::MAX));
 		mock_round_issuance_range(u32::MAX.into(), mock_annual_to_round(schedule, 1));
 		mock_round_issuance_range(u64::MAX.into(), mock_annual_to_round(schedule, 1));
-		mock_round_issuance_range(u128::MAX.into(), mock_annual_to_round(schedule, 1));
+		mock_round_issuance_range(u128::MAX, mock_annual_to_round(schedule, 1));
 	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2206,9 +2206,7 @@ pub mod pallet {
 			candidate: T::AccountId,
 			delegator: T::AccountId,
 		) {
-			if let Ok(amount_transferred) =
-				T::Currency::deposit_into_existing(&delegator, amt)
-			{
+			if let Ok(amount_transferred) = T::Currency::deposit_into_existing(&delegator, amt) {
 				Self::deposit_event(Event::Rewarded {
 					account: delegator.clone(),
 					rewards: amount_transferred.peek(),

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1389,7 +1389,7 @@ pub mod pallet {
 				<DelegationScheduledRequests<T>>::remove(candidate);
 			}
 
-			Ok(().into())
+			Ok(())
 		}
 
 		/// Notify a collator is inactive during MaxOfflineRounds
@@ -1462,7 +1462,7 @@ pub mod pallet {
 				return Err(<Error<T>>::CannotBeNotifiedAsInactive.into());
 			}
 
-			Ok(().into())
+			Ok(())
 		}
 
 		/// Enable/Disable marking offline feature

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1376,11 +1376,11 @@ pub mod pallet {
 			ensure!(candidates.len() < 100, <Error<T>>::InsufficientBalance);
 			for candidate in &candidates {
 				ensure!(
-					<CandidateInfo<T>>::get(&candidate).is_none(),
+					<CandidateInfo<T>>::get(candidate).is_none(),
 					<Error<T>>::CandidateNotLeaving
 				);
 				ensure!(
-					<DelegationScheduledRequests<T>>::get(&candidate).is_empty(),
+					<DelegationScheduledRequests<T>>::get(candidate).is_empty(),
 					<Error<T>>::CandidateNotLeaving
 				);
 			}
@@ -2056,10 +2056,10 @@ pub mod pallet {
 				let CountedDelegations {
 					uncounted_stake,
 					rewardable_delegations,
-				} = Self::get_rewardable_delegators(&account);
+				} = Self::get_rewardable_delegators(account);
 				let total_counted = state.total_counted.saturating_sub(uncounted_stake);
 
-				let auto_compounding_delegations = <AutoCompoundingDelegations<T>>::get(&account)
+				let auto_compounding_delegations = <AutoCompoundingDelegations<T>>::get(account)
 					.into_iter()
 					.map(|x| (x.delegator, x.value))
 					.collect::<BTreeMap<_, _>>();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1289,7 +1289,7 @@ pub mod pallet {
 			let (in_top, weight) = Self::delegation_bond_more_without_event(
 				delegator.clone(),
 				candidate.clone(),
-				more.clone(),
+				more,
 			)?;
 			Pallet::<T>::deposit_event(Event::DelegationIncreased {
 				delegator,
@@ -1936,7 +1936,7 @@ pub mod pallet {
 							num_paid_delegations += 1u32;
 							Self::mint_and_compound(
 								due,
-								auto_compound.clone(),
+								auto_compound,
 								collator.clone(),
 								owner.clone(),
 							);
@@ -2207,7 +2207,7 @@ pub mod pallet {
 			delegator: T::AccountId,
 		) {
 			if let Ok(amount_transferred) =
-				T::Currency::deposit_into_existing(&delegator, amt.clone())
+				T::Currency::deposit_into_existing(&delegator, amt)
 			{
 				Self::deposit_event(Event::Rewarded {
 					account: delegator.clone(),
@@ -2222,7 +2222,7 @@ pub mod pallet {
 				if let Err(err) = Self::delegation_bond_more_without_event(
 					delegator.clone(),
 					candidate.clone(),
-					compound_amount.clone(),
+					compound_amount,
 				) {
 					log::debug!(
 						"skipped compounding staking reward towards candidate '{:?}' for delegator '{:?}': {:?}",
@@ -2236,7 +2236,7 @@ pub mod pallet {
 				Pallet::<T>::deposit_event(Event::Compounded {
 					delegator,
 					candidate,
-					amount: compound_amount.clone(),
+					amount: compound_amount,
 				});
 			};
 		}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -970,8 +970,8 @@ pub mod pallet {
 			Self::deposit_event(Event::BlocksPerRoundSet {
 				current_round: now,
 				first_block: first,
-				old: old,
-				new: new,
+				old,
+				new,
 				new_per_round_inflation_min: inflation_config.round.min,
 				new_per_round_inflation_ideal: inflation_config.round.ideal,
 				new_per_round_inflation_max: inflation_config.round.max,
@@ -1762,8 +1762,8 @@ pub mod pallet {
 			let new_total = state.total_counted;
 			<CandidateInfo<T>>::insert(&candidate, state);
 			Self::deposit_event(Event::DelegatorLeftCandidate {
-				delegator: delegator,
-				candidate: candidate,
+				delegator,
+				candidate,
 				unstaked_amount: amount,
 				total_candidate_staked: new_total,
 			});

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2071,7 +2071,7 @@ pub mod pallet {
 						auto_compound: auto_compounding_delegations
 							.get(&d.owner)
 							.cloned()
-							.unwrap_or_else(|| Percent::zero()),
+							.unwrap_or_else(Percent::zero),
 					})
 					.collect();
 

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -523,7 +523,7 @@ pub(crate) fn set_block_author(acc: u64) {
 
 /// fn to query the lock amount
 pub(crate) fn query_lock_amount(account_id: u64, id: LockIdentifier) -> Option<Balance> {
-	for lock in Balances::locks(&account_id) {
+	for lock in Balances::locks(account_id) {
 		if lock.id == id {
 			return Some(lock.amount);
 		}

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1414,7 +1414,7 @@ fn execute_leave_candidates_removes_pending_delegation_requests() {
 				1,
 				5
 			));
-			let state = ParachainStaking::delegation_scheduled_requests(&1);
+			let state = ParachainStaking::delegation_scheduled_requests(1);
 			assert_eq!(
 				state,
 				vec![ScheduledRequest {
@@ -1439,13 +1439,13 @@ fn execute_leave_candidates_removes_pending_delegation_requests() {
 			));
 			assert!(ParachainStaking::candidate_info(1).is_none());
 			assert!(
-				!ParachainStaking::delegation_scheduled_requests(&1)
+				!ParachainStaking::delegation_scheduled_requests(1)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation request not removed"
 			);
 			assert!(
-				!<DelegationScheduledRequests<Test>>::contains_key(&1),
+				!<DelegationScheduledRequests<Test>>::contains_key(1),
 				"the key was not removed from storage"
 			);
 		});
@@ -1519,7 +1519,7 @@ fn cancel_leave_candidates_updates_candidate_state() {
 				1
 			));
 			let candidate =
-				ParachainStaking::candidate_info(&1).expect("just cancelled leave so exists");
+				ParachainStaking::candidate_info(1).expect("just cancelled leave so exists");
 			assert!(candidate.is_active());
 		});
 }
@@ -2051,7 +2051,7 @@ fn cancel_candidate_bond_less_updates_candidate_state() {
 			assert_ok!(ParachainStaking::cancel_candidate_bond_less(
 				RuntimeOrigin::signed(1)
 			));
-			assert!(ParachainStaking::candidate_info(&1)
+			assert!(ParachainStaking::candidate_info(1)
 				.unwrap()
 				.request
 				.is_none());
@@ -2841,7 +2841,7 @@ fn delegator_bond_less_updates_delegator_state() {
 				1,
 				5
 			));
-			let state = ParachainStaking::delegation_scheduled_requests(&1);
+			let state = ParachainStaking::delegation_scheduled_requests(1);
 			assert_eq!(
 				state,
 				vec![ScheduledRequest {
@@ -3077,14 +3077,14 @@ fn execute_revoke_delegation_adds_revocation_to_delegator_state() {
 		.with_delegations(vec![(2, 1, 10), (2, 3, 10)])
 		.build()
 		.execute_with(|| {
-			assert!(!ParachainStaking::delegation_scheduled_requests(&1)
+			assert!(!ParachainStaking::delegation_scheduled_requests(1)
 				.iter()
 				.any(|x| x.delegator == 2));
 			assert_ok!(ParachainStaking::schedule_revoke_delegation(
 				RuntimeOrigin::signed(2),
 				1
 			));
-			assert!(ParachainStaking::delegation_scheduled_requests(&1)
+			assert!(ParachainStaking::delegation_scheduled_requests(1)
 				.iter()
 				.any(|x| x.delegator == 2));
 		});
@@ -3108,7 +3108,7 @@ fn execute_revoke_delegation_removes_revocation_from_delegator_state_upon_execut
 				2,
 				1
 			));
-			assert!(!ParachainStaking::delegation_scheduled_requests(&1)
+			assert!(!ParachainStaking::delegation_scheduled_requests(1)
 				.iter()
 				.any(|x| x.delegator == 2));
 		});
@@ -3133,7 +3133,7 @@ fn execute_revoke_delegation_removes_revocation_from_state_for_single_delegation
 				1
 			));
 			assert!(
-				!ParachainStaking::delegation_scheduled_requests(&1)
+				!ParachainStaking::delegation_scheduled_requests(1)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation was not removed"
@@ -3270,8 +3270,8 @@ fn can_execute_leave_candidates_if_revoking_candidate() {
 				1
 			));
 			assert!(!ParachainStaking::is_delegator(&2));
-			assert_eq!(Balances::reserved_balance(&2), 0);
-			assert_eq!(Balances::free_balance(&2), 10);
+			assert_eq!(Balances::reserved_balance(2), 0);
+			assert_eq!(Balances::free_balance(2), 10);
 		});
 }
 
@@ -3534,11 +3534,11 @@ fn execute_delegator_bond_less_updates_just_bottom_delegations() {
 		.build()
 		.execute_with(|| {
 			let pre_call_candidate_info =
-				ParachainStaking::candidate_info(&1).expect("delegated by all so exists");
+				ParachainStaking::candidate_info(1).expect("delegated by all so exists");
 			let pre_call_top_delegations =
-				ParachainStaking::top_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::top_delegations(1).expect("delegated by all so exists");
 			let pre_call_bottom_delegations =
-				ParachainStaking::bottom_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::bottom_delegations(1).expect("delegated by all so exists");
 			assert_ok!(ParachainStaking::schedule_delegator_bond_less(
 				RuntimeOrigin::signed(2),
 				1,
@@ -3551,11 +3551,11 @@ fn execute_delegator_bond_less_updates_just_bottom_delegations() {
 				1
 			));
 			let post_call_candidate_info =
-				ParachainStaking::candidate_info(&1).expect("delegated by all so exists");
+				ParachainStaking::candidate_info(1).expect("delegated by all so exists");
 			let post_call_top_delegations =
-				ParachainStaking::top_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::top_delegations(1).expect("delegated by all so exists");
 			let post_call_bottom_delegations =
-				ParachainStaking::bottom_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::bottom_delegations(1).expect("delegated by all so exists");
 			let mut not_equal = false;
 			for Bond { owner, amount } in pre_call_bottom_delegations.delegations {
 				for Bond {
@@ -3610,11 +3610,11 @@ fn execute_delegator_bond_less_does_not_delete_bottom_delegations() {
 		.build()
 		.execute_with(|| {
 			let pre_call_candidate_info =
-				ParachainStaking::candidate_info(&1).expect("delegated by all so exists");
+				ParachainStaking::candidate_info(1).expect("delegated by all so exists");
 			let pre_call_top_delegations =
-				ParachainStaking::top_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::top_delegations(1).expect("delegated by all so exists");
 			let pre_call_bottom_delegations =
-				ParachainStaking::bottom_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::bottom_delegations(1).expect("delegated by all so exists");
 			assert_ok!(ParachainStaking::schedule_delegator_bond_less(
 				RuntimeOrigin::signed(6),
 				1,
@@ -3627,11 +3627,11 @@ fn execute_delegator_bond_less_does_not_delete_bottom_delegations() {
 				1
 			));
 			let post_call_candidate_info =
-				ParachainStaking::candidate_info(&1).expect("delegated by all so exists");
+				ParachainStaking::candidate_info(1).expect("delegated by all so exists");
 			let post_call_top_delegations =
-				ParachainStaking::top_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::top_delegations(1).expect("delegated by all so exists");
 			let post_call_bottom_delegations =
-				ParachainStaking::bottom_delegations(&1).expect("delegated by all so exists");
+				ParachainStaking::bottom_delegations(1).expect("delegated by all so exists");
 			let mut equal = true;
 			for Bond { owner, amount } in pre_call_bottom_delegations.delegations {
 				for Bond {
@@ -3740,7 +3740,7 @@ fn cancel_revoke_delegation_updates_delegator_state() {
 				RuntimeOrigin::signed(2),
 				1
 			));
-			let state = ParachainStaking::delegation_scheduled_requests(&1);
+			let state = ParachainStaking::delegation_scheduled_requests(1);
 			assert_eq!(
 				state,
 				vec![ScheduledRequest {
@@ -3750,7 +3750,7 @@ fn cancel_revoke_delegation_updates_delegator_state() {
 				}],
 			);
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				10
@@ -3759,11 +3759,11 @@ fn cancel_revoke_delegation_updates_delegator_state() {
 				RuntimeOrigin::signed(2),
 				1
 			));
-			assert!(!ParachainStaking::delegation_scheduled_requests(&1)
+			assert!(!ParachainStaking::delegation_scheduled_requests(1)
 				.iter()
 				.any(|x| x.delegator == 2));
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				0
@@ -3814,7 +3814,7 @@ fn cancel_delegator_bond_less_updates_delegator_state() {
 				1,
 				5
 			));
-			let state = ParachainStaking::delegation_scheduled_requests(&1);
+			let state = ParachainStaking::delegation_scheduled_requests(1);
 			assert_eq!(
 				state,
 				vec![ScheduledRequest {
@@ -3824,7 +3824,7 @@ fn cancel_delegator_bond_less_updates_delegator_state() {
 				}],
 			);
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				5
@@ -3833,11 +3833,11 @@ fn cancel_delegator_bond_less_updates_delegator_state() {
 				RuntimeOrigin::signed(2),
 				1
 			));
-			assert!(!ParachainStaking::delegation_scheduled_requests(&1)
+			assert!(!ParachainStaking::delegation_scheduled_requests(1)
 				.iter()
 				.any(|x| x.delegator == 2));
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				0
@@ -3860,7 +3860,7 @@ fn delegator_schedule_revocation_total() {
 				1
 			));
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				10
@@ -3872,7 +3872,7 @@ fn delegator_schedule_revocation_total() {
 				1
 			));
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				0
@@ -3893,7 +3893,7 @@ fn delegator_schedule_revocation_total() {
 				4
 			));
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				20,
@@ -3905,7 +3905,7 @@ fn delegator_schedule_revocation_total() {
 				3
 			));
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				10,
@@ -3916,7 +3916,7 @@ fn delegator_schedule_revocation_total() {
 				4
 			));
 			assert_eq!(
-				ParachainStaking::delegator_state(&2)
+				ParachainStaking::delegator_state(2)
 					.map(|x| x.less_total)
 					.expect("delegator state must exist"),
 				0
@@ -3951,7 +3951,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 		])
 		.build()
 		.execute_with(|| {
-			assert_eq!(Balances::free_balance(&11), 1);
+			assert_eq!(Balances::free_balance(11), 1);
 			// set parachain bond account so DefaultParachainBondReservePercent = 30% of inflation
 			// is allocated to this account hereafter
 			assert_ok!(ParachainStaking::set_parachain_bond_account(
@@ -3994,12 +3994,12 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					total_balance: 140,
 				},
 			);
-			assert_eq!(Balances::free_balance(&11), 1);
+			assert_eq!(Balances::free_balance(11), 1);
 			// ~ set block author as 1 for all blocks this round
 			set_author(2, 1, 100);
 			roll_to_round_begin(4);
 			// distribute total issuance to collator 1 and its delegators 6, 7, 19
-			assert_eq!(Balances::free_balance(&11), 16);
+			assert_eq!(Balances::free_balance(11), 16);
 			// ~ set block author as 1 for all blocks this round
 			set_author(3, 1, 100);
 			set_author(4, 1, 100);
@@ -4257,7 +4257,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					rewards: 7,
 				},
 			);
-			assert_eq!(Balances::free_balance(&11), 65);
+			assert_eq!(Balances::free_balance(11), 65);
 			roll_blocks(1);
 			assert_ok!(ParachainStaking::set_parachain_bond_reserve_percent(
 				RuntimeOrigin::root(),
@@ -4323,7 +4323,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					rewards: 5,
 				},
 			);
-			assert_eq!(Balances::free_balance(&11), 95);
+			assert_eq!(Balances::free_balance(11), 95);
 			set_author(7, 1, 100);
 			roll_to_round_begin(9);
 			// no more paying 6
@@ -4379,7 +4379,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					rewards: 5,
 				},
 			);
-			assert_eq!(Balances::free_balance(&11), 127);
+			assert_eq!(Balances::free_balance(11), 127);
 			set_author(8, 1, 100);
 			roll_blocks(1);
 			assert_ok!(ParachainStaking::delegate(
@@ -4450,7 +4450,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					rewards: 5,
 				},
 			);
-			assert_eq!(Balances::free_balance(&11), 160);
+			assert_eq!(Balances::free_balance(11), 160);
 			set_author(9, 1, 100);
 			set_author(10, 1, 100);
 			roll_to_round_begin(11);
@@ -4507,7 +4507,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					rewards: 5,
 				},
 			);
-			assert_eq!(Balances::free_balance(&11), 195);
+			assert_eq!(Balances::free_balance(11), 195);
 			roll_to_round_begin(12);
 			// new delegation is rewarded, 2 rounds after joining (`RewardPaymentDelay` is 2)
 			assert_events_eq!(
@@ -4566,7 +4566,7 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					rewards: 4,
 				},
 			);
-			assert_eq!(Balances::free_balance(&11), 232);
+			assert_eq!(Balances::free_balance(11), 232);
 		});
 }
 
@@ -4731,7 +4731,7 @@ fn collator_exit_executes_after_delay() {
 				candidate: 2,
 				scheduled_exit: 5,
 			});
-			let info = ParachainStaking::candidate_info(&2).unwrap();
+			let info = ParachainStaking::candidate_info(2).unwrap();
 			assert_eq!(info.status, CollatorStatus::Leaving(5));
 			roll_to(21);
 			assert_ok!(ParachainStaking::execute_leave_candidates(
@@ -5259,8 +5259,8 @@ fn multiple_delegations() {
 					.len(),
 				4usize
 			);
-			assert_eq!(Balances::locks(&6)[0].amount, 40);
-			assert_eq!(Balances::locks(&7)[0].amount, 90);
+			assert_eq!(Balances::locks(6)[0].amount, 40);
+			assert_eq!(Balances::locks(7)[0].amount, 90);
 			assert_eq!(
 				ParachainStaking::get_delegator_stakable_free_balance(&6),
 				60
@@ -5321,7 +5321,7 @@ fn execute_leave_candidate_removes_delegations() {
 		.build()
 		.execute_with(|| {
 			// Verifies the revocation request is initially empty
-			assert!(!ParachainStaking::delegation_scheduled_requests(&2)
+			assert!(!ParachainStaking::delegation_scheduled_requests(2)
 				.iter()
 				.any(|x| x.delegator == 3));
 
@@ -5334,7 +5334,7 @@ fn execute_leave_candidate_removes_delegations() {
 				2
 			));
 			// Verifies the revocation request is present
-			assert!(ParachainStaking::delegation_scheduled_requests(&2)
+			assert!(ParachainStaking::delegation_scheduled_requests(2)
 				.iter()
 				.any(|x| x.delegator == 3));
 
@@ -5345,7 +5345,7 @@ fn execute_leave_candidate_removes_delegations() {
 				2
 			));
 			// Verifies the revocation request is again empty
-			assert!(!ParachainStaking::delegation_scheduled_requests(&2)
+			assert!(!ParachainStaking::delegation_scheduled_requests(2)
 				.iter()
 				.any(|x| x.delegator == 3));
 		});
@@ -6844,7 +6844,7 @@ fn delegation_kicked_from_bottom_removes_pending_request() {
 				unstaked_amount: 19,
 			});
 			// ensure request DNE
-			assert!(!ParachainStaking::delegation_scheduled_requests(&1)
+			assert!(!ParachainStaking::delegation_scheduled_requests(1)
 				.iter()
 				.any(|x| x.delegator == 2));
 		});
@@ -7711,7 +7711,7 @@ fn test_set_auto_compound_inserts_if_not_exists() {
 					delegator: 2,
 					value: Percent::from_percent(50),
 				}],
-				ParachainStaking::auto_compounding_delegations(&1).into_inner(),
+				ParachainStaking::auto_compounding_delegations(1).into_inner(),
 			);
 		});
 }
@@ -7751,7 +7751,7 @@ fn test_set_auto_compound_updates_if_existing() {
 					delegator: 2,
 					value: Percent::from_percent(50),
 				}],
-				ParachainStaking::auto_compounding_delegations(&1).into_inner(),
+				ParachainStaking::auto_compounding_delegations(1).into_inner(),
 			);
 		});
 }
@@ -7786,7 +7786,7 @@ fn test_set_auto_compound_removes_if_auto_compound_zero_percent() {
 				delegator: 2,
 				value: Percent::zero(),
 			});
-			assert_eq!(0, ParachainStaking::auto_compounding_delegations(&1).len(),);
+			assert_eq!(0, ParachainStaking::auto_compounding_delegations(1).len(),);
 		});
 }
 
@@ -7823,13 +7823,13 @@ fn test_execute_revoke_delegation_removes_auto_compounding_from_state_for_delega
 				1
 			));
 			assert!(
-				!ParachainStaking::auto_compounding_delegations(&1)
+				!ParachainStaking::auto_compounding_delegations(1)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation auto-compound config was not removed"
 			);
 			assert!(
-				ParachainStaking::auto_compounding_delegations(&3)
+				ParachainStaking::auto_compounding_delegations(3)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation auto-compound config was erroneously removed"
@@ -7881,13 +7881,13 @@ fn test_execute_leave_delegators_removes_auto_compounding_state() {
 			));
 
 			assert!(
-				!ParachainStaking::auto_compounding_delegations(&1)
+				!ParachainStaking::auto_compounding_delegations(1)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation auto-compound config was not removed"
 			);
 			assert!(
-				!ParachainStaking::auto_compounding_delegations(&3)
+				!ParachainStaking::auto_compounding_delegations(3)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation auto-compound config was not removed"
@@ -7930,13 +7930,13 @@ fn test_execute_leave_candidates_removes_auto_compounding_state() {
 			));
 
 			assert!(
-				!ParachainStaking::auto_compounding_delegations(&1)
+				!ParachainStaking::auto_compounding_delegations(1)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation auto-compound config was not removed"
 			);
 			assert!(
-				ParachainStaking::auto_compounding_delegations(&3)
+				ParachainStaking::auto_compounding_delegations(3)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation auto-compound config was erroneously removed"
@@ -7992,7 +7992,7 @@ fn test_delegation_kicked_from_bottom_delegation_removes_auto_compounding_state(
 			));
 
 			assert!(
-				!ParachainStaking::auto_compounding_delegations(&1)
+				!ParachainStaking::auto_compounding_delegations(1)
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation auto-compound config was not removed"
@@ -8266,7 +8266,7 @@ fn test_delegate_with_auto_compound_sets_auto_compound_config() {
 					delegator: 2,
 					value: Percent::from_percent(50),
 				}],
-				ParachainStaking::auto_compounding_delegations(&1).into_inner(),
+				ParachainStaking::auto_compounding_delegations(1).into_inner(),
 			);
 		});
 }
@@ -8287,7 +8287,7 @@ fn test_delegate_with_auto_compound_skips_storage_but_emits_event_for_zero_auto_
 				0,
 				0,
 			));
-			assert_eq!(0, ParachainStaking::auto_compounding_delegations(&1).len(),);
+			assert_eq!(0, ParachainStaking::auto_compounding_delegations(1).len(),);
 			assert_events_eq!(Event::Delegation {
 				delegator: 2,
 				locked_amount: 10,
@@ -8631,7 +8631,7 @@ fn test_delegate_skips_auto_compound_storage_but_emits_event_for_zero_auto_compo
 				1,
 				0,
 			));
-			assert_eq!(1, ParachainStaking::auto_compounding_delegations(&1).len(),);
+			assert_eq!(1, ParachainStaking::auto_compounding_delegations(1).len(),);
 			assert_events_eq!(Event::Delegation {
 				delegator: 2,
 				locked_amount: 10,

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -654,7 +654,7 @@ impl<
 			// only increment delegation count if we are not kicking a bottom delegation
 			self.delegation_count = self.delegation_count.saturating_add(1u32);
 		}
-		<TopDelegations<T>>::insert(&candidate, top_delegations);
+		<TopDelegations<T>>::insert(candidate, top_delegations);
 		less_total_staked
 	}
 	/// Add delegation to bottom delegations
@@ -694,12 +694,12 @@ impl<
 			let leaving = delegator_state.delegations.0.len() == 1usize;
 			delegator_state.rm_delegation::<T>(candidate);
 			<Pallet<T>>::delegation_remove_request_with_state(
-				&candidate,
+				candidate,
 				&lowest_bottom_to_be_kicked.owner,
 				&mut delegator_state,
 			);
 			<AutoCompoundDelegations<T>>::remove_auto_compound(
-				&candidate,
+				candidate,
 				&lowest_bottom_to_be_kicked.owner,
 			);
 

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -511,7 +511,7 @@ impl<
 		);
 		self.total_counted = self.total_counted.saturating_sub(request.amount);
 		let event = Event::CandidateBondedLess {
-			candidate: who.clone().into(),
+			candidate: who.clone(),
 			amount: request.amount.into(),
 			new_bond: self.bond.into(),
 		};
@@ -519,7 +519,7 @@ impl<
 		self.request = None;
 		// update candidate pool value because it must change if self bond changes
 		if self.is_active() {
-			Pallet::<T>::update_active(who.into(), self.total_counted.into());
+			Pallet::<T>::update_active(who, self.total_counted.into());
 		}
 		Pallet::<T>::deposit_event(event);
 		Ok(())
@@ -533,7 +533,7 @@ impl<
 			.request
 			.ok_or(Error::<T>::PendingCandidateRequestsDNE)?;
 		let event = Event::CancelledCandidateBondLess {
-			candidate: who.clone().into(),
+			candidate: who.clone(),
 			amount: request.amount.into(),
 			execute_round: request.when_executable,
 		};

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -82,21 +82,16 @@ impl<AccountId: Ord, Balance> PartialEq for Bond<AccountId, Balance> {
 	}
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
 /// The activity status of the collator
 pub enum CollatorStatus {
 	/// Committed to be online and producing valid blocks (not equivocating)
+	#[default]
 	Active,
 	/// Temporarily inactive and excused for inactivity
 	Idle,
 	/// Bonded until the inner round
 	Leaving(RoundIndex),
-}
-
-impl Default for CollatorStatus {
-	fn default() -> CollatorStatus {
-		CollatorStatus::Active
-	}
 }
 
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]

--- a/pallets/proxy-genesis-companion/src/mock.rs
+++ b/pallets/proxy-genesis-companion/src/mock.rs
@@ -158,18 +158,10 @@ impl Config for Test {
 }
 
 /// Externality builder for pallet maintenance mode's mock runtime
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	proxies: Vec<(AccountId, AccountId)>,
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder {
-			proxies: Vec::new(),
-			balances: Vec::new(),
-		}
-	}
 }
 
 impl ExtBuilder {

--- a/pallets/xcm-transactor/src/benchmarks.rs
+++ b/pallets/xcm-transactor/src/benchmarks.rs
@@ -51,7 +51,7 @@ benchmarks! {
 		let location = MultiLocation::parent();
 	}: _(
 		RawOrigin::Root,
-		Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+		Box::new(xcm::VersionedMultiLocation::V3(location)),
 		extra_weight,
 		max_weight,
 		None
@@ -70,12 +70,12 @@ benchmarks! {
 		let location = MultiLocation::parent();
 		Pallet::<T>::set_transact_info(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			extra_weight,
 			max_weight,
 			None
 		).expect("must succeed");
-	}: _(RawOrigin::Root, Box::new(xcm::VersionedMultiLocation::V3(location.clone())))
+	}: _(RawOrigin::Root, Box::new(xcm::VersionedMultiLocation::V3(location)))
 	verify {
 		assert!(Pallet::<T>::transact_info(&location).is_none());
 	}
@@ -85,7 +85,7 @@ benchmarks! {
 		let location = MultiLocation::parent();
 	}: _(
 		RawOrigin::Root,
-		Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+		Box::new(xcm::VersionedMultiLocation::V3(location)),
 		fee_per_second
 	)
 	verify {
@@ -101,18 +101,18 @@ benchmarks! {
 		let location = MultiLocation::parent();
 		let call = vec![1u8];
 		let dest_weight: Weight = Weight::from_parts(100u64, 0);
-		let currency: T::CurrencyId = location.clone().into();
+		let currency: T::CurrencyId = location.into();
 		let user: T::AccountId  = account("account id", 0u32, 0u32);
 		Pallet::<T>::set_transact_info(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			extra_weight,
 			max_weight,
 			Some(extra_weight)
 		).expect("must succeed");
 		Pallet::<T>::set_fee_per_second(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			fee_per_second
 		).expect("must succeed");
 		Pallet::<T>::register(
@@ -156,27 +156,27 @@ benchmarks! {
 		let extra_weight: Weight = Weight::from_parts(300000000u64, 0);
 		let max_weight: Weight = Weight::from_parts(20000000000u64, u64::MAX);
 		let location = MultiLocation::parent();
-		let currency: T::CurrencyId = location.clone().into();
+		let currency: T::CurrencyId = location.into();
 		let call = vec![1u8];
 		let dest_weight: Weight = Weight::from_parts(100u64, 0);
 		let user: T::AccountId  = account("account id", 0u32, 0u32);
 		Pallet::<T>::set_transact_info(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			extra_weight,
 			max_weight,
 			Some(extra_weight)
 		).expect("must succeed");
 		Pallet::<T>::set_fee_per_second(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			fee_per_second
 		).expect("must succeed");
 	}: {
 
 		let result = Pallet::<T>::transact_through_sovereign(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			user.clone(),
 			CurrencyPayment {
 				// This might involve a db Read when translating, therefore worst case
@@ -209,25 +209,25 @@ benchmarks! {
 		let extra_weight: Weight = Weight::from_parts(300000000u64, 0);
 		let max_weight: Weight = Weight::from_parts(20000000000u64, u64::MAX);
 		let location = MultiLocation::parent();
-		let currency: T::CurrencyId = location.clone().into();
+		let currency: T::CurrencyId = location.into();
 		let call = vec![1u8];
 		let dest_weight: Weight = Weight::from_parts(100u64, 0);
 		let user: T::AccountId  = account("account id", 0u32, 0u32);
 		Pallet::<T>::set_transact_info(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			extra_weight,
 			max_weight,
 			Some(extra_weight)
 		).expect("must succeed");
 		Pallet::<T>::set_fee_per_second(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			fee_per_second
 		).expect("must succeed");
 	}: _(
 		RawOrigin::Signed(user.clone()),
-		Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+		Box::new(xcm::VersionedMultiLocation::V3(location)),
 		CurrencyPayment {
 			// This might involve a db Read when translating, therefore worst case
 			currency: Currency::AsCurrencyId(currency),
@@ -248,20 +248,20 @@ benchmarks! {
 		let extra_weight: Weight = Weight::from_parts(300000000u64, 0);
 		let max_weight: Weight = Weight::from_parts(20000000000u64, u64::MAX);
 		let location = MultiLocation::parent();
-		let currency: T::CurrencyId = location.clone().into();
+		let currency: T::CurrencyId = location.into();
 		let call = vec![1u8];
 		let dest_weight: Weight = Weight::from_parts(100u64, 0);
 		let user: T::AccountId  = account("account id", 0u32, 0u32);
 		Pallet::<T>::set_transact_info(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			extra_weight,
 			max_weight,
 			Some(extra_weight)
 		).expect("must succeed");
 		Pallet::<T>::set_fee_per_second(
 			RawOrigin::Root.into(),
-			Box::new(xcm::VersionedMultiLocation::V3(location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(location)),
 			fee_per_second
 		).expect("must succeed");
 	}: _(

--- a/pallets/xcm-transactor/src/benchmarks.rs
+++ b/pallets/xcm-transactor/src/benchmarks.rs
@@ -58,8 +58,8 @@ benchmarks! {
 	)
 	verify {
 		assert_eq!(Pallet::<T>::transact_info(location), Some(crate::RemoteTransactInfoWithMaxWeight {
-			transact_extra_weight: extra_weight.into(),
-			max_weight: max_weight.into(),
+			transact_extra_weight: extra_weight,
+			max_weight: max_weight,
 			transact_extra_weight_signed: None
 		}));
 	}

--- a/pallets/xcm-transactor/src/benchmarks.rs
+++ b/pallets/xcm-transactor/src/benchmarks.rs
@@ -57,7 +57,7 @@ benchmarks! {
 		None
 	)
 	verify {
-		assert_eq!(Pallet::<T>::transact_info(&location), Some(crate::RemoteTransactInfoWithMaxWeight {
+		assert_eq!(Pallet::<T>::transact_info(location), Some(crate::RemoteTransactInfoWithMaxWeight {
 			transact_extra_weight: extra_weight.into(),
 			max_weight: max_weight.into(),
 			transact_extra_weight_signed: None
@@ -77,7 +77,7 @@ benchmarks! {
 		).expect("must succeed");
 	}: _(RawOrigin::Root, Box::new(xcm::VersionedMultiLocation::V3(location)))
 	verify {
-		assert!(Pallet::<T>::transact_info(&location).is_none());
+		assert!(Pallet::<T>::transact_info(location).is_none());
 	}
 
 	set_fee_per_second {
@@ -89,7 +89,7 @@ benchmarks! {
 		fee_per_second
 	)
 	verify {
-		assert_eq!(Pallet::<T>::dest_asset_fee_per_second(&location), Some(fee_per_second));
+		assert_eq!(Pallet::<T>::dest_asset_fee_per_second(location), Some(fee_per_second));
 	}
 
 	// Worst Case: AsCurrencyId, as the translation could involve db reads

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -416,11 +416,11 @@ pub mod pallet {
 			T::DerivativeAddressRegistrationOrigin::ensure_origin(origin)?;
 
 			ensure!(
-				IndexToAccount::<T>::get(&index).is_none(),
+				IndexToAccount::<T>::get(index).is_none(),
 				Error::<T>::IndexAlreadyClaimed
 			);
 
-			IndexToAccount::<T>::insert(&index, who.clone());
+			IndexToAccount::<T>::insert(index, who.clone());
 
 			// Deposit event
 			Self::deposit_event(Event::<T>::RegisteredDerivative {
@@ -439,7 +439,7 @@ pub mod pallet {
 			T::DerivativeAddressRegistrationOrigin::ensure_origin(origin)?;
 
 			// Remove index
-			IndexToAccount::<T>::remove(&index);
+			IndexToAccount::<T>::remove(index);
 
 			// Deposit event
 			Self::deposit_event(Event::<T>::DeRegisteredDerivative { index });
@@ -640,7 +640,7 @@ pub mod pallet {
 				transact_extra_weight_signed,
 			};
 
-			TransactInfoWithWeightLimit::<T>::insert(&location, &remote_info);
+			TransactInfoWithWeightLimit::<T>::insert(location, &remote_info);
 
 			Self::deposit_event(Event::TransactInfoChanged {
 				location,
@@ -661,7 +661,7 @@ pub mod pallet {
 				MultiLocation::try_from(*location).map_err(|()| Error::<T>::BadVersion)?;
 
 			// Remove transact info
-			TransactInfoWithWeightLimit::<T>::remove(&location);
+			TransactInfoWithWeightLimit::<T>::remove(location);
 
 			Self::deposit_event(Event::TransactInfoRemoved { location });
 			Ok(())
@@ -755,7 +755,7 @@ pub mod pallet {
 			let asset_location =
 				MultiLocation::try_from(*asset_location).map_err(|()| Error::<T>::BadVersion)?;
 
-			DestinationAssetFeePerSecond::<T>::insert(&asset_location, &fee_per_second);
+			DestinationAssetFeePerSecond::<T>::insert(asset_location, fee_per_second);
 
 			Self::deposit_event(Event::DestFeePerSecondChanged {
 				location: asset_location,
@@ -775,7 +775,7 @@ pub mod pallet {
 			let asset_location =
 				MultiLocation::try_from(*asset_location).map_err(|()| Error::<T>::BadVersion)?;
 
-			DestinationAssetFeePerSecond::<T>::remove(&asset_location);
+			DestinationAssetFeePerSecond::<T>::remove(asset_location);
 
 			Self::deposit_event(Event::DestFeePerSecondRemoved {
 				location: asset_location,
@@ -1146,7 +1146,7 @@ pub mod pallet {
 			// so we have to ensure 'refund' is false
 			ensure!(!refund, Error::<T>::RefundNotSupportedWithTransactInfo);
 			// Grab transact info for the destination provided
-			let transactor_info = TransactInfoWithWeightLimit::<T>::get(&dest)
+			let transactor_info = TransactInfoWithWeightLimit::<T>::get(dest)
 				.ok_or(Error::<T>::TransactorInfoNotSet)?;
 
 			let total_weight = dest_weight
@@ -1171,7 +1171,7 @@ pub mod pallet {
 			// so we have to ensure 'refund' is false
 			ensure!(!refund, Error::<T>::RefundNotSupportedWithTransactInfo);
 			// Grab transact info for the destination provided
-			let transactor_info = TransactInfoWithWeightLimit::<T>::get(&dest)
+			let transactor_info = TransactInfoWithWeightLimit::<T>::get(dest)
 				.ok_or(Error::<T>::TransactorInfoNotSet)?;
 
 			// If this storage item is not set, it means that the destination chain
@@ -1198,7 +1198,7 @@ pub mod pallet {
 			destination: MultiLocation,
 			total_weight: Weight,
 		) -> Result<u128, DispatchError> {
-			let fee_per_second = DestinationAssetFeePerSecond::<T>::get(&fee_location)
+			let fee_per_second = DestinationAssetFeePerSecond::<T>::get(fee_location)
 				.ok_or(Error::<T>::FeePerSecondNotSet)?;
 
 			// Ensure the asset is a reserve

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -888,7 +888,7 @@ pub mod pallet {
 
 				// Construct the local withdraw message with the previous calculated amount
 				// This message deducts and burns "amount" from the caller when executed
-				T::AssetTransactor::withdraw_asset(&fee.clone().into(), &origin_as_mult, None)
+				T::AssetTransactor::withdraw_asset(&fee.clone(), &origin_as_mult, None)
 					.map_err(|_| Error::<T>::UnableToWithdrawAsset)?;
 			}
 

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -506,12 +506,7 @@ pub mod pallet {
 			)?;
 
 			// Calculate fee based on FeePerSecond
-			let fee = Self::calculate_fee(
-				fee_location,
-				fee.fee_amount,
-				dest,
-				total_weight,
-			)?;
+			let fee = Self::calculate_fee(fee_location, fee.fee_amount, dest, total_weight)?;
 
 			// If refund is true, the appendix instruction will be a deposit back to the sovereign
 			let appendix = refund
@@ -592,12 +587,7 @@ pub mod pallet {
 			)?;
 
 			// Calculate fee based on FeePerSecond and total_weight
-			let fee = Self::calculate_fee(
-				fee_location,
-				fee.fee_amount,
-				dest,
-				total_weight,
-			)?;
+			let fee = Self::calculate_fee(fee_location, fee.fee_amount, dest, total_weight)?;
 
 			// If refund is true, the appendix instruction will be a deposit back to the sovereign
 			let appendix = refund
@@ -718,12 +708,7 @@ pub mod pallet {
 			)?;
 
 			// Fee to be paid
-			let fee = Self::calculate_fee(
-				fee_location,
-				fee.fee_amount,
-				dest,
-				total_weight,
-			)?;
+			let fee = Self::calculate_fee(fee_location, fee.fee_amount, dest, total_weight)?;
 
 			// If refund is true, the appendix instruction will be a deposit back to the sender
 			let appendix = refund
@@ -858,12 +843,7 @@ pub mod pallet {
 				|v| Ok(v),
 			)?;
 
-			let fee = Self::calculate_fee(
-				fee_location,
-				fee.fee_amount,
-				destination,
-				total_weight,
-			)?;
+			let fee = Self::calculate_fee(fee_location, fee.fee_amount, destination, total_weight)?;
 
 			ensure!(
 				T::MaxHrmpFee::filter_max_asset_fee(&fee),
@@ -995,13 +975,7 @@ pub mod pallet {
 			// Else, multiply weight*destination_units_per_second to see how much we should charge for
 			// this weight execution
 			let amount: u128 = fee_amount.map_or_else(
-				|| {
-					Self::take_fee_per_second_from_storage(
-						fee_location,
-						destination,
-						total_weight,
-					)
-				},
+				|| Self::take_fee_per_second_from_storage(fee_location, destination, total_weight),
 				|v| Ok(v),
 			)?;
 

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -425,7 +425,7 @@ pub mod pallet {
 			// Deposit event
 			Self::deposit_event(Event::<T>::RegisteredDerivative {
 				account_id: who,
-				index: index,
+				index,
 			});
 
 			Ok(())
@@ -532,9 +532,9 @@ pub mod pallet {
 			// Deposit event
 			Self::deposit_event(Event::<T>::TransactedDerivative {
 				account_id: who,
-				dest: dest,
+				dest,
 				call: call_bytes,
-				index: index,
+				index,
 			});
 
 			Ok(())
@@ -1004,7 +1004,7 @@ pub mod pallet {
 				instructions.push(Self::appendix_instruction(appendix)?);
 			}
 			instructions.push(Transact {
-				origin_kind: origin_kind,
+				origin_kind,
 				require_weight_at_most: dispatch_weight,
 				call: call.into(),
 			});

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -502,7 +502,7 @@ pub mod pallet {
 						refund,
 					)
 				},
-				|v| Ok(v),
+				Ok,
 			)?;
 
 			// Calculate fee based on FeePerSecond
@@ -583,7 +583,7 @@ pub mod pallet {
 						refund,
 					)
 				},
-				|v| Ok(v),
+				Ok,
 			)?;
 
 			// Calculate fee based on FeePerSecond and total_weight
@@ -704,7 +704,7 @@ pub mod pallet {
 						refund,
 					)
 				},
-				|v| Ok(v),
+				Ok,
 			)?;
 
 			// Fee to be paid
@@ -840,7 +840,7 @@ pub mod pallet {
 						false,
 					)
 				},
-				|v| Ok(v),
+				Ok,
 			)?;
 
 			let fee = Self::calculate_fee(fee_location, fee.fee_amount, destination, total_weight)?;
@@ -976,7 +976,7 @@ pub mod pallet {
 			// this weight execution
 			let amount: u128 = fee_amount.map_or_else(
 				|| Self::take_fee_per_second_from_storage(fee_location, destination, total_weight),
-				|v| Ok(v),
+				Ok,
 			)?;
 
 			// Construct MultiAsset

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -497,7 +497,7 @@ pub mod pallet {
 			let total_weight = weight_info.overall_weight.map_or_else(
 				|| {
 					Self::take_weight_from_transact_info(
-						dest.clone(),
+						dest,
 						weight_info.transact_required_weight_at_most,
 						refund,
 					)
@@ -509,8 +509,8 @@ pub mod pallet {
 			let fee = Self::calculate_fee(
 				fee_location,
 				fee.fee_amount,
-				dest.clone(),
-				total_weight.clone(),
+				dest,
+				total_weight,
 			)?;
 
 			// If refund is true, the appendix instruction will be a deposit back to the sovereign
@@ -524,7 +524,7 @@ pub mod pallet {
 				.transpose()?;
 
 			Self::transact_in_dest_chain_asset_non_signed(
-				dest.clone(),
+				dest,
 				Some(who.clone()),
 				fee,
 				call_bytes.clone(),
@@ -583,7 +583,7 @@ pub mod pallet {
 			let total_weight = weight_info.overall_weight.map_or_else(
 				|| {
 					Self::take_weight_from_transact_info(
-						dest.clone(),
+						dest,
 						weight_info.transact_required_weight_at_most,
 						refund,
 					)
@@ -595,8 +595,8 @@ pub mod pallet {
 			let fee = Self::calculate_fee(
 				fee_location,
 				fee.fee_amount,
-				dest.clone(),
-				total_weight.clone(),
+				dest,
+				total_weight,
 			)?;
 
 			// If refund is true, the appendix instruction will be a deposit back to the sovereign
@@ -611,7 +611,7 @@ pub mod pallet {
 
 			// Grab the destination
 			Self::transact_in_dest_chain_asset_non_signed(
-				dest.clone(),
+				dest,
 				Some(fee_payer.clone()),
 				fee,
 				call.clone(),
@@ -709,7 +709,7 @@ pub mod pallet {
 			let total_weight = weight_info.overall_weight.map_or_else(
 				|| {
 					Self::take_weight_from_transact_info_signed(
-						dest.clone(),
+						dest,
 						weight_info.transact_required_weight_at_most,
 						refund,
 					)
@@ -721,8 +721,8 @@ pub mod pallet {
 			let fee = Self::calculate_fee(
 				fee_location,
 				fee.fee_amount,
-				dest.clone(),
-				total_weight.clone(),
+				dest,
+				total_weight,
 			)?;
 
 			// If refund is true, the appendix instruction will be a deposit back to the sender
@@ -738,7 +738,7 @@ pub mod pallet {
 
 			// Grab the destination
 			Self::transact_in_dest_chain_asset_signed(
-				dest.clone(),
+				dest,
 				who.clone(),
 				fee,
 				call.clone(),
@@ -850,7 +850,7 @@ pub mod pallet {
 			let total_weight = weight_info.overall_weight.map_or_else(
 				|| {
 					Self::take_weight_from_transact_info(
-						destination.clone(),
+						destination,
 						weight_info.transact_required_weight_at_most,
 						false,
 					)
@@ -861,8 +861,8 @@ pub mod pallet {
 			let fee = Self::calculate_fee(
 				fee_location,
 				fee.fee_amount,
-				destination.clone(),
-				total_weight.clone(),
+				destination,
+				total_weight,
 			)?;
 
 			ensure!(
@@ -919,7 +919,7 @@ pub mod pallet {
 			// BuyExecution: Buys "execution power" in the destination chain
 			// Transact: Issues the transaction
 			let transact_message: Xcm<()> = Self::transact_message(
-				dest.clone(),
+				dest,
 				fee,
 				total_weight,
 				call,
@@ -957,7 +957,7 @@ pub mod pallet {
 			// BuyExecution: Buys "execution power" in the destination chain
 			// Transact: Issues the transaction
 			let mut transact_message: Xcm<()> = Self::transact_message(
-				dest.clone(),
+				dest,
 				fee,
 				total_weight,
 				call,
@@ -970,7 +970,6 @@ pub mod pallet {
 			// The new message looks like DescendOrigin||WithdrawAsset||BuyExecution||
 			// Transact.
 			let interior: Junctions = origin_as_mult
-				.clone()
 				.try_into()
 				.map_err(|_| Error::<T>::FailedMultiLocationToJunction)?;
 			transact_message.0.insert(0, DescendOrigin(interior));
@@ -998,7 +997,7 @@ pub mod pallet {
 			let amount: u128 = fee_amount.map_or_else(
 				|| {
 					Self::take_fee_per_second_from_storage(
-						fee_location.clone(),
+						fee_location,
 						destination,
 						total_weight,
 					)
@@ -1131,7 +1130,7 @@ pub mod pallet {
 
 			// Construct MultiAsset
 			let fee = MultiAsset {
-				id: Concrete(asset.clone()),
+				id: Concrete(asset),
 				fun: Fungible(0),
 			};
 
@@ -1139,7 +1138,7 @@ pub mod pallet {
 				WithdrawAsset(fee.into()),
 				InitiateReserveWithdraw {
 					assets: MultiAssetFilter::Wild(All),
-					reserve: dest.clone(),
+					reserve: dest,
 					xcm: Xcm(vec![]),
 				},
 			]);

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -294,8 +294,7 @@ impl UtilityEncodeCall for Transactors {
 		match self {
 			Transactors::Relay => match call {
 				UtilityAvailableCalls::AsDerivative(a, b) => {
-					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
+					let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -419,15 +419,10 @@ impl Config for Test {
 	type HrmpEncoder = MockHrmpEncoder;
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -212,7 +212,7 @@ impl sp_runtime::traits::Convert<u64, MultiLocation> for AccountIdToMultiLocatio
 			0,
 			Junctions::X1(AccountKey20 {
 				network: None,
-				key: as_h160.as_fixed_bytes().clone(),
+				key: *as_h160.as_fixed_bytes(),
 			}),
 		)
 	}
@@ -295,7 +295,7 @@ impl UtilityEncodeCall for Transactors {
 			Transactors::Relay => match call {
 				UtilityAvailableCalls::AsDerivative(a, b) => {
 					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}
@@ -381,7 +381,7 @@ impl SendXcm for TestSendXcm {
 	) -> SendResult<Self::Ticket> {
 		SENT_XCM.with(|q| {
 			q.borrow_mut()
-				.push((destination.clone().unwrap(), message.clone().unwrap()))
+				.push(((*destination).unwrap(), message.clone().unwrap()))
 		});
 		CustomVersionWrapper::wrap_version(&destination.unwrap(), message.clone().unwrap())
 			.map_err(|()| SendError::DestinationUnsupported)?;

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -39,7 +39,7 @@ fn test_register_address() {
 			// Root can register
 			assert_ok!(XcmTransactor::register(RuntimeOrigin::root(), 1u64, 1));
 
-			assert_eq!(XcmTransactor::index_to_account(&1).unwrap(), 1u64);
+			assert_eq!(XcmTransactor::index_to_account(1).unwrap(), 1u64);
 
 			let expected = vec![crate::Event::RegisteredDerivative {
 				account_id: 1u64,
@@ -608,11 +608,11 @@ fn de_registering_works() {
 			// Root can register
 			assert_ok!(XcmTransactor::register(RuntimeOrigin::root(), 1u64, 1));
 
-			assert_eq!(XcmTransactor::index_to_account(&1).unwrap(), 1u64);
+			assert_eq!(XcmTransactor::index_to_account(1).unwrap(), 1u64);
 
 			assert_ok!(XcmTransactor::deregister(RuntimeOrigin::root(), 1));
 
-			assert!(XcmTransactor::index_to_account(&1).is_none());
+			assert!(XcmTransactor::index_to_account(1).is_none());
 
 			let expected = vec![
 				crate::Event::RegisteredDerivative {

--- a/precompiles/assets-erc20/src/eip2612.rs
+++ b/precompiles/assets-erc20/src/eip2612.rs
@@ -153,7 +153,7 @@ where
 			Address(address),
 		));
 
-		keccak_256(&domain_separator_inner).into()
+		keccak_256(&domain_separator_inner)
 	}
 
 	pub fn generate_permit(

--- a/precompiles/assets-erc20/src/eip2612.rs
+++ b/precompiles/assets-erc20/src/eip2612.rs
@@ -223,8 +223,8 @@ where
 		);
 
 		let mut sig = [0u8; 65];
-		sig[0..32].copy_from_slice(&r.as_bytes());
-		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[0..32].copy_from_slice(r.as_bytes());
+		sig[32..64].copy_from_slice(s.as_bytes());
 		sig[64] = v;
 
 		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -354,7 +354,7 @@ where
 		{
 			let caller: Runtime::AccountId =
 				Runtime::AddressMapping::into_account_id(handle.context().caller);
-			let from: Runtime::AccountId = Runtime::AddressMapping::into_account_id(from.clone());
+			let from: Runtime::AccountId = Runtime::AddressMapping::into_account_id(from);
 			let to: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to);
 
 			// If caller is "from", it can spend as much as it wants from its own balance.

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -309,15 +309,10 @@ construct_runtime!(
 	}
 );
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -503,10 +503,10 @@ fn transfer_not_enough_founds() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error: ")
-						&& from_utf8(&output).unwrap().contains("BalanceLow")
+						&& from_utf8(output).unwrap().contains("BalanceLow")
 				});
 		});
 }
@@ -1067,10 +1067,10 @@ fn freeze_local_assets() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error: ")
-						&& from_utf8(&output).unwrap().contains("Frozen")
+						&& from_utf8(output).unwrap().contains("Frozen")
 				});
 		});
 }
@@ -1196,10 +1196,10 @@ fn freeze_asset_local_asset() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error: ")
-						&& from_utf8(&output).unwrap().contains("AssetNotLive")
+						&& from_utf8(output).unwrap().contains("AssetNotLive")
 				});
 		});
 }
@@ -1313,10 +1313,10 @@ fn transfer_ownership_local_assets() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error: ")
-						&& from_utf8(&output).unwrap().contains("NoPermission")
+						&& from_utf8(output).unwrap().contains("NoPermission")
 				});
 
 			precompiles()
@@ -1380,10 +1380,10 @@ fn set_team_local_assets() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error: ")
-						&& from_utf8(&output).unwrap().contains("NoPermission")
+						&& from_utf8(output).unwrap().contains("NoPermission")
 				});
 
 			precompiles()

--- a/precompiles/author-mapping/src/mock.rs
+++ b/precompiles/author-mapping/src/mock.rs
@@ -180,15 +180,10 @@ impl pallet_scheduler::Config for Runtime {
 	type Preimages = ();
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -122,7 +122,7 @@ fn add_association_works() {
 					AuthorMappingEvent::KeysRegistered {
 						nimbus_id: expected_nimbus_id.clone(),
 						account_id: Alice.into(),
-						keys: expected_nimbus_id.into(),
+						keys: expected_nimbus_id,
 					}
 					.into(),
 					EvmEvent::Executed {
@@ -173,13 +173,13 @@ fn update_association_works() {
 					AuthorMappingEvent::KeysRegistered {
 						nimbus_id: first_nimbus_id.clone(),
 						account_id: Alice.into(),
-						keys: first_nimbus_id.into(),
+						keys: first_nimbus_id,
 					}
 					.into(),
 					AuthorMappingEvent::KeysRotated {
 						new_nimbus_id: second_nimbus_id.clone(),
 						account_id: Alice.into(),
-						new_keys: second_nimbus_id.into(),
+						new_keys: second_nimbus_id,
 					}
 					.into(),
 					EvmEvent::Executed {
@@ -226,7 +226,7 @@ fn clear_association_works() {
 					AuthorMappingEvent::KeysRegistered {
 						nimbus_id: nimbus_id.clone(),
 						account_id: Alice.into(),
-						keys: nimbus_id.clone().into(),
+						keys: nimbus_id.clone(),
 					}
 					.into(),
 					BalancesEvent::Unreserved {
@@ -237,7 +237,7 @@ fn clear_association_works() {
 					AuthorMappingEvent::KeysRemoved {
 						nimbus_id: nimbus_id.clone(),
 						account_id: Alice.into(),
-						keys: nimbus_id.into(),
+						keys: nimbus_id,
 					}
 					.into(),
 					EvmEvent::Executed {
@@ -281,7 +281,7 @@ fn remove_keys_works() {
 					AuthorMappingEvent::KeysRegistered {
 						nimbus_id: nimbus_id.clone(),
 						account_id: Alice.into(),
-						keys: nimbus_id.clone().into(),
+						keys: nimbus_id.clone(),
 					}
 					.into(),
 					BalancesEvent::Unreserved {
@@ -292,7 +292,7 @@ fn remove_keys_works() {
 					AuthorMappingEvent::KeysRemoved {
 						nimbus_id: nimbus_id.clone(),
 						account_id: Alice.into(),
-						keys: nimbus_id.into(),
+						keys: nimbus_id,
 					}
 					.into(),
 					EvmEvent::Executed {
@@ -346,13 +346,13 @@ fn set_keys_works() {
 					AuthorMappingEvent::KeysRegistered {
 						nimbus_id: first_nimbus_id.clone(),
 						account_id: Alice.into(),
-						keys: first_vrf_key.into(),
+						keys: first_vrf_key,
 					}
 					.into(),
 					AuthorMappingEvent::KeysRotated {
 						new_nimbus_id: second_nimbus_id.clone(),
 						account_id: Alice.into(),
-						new_keys: second_vrf_key.into(),
+						new_keys: second_vrf_key,
 					}
 					.into(),
 					EvmEvent::Executed {

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -121,8 +121,8 @@ where
 		);
 
 		let mut sig = [0u8; 65];
-		sig[0..32].copy_from_slice(&r.as_bytes());
-		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[0..32].copy_from_slice(r.as_bytes());
+		sig[32..64].copy_from_slice(s.as_bytes());
 		sig[64] = v;
 
 		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -56,7 +56,7 @@ where
 			Address(address),
 		));
 
-		keccak_256(&domain_separator_inner).into()
+		keccak_256(&domain_separator_inner)
 	}
 
 	pub fn generate_permit(

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -286,7 +286,7 @@ where
 				Some(origin).into(),
 				pallet_balances::Call::<Runtime, Instance>::transfer {
 					dest: Runtime::Lookup::unlookup(to),
-					value: value,
+					value,
 				},
 				SYSTEM_ACCOUNT_SIZE,
 			)?;
@@ -352,7 +352,7 @@ where
 				Some(from).into(),
 				pallet_balances::Call::<Runtime, Instance>::transfer {
 					dest: Runtime::Lookup::unlookup(to),
-					value: value,
+					value,
 				},
 				SYSTEM_ACCOUNT_SIZE,
 			)?;

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -178,15 +178,10 @@ impl Erc20Metadata for NativeErc20Metadata {
 	}
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -335,10 +335,10 @@ fn transfer_not_enough_funds() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error: ")
-						&& from_utf8(&output).unwrap().contains("FundsUnavailable")
+						&& from_utf8(output).unwrap().contains("FundsUnavailable")
 				});
 		});
 }

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -879,7 +879,7 @@ fn permit_valid() {
 					SELECTOR_LOG_APPROVAL,
 					CryptoAlith,
 					Bob,
-					solidity::encode_event_data(U256::from(value)),
+					solidity::encode_event_data(value),
 				))
 				.execute_returns(());
 

--- a/precompiles/batch/src/lib.rs
+++ b/precompiles/batch/src/lib.rs
@@ -121,10 +121,7 @@ where
 		gas_limit: BoundedVec<u64, GetArrayLimit>,
 	) -> EvmResult {
 		let addresses = Vec::from(to).into_iter().enumerate();
-		let values = Vec::from(value)
-			.into_iter()
-			.map(|x| Some(x))
-			.chain(repeat(None));
+		let values = Vec::from(value).into_iter().map(Some).chain(repeat(None));
 		let calls_data = Vec::from(call_data)
 			.into_iter()
 			.map(|x| Some(x.into()))

--- a/precompiles/batch/src/lib.rs
+++ b/precompiles/batch/src/lib.rs
@@ -152,7 +152,7 @@ where
 
 			let sub_context = Context {
 				caller: handle.context().caller,
-				address: address.clone(),
+				address,
 				apparent_value: value,
 			};
 
@@ -161,7 +161,7 @@ where
 			} else {
 				Some(Transfer {
 					source: handle.context().caller,
-					target: address.clone(),
+					target: address,
 					value,
 				})
 			};

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -167,15 +167,10 @@ impl pallet_timestamp::Config for Runtime {
 	type WeightInfo = ();
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -983,10 +983,10 @@ fn evm_batch_recursion_over_limit() {
 						vec![Address(Bob.into())],
 						vec![1000_u32.into()],
 						vec![],
-						vec![].into(),
+						vec![],
 					)
 					.into()],
-					vec![].into(),
+					vec![],
 				)
 				.into()],
 				vec![],

--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -208,7 +208,7 @@ where
 		// DISPATCH CALL
 		let sub_context = Context {
 			caller: from,
-			address: to.clone(),
+			address: to,
 			apparent_value: value,
 		};
 
@@ -217,7 +217,7 @@ where
 		} else {
 			Some(Transfer {
 				source: from,
-				target: to.clone(),
+				target: to,
 				value,
 			})
 		};

--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -94,7 +94,7 @@ where
 			Address(address),
 		));
 
-		keccak_256(&domain_separator_inner).into()
+		keccak_256(&domain_separator_inner)
 	}
 
 	pub fn generate_permit(

--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -190,8 +190,8 @@ where
 		);
 
 		let mut sig = [0u8; 65];
-		sig[0..32].copy_from_slice(&r.as_bytes());
-		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[0..32].copy_from_slice(r.as_bytes());
+		sig[32..64].copy_from_slice(s.as_bytes());
 		sig[64] = v;
 
 		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -146,15 +146,10 @@ impl pallet_timestamp::Config for Runtime {
 	type WeightInfo = ();
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -132,7 +132,7 @@ where
 		let (poll_index, vote, event) = Self::log_vote_event(handle, poll_index, vote)?;
 
 		let origin = Runtime::AddressMapping::into_account_id(caller);
-		let call = ConvictionVotingCall::<Runtime>::vote { poll_index, vote }.into();
+		let call = ConvictionVotingCall::<Runtime>::vote { poll_index, vote };
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 

--- a/precompiles/conviction-voting/src/mock.rs
+++ b/precompiles/conviction-voting/src/mock.rs
@@ -263,15 +263,10 @@ impl pallet_conviction_voting::Config for Runtime {
 	type Polls = TestPolls;
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	/// Endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/conviction-voting/src/tests.rs
+++ b/precompiles/conviction-voting/src/tests.rs
@@ -113,10 +113,10 @@ fn standard_vote_logs_work() {
 		.build()
 		.execute_with(|| {
 			// Vote Yes
-			assert_ok!(standard_vote(true, 100_000.into(), 0.into()));
+			assert_ok!(standard_vote(true, 100_000.into(), 0));
 
 			// Vote No
-			assert_ok!(standard_vote(false, 99_000.into(), 1.into()));
+			assert_ok!(standard_vote(false, 99_000.into(), 1));
 
 			// Assert vote events are emitted.
 			let expected_events = vec![
@@ -224,7 +224,7 @@ fn remove_vote_logs_work() {
 		.build()
 		.execute_with(|| {
 			// Vote..
-			assert_ok!(standard_vote(true, 100_000.into(), 0.into()));
+			assert_ok!(standard_vote(true, 100_000.into(), 0));
 
 			// ..and remove
 			let input = PCall::remove_vote {
@@ -255,7 +255,7 @@ fn remove_vote_for_track_logs_work() {
 		.build()
 		.execute_with(|| {
 			// Vote..
-			assert_ok!(standard_vote(true, 100_000.into(), 0.into()));
+			assert_ok!(standard_vote(true, 100_000.into(), 0));
 
 			// ..and remove
 			let input = PCall::remove_vote_for_track {
@@ -290,7 +290,7 @@ fn remove_other_vote_logs_work() {
 		.build()
 		.execute_with(|| {
 			// Vote..
-			assert_ok!(standard_vote(true, 100_000.into(), 0.into()));
+			assert_ok!(standard_vote(true, 100_000.into(), 0));
 
 			// ..and remove other
 			let input = PCall::remove_other_vote {
@@ -330,7 +330,7 @@ fn delegate_undelegate_logs_work() {
 			let input = PCall::delegate {
 				track_id: 0u16,
 				representative: H160::from(Bob).into(),
-				conviction: 0.into(),
+				conviction: 0,
 				amount: 100_000.into(),
 			}
 			.into();
@@ -380,7 +380,7 @@ fn unlock_logs_work() {
 		.build()
 		.execute_with(|| {
 			// Vote
-			assert_ok!(standard_vote(true, 100_000.into(), 0.into()));
+			assert_ok!(standard_vote(true, 100_000.into(), 0));
 
 			// Remove
 			let input = PCall::remove_vote {
@@ -419,7 +419,7 @@ fn test_voting_for_returns_correct_value_for_standard_vote() {
 		.build()
 		.execute_with(|| {
 			// Vote Yes
-			assert_ok!(standard_vote(true, 100_000.into(), 1.into()));
+			assert_ok!(standard_vote(true, 100_000.into(), 1));
 
 			precompiles()
 				.prepare_test(
@@ -559,7 +559,7 @@ fn test_class_locks_for_returns_correct_value() {
 		.build()
 		.execute_with(|| {
 			// Vote Yes
-			assert_ok!(standard_vote(true, 100_000.into(), 1.into()));
+			assert_ok!(standard_vote(true, 100_000.into(), 1));
 
 			precompiles()
 				.prepare_test(

--- a/precompiles/crowdloan-rewards/src/tests.rs
+++ b/precompiles/crowdloan-rewards/src/tests.rs
@@ -160,8 +160,8 @@ fn claim_works() {
 			assert_ok!(
 				RuntimeCall::Crowdloan(CrowdloanCall::initialize_reward_vec {
 					rewards: vec![
-						([1u8; 32].into(), Some(Alice.into()), 50u32.into()),
-						([2u8; 32].into(), Some(Bob.into()), 50u32.into()),
+						([1u8; 32], Some(Alice.into()), 50u32.into()),
+						([2u8; 32], Some(Bob.into()), 50u32.into()),
 					]
 				})
 				.dispatch(RuntimeOrigin::root())
@@ -201,8 +201,8 @@ fn reward_info_works() {
 			assert_ok!(
 				RuntimeCall::Crowdloan(CrowdloanCall::initialize_reward_vec {
 					rewards: vec![
-						([1u8; 32].into(), Some(Alice.into()), 50u32.into()),
-						([2u8; 32].into(), Some(Bob.into()), 50u32.into()),
+						([1u8; 32], Some(Alice.into()), 50u32.into()),
+						([2u8; 32], Some(Bob.into()), 50u32.into()),
 					]
 				})
 				.dispatch(RuntimeOrigin::root())
@@ -245,8 +245,8 @@ fn update_reward_address_works() {
 			assert_ok!(
 				RuntimeCall::Crowdloan(CrowdloanCall::initialize_reward_vec {
 					rewards: vec![
-						([1u8; 32].into(), Some(Alice.into()), 50u32.into()),
-						([2u8; 32].into(), Some(Bob.into()), 50u32.into()),
+						([1u8; 32], Some(Alice.into()), 50u32.into()),
+						([2u8; 32], Some(Bob.into()), 50u32.into()),
 					]
 				})
 				.dispatch(RuntimeOrigin::root())

--- a/precompiles/gmp/src/mock.rs
+++ b/precompiles/gmp/src/mock.rs
@@ -335,7 +335,7 @@ impl sp_runtime::traits::Convert<AccountId, MultiLocation> for AccountIdToMultiL
 			1,
 			Junctions::X1(AccountKey20 {
 				network: None,
-				key: as_h160.as_fixed_bytes().clone(),
+				key: *as_h160.as_fixed_bytes(),
 			}),
 		)
 	}

--- a/precompiles/gmp/src/mock.rs
+++ b/precompiles/gmp/src/mock.rs
@@ -409,15 +409,10 @@ impl orml_xtokens::Config for Runtime {
 	type UniversalLocation = UniversalLocation;
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	/// Endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/identity/src/lib.rs
+++ b/precompiles/identity/src/lib.rs
@@ -705,7 +705,7 @@ where
 			return Ok(pallet_identity::Judgement::Erroneous);
 		}
 
-		return Err(RevertReason::custom("invalid"));
+		Err(RevertReason::custom("invalid"))
 	}
 
 	fn data_to_output(data: pallet_identity::Data) -> Data {

--- a/precompiles/identity/src/lib.rs
+++ b/precompiles/identity/src/lib.rs
@@ -630,7 +630,7 @@ where
 
 		let reg = Registration::<Runtime::MaxAdditionalFields> {
 			is_valid: true,
-			judgements: judgements.into(),
+			judgements: judgements,
 			deposit: registration.deposit.into(),
 			info: identity_info,
 		};
@@ -680,7 +680,7 @@ where
 			let amount: BalanceOf<Runtime> = value
 				.fee_paid_deposit
 				.try_into()
-				.map_err(|_| RevertReason::value_is_too_large("fee_paid_deposit").into())?;
+				.map_err(|_| RevertReason::value_is_too_large("fee_paid_deposit"))?;
 
 			return Ok(pallet_identity::Judgement::FeePaid(amount));
 		}

--- a/precompiles/identity/src/mock.rs
+++ b/precompiles/identity/src/mock.rs
@@ -195,15 +195,10 @@ impl pallet_identity::Config for Runtime {
 	type WeightInfo = ();
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	/// Endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -297,11 +297,10 @@ where
 		let ref_index = ref_index.converted();
 		let vote_amount_balance = Self::u256_to_amount(vote_amount).in_field("voteAmount")?;
 
-		let conviction_enum: Conviction =
-			conviction.converted().try_into().map_err(|_| {
-				RevertReason::custom("Must be an integer between 0 and 6 included")
-					.in_field("conviction")
-			})?;
+		let conviction_enum: Conviction = conviction.converted().try_into().map_err(|_| {
+			RevertReason::custom("Must be an integer between 0 and 6 included")
+				.in_field("conviction")
+		})?;
 
 		let vote = AccountVote::Standard {
 			vote: Vote {

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -173,8 +173,8 @@ where
 
 		Ok((
 			ref_status.end.into(),
-			ref_status.proposal.hash().into(),
-			threshold_u8.into(),
+			ref_status.proposal.hash(),
+			threshold_u8,
 			ref_status.delay.into(),
 			ref_status.tally.ayes.into(),
 			ref_status.tally.nays.into(),
@@ -456,7 +456,7 @@ where
 
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 		let call = PreimageCall::<Runtime>::note_preimage {
-			bytes: encoded_proposal.into(),
+			bytes: encoded_proposal,
 		};
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 
@@ -491,7 +491,7 @@ where
 
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 		let call = PreimageCall::<Runtime>::note_preimage {
-			bytes: encoded_proposal.into(),
+			bytes: encoded_proposal,
 		};
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -298,7 +298,7 @@ where
 		let vote_amount_balance = Self::u256_to_amount(vote_amount).in_field("voteAmount")?;
 
 		let conviction_enum: Conviction =
-			conviction.clone().converted().try_into().map_err(|_| {
+			conviction.converted().try_into().map_err(|_| {
 				RevertReason::custom("Must be an integer between 0 and 6 included")
 					.in_field("conviction")
 			})?;

--- a/precompiles/pallet-democracy/src/mock.rs
+++ b/precompiles/pallet-democracy/src/mock.rs
@@ -228,20 +228,12 @@ impl pallet_preimage::Config for Runtime {
 }
 
 /// Build test externalities, prepopulated with data for testing democracy precompiles
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	/// Endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
 	/// Referenda that already exist (don't need a proposal and launch period delay)
 	referenda: Vec<(Bounded<RuntimeCall>, VoteThreshold, BlockNumber)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder {
-			balances: vec![],
-			referenda: vec![],
-		}
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/pallet-democracy/src/tests.rs
+++ b/precompiles/pallet-democracy/src/tests.rs
@@ -902,7 +902,7 @@ fn remove_vote_dne() {
 						ref_index: 0.into(),
 					},
 				)
-				.execute_reverts(|output| from_utf8(&output).unwrap().contains("NotVoter"));
+				.execute_reverts(|output| from_utf8(output).unwrap().contains("NotVoter"));
 		})
 }
 
@@ -1070,7 +1070,7 @@ fn undelegate_dne() {
 	ExtBuilder::default().build().execute_with(|| {
 		precompiles()
 			.prepare_test(Alice, Precompile1, PCall::un_delegate {})
-			.execute_reverts(|output| from_utf8(&output).unwrap().contains("NotDelegating"));
+			.execute_reverts(|output| from_utf8(output).unwrap().contains("NotDelegating"));
 	})
 }
 

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -96,7 +96,7 @@ where
 
 		let candidate = Runtime::AddressMapping::into_account_id(candidate.0);
 
-		let points = <pallet_parachain_staking::Pallet<Runtime>>::awarded_pts(&round, &candidate);
+		let points = <pallet_parachain_staking::Pallet<Runtime>>::awarded_pts(round, &candidate);
 
 		Ok(points)
 	}

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -201,7 +201,7 @@ fn awarded_points_zero() {
 					Alice,
 					Precompile1,
 					PCall::awarded_points {
-						round: 1u32.into(),
+						round: 1u32,
 						candidate: Address(Bob.into()),
 					},
 				)
@@ -226,7 +226,7 @@ fn awarded_points_non_zero() {
 					Alice,
 					Precompile1,
 					PCall::awarded_points {
-						round: 1u32.into(),
+						round: 1u32,
 						candidate: Address(Alice.into()),
 					},
 				)

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -1520,7 +1520,7 @@ fn delegate_with_auto_compound_returns_error_if_percent_above_hundred() {
 						},
 					)
 					.execute_reverts(|output| {
-						from_utf8(&output).unwrap().contains(
+						from_utf8(output).unwrap().contains(
 							"auto_compound: Must be an integer between 0 and 100 included",
 						)
 					});
@@ -1588,7 +1588,7 @@ fn set_auto_compound_returns_error_if_value_above_hundred_percent() {
 						},
 					)
 					.execute_reverts(|output| {
-						from_utf8(&output)
+						from_utf8(output)
 							.unwrap()
 							.contains("value: Must be an integer between 0 and 100 included")
 					});
@@ -1614,7 +1614,7 @@ fn set_auto_compound_fails_if_not_delegation() {
 						delegator_delegation_count: 0.into(),
 					},
 				)
-				.execute_reverts(|output| from_utf8(&output).unwrap().contains("DelegatorDNE"));
+				.execute_reverts(|output| from_utf8(output).unwrap().contains("DelegatorDNE"));
 		});
 }
 

--- a/precompiles/precompile-registry/src/mock.rs
+++ b/precompiles/precompile-registry/src/mock.rs
@@ -147,15 +147,10 @@ impl pallet_timestamp::Config for Runtime {
 	type WeightInfo = ();
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/preimage/src/lib.rs
+++ b/precompiles/preimage/src/lib.rs
@@ -70,12 +70,12 @@ where
 		let event = log1(
 			handle.context().address,
 			SELECTOR_LOG_PREIMAGE_NOTED,
-			solidity::encode_arguments(H256::from(hash)),
+			solidity::encode_arguments(hash),
 		);
 		handle.record_log_costs(&[&event])?;
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 
-		let call = PreimageCall::<Runtime>::note_preimage { bytes }.into();
+		let call = PreimageCall::<Runtime>::note_preimage { bytes };
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 
@@ -92,7 +92,7 @@ where
 		let event = log1(
 			handle.context().address,
 			SELECTOR_LOG_PREIMAGE_UNNOTED,
-			solidity::encode_arguments(H256::from(hash)),
+			solidity::encode_arguments(hash),
 		);
 		handle.record_log_costs(&[&event])?;
 
@@ -101,7 +101,7 @@ where
 			.map_err(|_| RevertReason::custom("H256 is Runtime::Hash").in_field("hash"))?;
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 
-		let call = PreimageCall::<Runtime>::unnote_preimage { hash }.into();
+		let call = PreimageCall::<Runtime>::unnote_preimage { hash };
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 

--- a/precompiles/preimage/src/mock.rs
+++ b/precompiles/preimage/src/mock.rs
@@ -159,15 +159,10 @@ impl pallet_preimage::Config for Runtime {
 	type ByteDeposit = ExistentialDeposit;
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -194,8 +194,7 @@ where
 			delegate,
 			proxy_type,
 			delay,
-		}
-		.into();
+		};
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 
@@ -230,8 +229,7 @@ where
 			delegate,
 			proxy_type,
 			delay,
-		}
-		.into();
+		};
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 
@@ -245,7 +243,7 @@ where
 	#[precompile::public("removeProxies()")]
 	fn remove_proxies(handle: &mut impl PrecompileHandle) -> EvmResult {
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
-		let call: ProxyCall<Runtime> = ProxyCall::<Runtime>::remove_proxies {}.into();
+		let call: ProxyCall<Runtime> = ProxyCall::<Runtime>::remove_proxies {};
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -396,7 +396,7 @@ where
 
 		let sub_context = Context {
 			caller: real.0,
-			address: address.clone(),
+			address,
 			apparent_value: value,
 		};
 
@@ -426,7 +426,7 @@ where
 
 			Some(Transfer {
 				source: sub_context.caller,
-				target: address.clone(),
+				target: address,
 				value,
 			})
 		};

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -192,18 +192,24 @@ impl pallet_timestamp::Config for Runtime {
 
 #[repr(u8)]
 #[derive(
-	Debug, Eq, PartialEq, Ord, PartialOrd, Decode, MaxEncodedLen, Encode, Clone, Copy, TypeInfo,
+	Debug,
+	Eq,
+	PartialEq,
+	Ord,
+	PartialOrd,
+	Decode,
+	MaxEncodedLen,
+	Encode,
+	Clone,
+	Copy,
+	TypeInfo,
+	Default,
 )]
 pub enum ProxyType {
+	#[default]
 	Any = 0,
 	Something = 1,
 	Nothing = 2,
-}
-
-impl std::default::Default for ProxyType {
-	fn default() -> Self {
-		ProxyType::Any
-	}
 }
 
 impl crate::EvmProxyCallFilter for ProxyType {
@@ -253,15 +259,10 @@ impl pallet_proxy::Config for Runtime {
 }
 
 /// Build test externalities, prepopulated with data for testing democracy precompiles
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	/// Endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/proxy/src/tests.rs
+++ b/precompiles/proxy/src/tests.rs
@@ -254,7 +254,7 @@ fn test_remove_proxy_fails_if_proxy_not_exist() {
 						delay: 0,
 					},
 				)
-				.execute_reverts(|output| from_utf8(&output).unwrap().contains("NotFound"));
+				.execute_reverts(|output| from_utf8(output).unwrap().contains("NotFound"));
 		})
 }
 

--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -481,7 +481,7 @@ where
 			handle,
 			request_id,
 			request.gas_limit,
-			request.contract_address.clone().into(),
+			request.contract_address.into(),
 			randomness.into_iter().map(|x| H256(x)).collect(),
 		)?;
 		let remaining_gas_after = handle.remaining_gas();

--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -482,7 +482,7 @@ where
 			request_id,
 			request.gas_limit,
 			request.contract_address,
-			randomness.into_iter().map(|x| H256(x)).collect(),
+			randomness.into_iter().map(H256).collect(),
 		)?;
 		let remaining_gas_after = handle.remaining_gas();
 

--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -309,7 +309,7 @@ where
 
 		Ok((
 			request_id.into(),
-			refund_address.into(),
+			refund_address,
 			contract_address,
 			fee,
 			request.gas_limit.into(),
@@ -481,7 +481,7 @@ where
 			handle,
 			request_id,
 			request.gas_limit,
-			request.contract_address.into(),
+			request.contract_address,
 			randomness.into_iter().map(|x| H256(x)).collect(),
 		)?;
 		let remaining_gas_after = handle.remaining_gas();

--- a/precompiles/randomness/src/mock.rs
+++ b/precompiles/randomness/src/mock.rs
@@ -193,20 +193,12 @@ impl pallet_randomness::Config for Runtime {
 }
 
 /// Externality builder for pallet randomness mock runtime
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	/// Balance amounts per AccountId
 	balances: Vec<(AccountId, Balance)>,
 	/// AuthorId -> AccountId mappings
 	mappings: Vec<(NimbusId, AccountId)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder {
-			balances: Vec::new(),
-			mappings: Vec::new(),
-		}
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/randomness/src/tests.rs
+++ b/precompiles/randomness/src/tests.rs
@@ -393,7 +393,7 @@ fn fulfill_request_reverts_if_not_enough_gas() {
 				.execute_reverts(|revert| revert == b"not enough gas to perform the call");
 
 			// no refund
-			assert_eq!(Balances::free_balance(&AccountId::from(Charlie)), 0);
+			assert_eq!(Balances::free_balance(AccountId::from(Charlie)), 0);
 		})
 }
 
@@ -497,7 +497,7 @@ fn fulfill_request_works() {
 
 			// correctly refunded
 			assert_eq!(
-				U256::from(Balances::free_balance(&AccountId::from(Charlie))),
+				U256::from(Balances::free_balance(AccountId::from(Charlie))),
 				refunded_amount
 			);
 		})
@@ -605,7 +605,7 @@ fn fulfill_request_works_with_higher_gas() {
 
 			// correctly refunded
 			assert_eq!(
-				U256::from(Balances::free_balance(&AccountId::from(Charlie))),
+				U256::from(Balances::free_balance(AccountId::from(Charlie))),
 				refunded_amount
 			);
 		})
@@ -712,7 +712,7 @@ fn fulfill_request_works_with_subcall_revert() {
 
 			// correctly refunded
 			assert_eq!(
-				U256::from(Balances::free_balance(&AccountId::from(Charlie))),
+				U256::from(Balances::free_balance(AccountId::from(Charlie))),
 				refunded_amount
 			);
 		})

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -197,7 +197,7 @@ where
 	#[precompile::view]
 	fn track_ids(_handle: &mut impl PrecompileHandle) -> EvmResult<Vec<u16>> {
 		let track_ids: Vec<u16> = Runtime::Tracks::tracks()
-			.into_iter()
+			.iter()
 			.filter_map(|(id, _)| {
 				if let Ok(track_id) = (*id).try_into() {
 					Some(track_id)

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -286,8 +286,7 @@ where
 			proposal_origin,
 			proposal,
 			enactment_moment,
-		}
-		.into();
+		};
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 
@@ -563,7 +562,7 @@ where
 
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 
-		let call = ReferendaCall::<Runtime>::place_decision_deposit { index }.into();
+		let call = ReferendaCall::<Runtime>::place_decision_deposit { index };
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 
@@ -616,7 +615,7 @@ where
 
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 
-		let call = ReferendaCall::<Runtime>::refund_decision_deposit { index }.into();
+		let call = ReferendaCall::<Runtime>::refund_decision_deposit { index };
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 		let event = log1(
@@ -652,7 +651,7 @@ where
 
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 
-		let call = ReferendaCall::<Runtime>::refund_submission_deposit { index }.into();
+		let call = ReferendaCall::<Runtime>::refund_submission_deposit { index };
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call, 0)?;
 

--- a/precompiles/referenda/src/mock.rs
+++ b/precompiles/referenda/src/mock.rs
@@ -358,17 +358,10 @@ impl From<GovOrigin> for OriginCaller {
 }
 
 /// Externality builder for pallet referenda mock runtime
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	/// Balance amounts per AccountId
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder {
-			balances: Vec::new(),
-		}
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/referenda/src/tests.rs
+++ b/precompiles/referenda/src/tests.rs
@@ -62,7 +62,7 @@ fn submitted_at_logs_work() {
 			// Submit referendum at index 0
 			let input = PCall::submit_at {
 				track_id: 0u16,
-				proposal_hash: proposal_hash,
+				proposal_hash,
 				proposal_len: proposal.len() as u32,
 				block_number: 0u32,
 			}
@@ -72,7 +72,7 @@ fn submitted_at_logs_work() {
 			// Submit referendum at index 1
 			let input = PCall::submit_at {
 				track_id: 0u16,
-				proposal_hash: proposal_hash,
+				proposal_hash,
 				proposal_len: proposal.len() as u32,
 				block_number: 0u32,
 			}
@@ -122,7 +122,7 @@ fn submitted_after_logs_work() {
 			// Submit referendum at index 0
 			let input = PCall::submit_after {
 				track_id: 0u16,
-				proposal_hash: proposal_hash,
+				proposal_hash,
 				proposal_len: proposal.len() as u32,
 				block_number: 0u32,
 			}
@@ -132,7 +132,7 @@ fn submitted_after_logs_work() {
 			// Submit referendum at index 1
 			let input = PCall::submit_after {
 				track_id: 0u16,
-				proposal_hash: proposal_hash,
+				proposal_hash,
 				proposal_len: proposal.len() as u32,
 				block_number: 0u32,
 			}
@@ -183,7 +183,7 @@ fn place_and_refund_decision_deposit_logs_work() {
 			// Create referendum
 			let input = PCall::submit_at {
 				track_id: 0u16,
-				proposal_hash: proposal_hash,
+				proposal_hash,
 				proposal_len: proposal.len() as u32,
 				block_number: 0u32,
 			}
@@ -301,7 +301,7 @@ fn submit_track_id_oob_fails() {
 			// submit with an invalid track_id
 			let input = PCall::submit_at {
 				track_id: oob_track_id as u16,
-				proposal_hash: proposal_hash,
+				proposal_hash,
 				proposal_len: proposal.len() as u32,
 				block_number: 0u32,
 			};

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -173,7 +173,7 @@ where
 		let encoded = RelayRuntime::encode_call(AvailableStakeCalls::Validate(
 			pallet_staking::ValidatorPrefs {
 				commission: fraction,
-				blocked: blocked,
+				blocked,
 			},
 		))
 		.as_slice()

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -426,7 +426,7 @@ impl solidity::Codec for RewardDestinationWrapper {
 			3u8 => {
 				let address = encoded_reward_destination.read::<H256>()?;
 				Ok(RewardDestinationWrapper(RewardDestination::Account(
-					address.as_fixed_bytes().clone().into(),
+					(*address.as_fixed_bytes()).into(),
 				)))
 			}
 			4u8 => Ok(RewardDestinationWrapper(RewardDestination::None)),

--- a/precompiles/relay-encoder/src/mock.rs
+++ b/precompiles/relay-encoder/src/mock.rs
@@ -173,15 +173,10 @@ parameter_types! {
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -118,17 +118,17 @@ impl xcm_primitives::HrmpEncodeCall for TestEncoder {
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
 			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a.clone(), b.clone(), c.clone()),
+				HrmpCall::InitOpenChannel(a, b, c),
 			)
 			.encode()),
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CancelOpenRequest(a, b) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b)).encode())
 			}
 		}
 	}

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -90,17 +90,13 @@ impl StakeEncodeCall for TestEncoder {
 
 			AvailableStakeCalls::Chill => RelayCall::Stake(StakeCall::Chill).encode(),
 
-			AvailableStakeCalls::SetPayee(a) => {
-				RelayCall::Stake(StakeCall::SetPayee(a)).encode()
-			}
+			AvailableStakeCalls::SetPayee(a) => RelayCall::Stake(StakeCall::SetPayee(a)).encode(),
 
 			AvailableStakeCalls::SetController => {
 				RelayCall::Stake(StakeCall::SetController).encode()
 			}
 
-			AvailableStakeCalls::Rebond(a) => {
-				RelayCall::Stake(StakeCall::Rebond(a)).encode()
-			}
+			AvailableStakeCalls::Rebond(a) => RelayCall::Stake(StakeCall::Rebond(a)).encode(),
 
 			AvailableStakeCalls::Nominate(a) => {
 				let nominated: Vec<<AccountIdLookup<AccountId32, ()> as StaticLookup>::Source> =

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -91,7 +91,7 @@ impl StakeEncodeCall for TestEncoder {
 			AvailableStakeCalls::Chill => RelayCall::Stake(StakeCall::Chill).encode(),
 
 			AvailableStakeCalls::SetPayee(a) => {
-				RelayCall::Stake(StakeCall::SetPayee(a.into())).encode()
+				RelayCall::Stake(StakeCall::SetPayee(a)).encode()
 			}
 
 			AvailableStakeCalls::SetController => {
@@ -99,7 +99,7 @@ impl StakeEncodeCall for TestEncoder {
 			}
 
 			AvailableStakeCalls::Rebond(a) => {
-				RelayCall::Stake(StakeCall::Rebond(a.into())).encode()
+				RelayCall::Stake(StakeCall::Rebond(a)).encode()
 			}
 
 			AvailableStakeCalls::Nominate(a) => {

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -117,10 +117,9 @@ impl xcm_primitives::HrmpEncodeCall for TestEncoder {
 		call: xcm_primitives::HrmpAvailableCalls,
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
-			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a, b, c),
-			)
-			.encode()),
+			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => {
+				Ok(RelayCall::Hrmp(HrmpCall::InitOpenChannel(a, b, c)).encode())
+			}
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}

--- a/precompiles/relay-encoder/src/tests.rs
+++ b/precompiles/relay-encoder/src/tests.rs
@@ -268,7 +268,7 @@ fn test_encode_validate() {
 				.expect_no_logs()
 				.execute_returns(UnboundedBytes::from(
 					TestEncoder::encode_call(AvailableStakeCalls::Validate(ValidatorPrefs {
-						commission: Perbill::from_parts(100u32.into()),
+						commission: Perbill::from_parts(100u32),
 						blocked: true,
 					}))
 					.as_slice(),
@@ -291,7 +291,7 @@ fn test_encode_withdraw_unbonded() {
 				.expect_cost(1000)
 				.expect_no_logs()
 				.execute_returns(UnboundedBytes::from(
-					TestEncoder::encode_call(AvailableStakeCalls::WithdrawUnbonded(100u32.into()))
+					TestEncoder::encode_call(AvailableStakeCalls::WithdrawUnbonded(100u32))
 						.as_slice(),
 				));
 		});

--- a/precompiles/utils/macro/src/derive_codec.rs
+++ b/precompiles/utils/macro/src/derive_codec.rs
@@ -38,7 +38,7 @@ pub fn main(input: TokenStream) -> TokenStream {
 	};
 	let fields = fields.named;
 
-	if fields.len() == 0 {
+	if fields.is_empty() {
 		return quote_spanned! { ident.span() =>
 			compile_error!("Codec can only be derived for structs with at least one field");
 		}

--- a/precompiles/utils/macro/src/precompile/parse.rs
+++ b/precompiles/utils/macro/src/precompile/parse.rs
@@ -335,7 +335,7 @@ impl Precompile {
 
 			let input_type = input.ty.as_ref();
 
-			self.try_register_discriminant_type(&input_type)?;
+			self.try_register_discriminant_type(input_type)?;
 		}
 
 		// Precompile handle input
@@ -364,7 +364,7 @@ impl Precompile {
 
 			let input_type = input.ty.as_ref();
 
-			if !is_same_type(&input_type, &syn::parse_quote! {&mut impl PrecompileHandle}) {
+			if !is_same_type(input_type, &syn::parse_quote! {&mut impl PrecompileHandle}) {
 				let msg = "This parameter must have type `&mut impl PrecompileHandle`";
 				return Err(syn::Error::new(input_type.span(), msg));
 			}
@@ -376,7 +376,7 @@ impl Precompile {
 	/// Records the type of the discriminant and ensure they all have the same type.
 	fn try_register_discriminant_type(&mut self, ty: &syn::Type) -> syn::Result<()> {
 		if let Some(known_type) = &self.precompile_set_discriminant_type {
-			if !is_same_type(&known_type, &ty) {
+			if !is_same_type(known_type, ty) {
 				let msg = format!(
 					"All discriminants must have the same type (found {} before)",
 					known_type.to_token_stream()
@@ -458,7 +458,7 @@ impl Precompile {
 			_ => return Err(syn::Error::new(result_arguments.args.span(), msg)),
 		};
 
-		self.try_register_discriminant_type(&discriminant_type)?;
+		self.try_register_discriminant_type(discriminant_type)?;
 
 		self.precompile_set_discriminant_fn = Some(method.sig.ident.clone());
 
@@ -560,7 +560,7 @@ ensuring the Solidity function signatures are correct.";
 			| syn::Type::Paren(syn::TypeParen { elem, .. })
 			| syn::Type::Reference(syn::TypeReference { elem, .. })
 			| syn::Type::Ptr(syn::TypePtr { elem, .. })
-			| syn::Type::Slice(syn::TypeSlice { elem, .. }) => self.check_type_parameter_usage(&elem)?,
+			| syn::Type::Slice(syn::TypeSlice { elem, .. }) => self.check_type_parameter_usage(elem)?,
 
 			syn::Type::Path(syn::TypePath {
 				path: syn::Path { segments, .. },
@@ -589,7 +589,7 @@ ensuring the Solidity function signatures are correct.";
 						});
 
 						for ty in types {
-							self.check_type_parameter_usage(&ty)?;
+							self.check_type_parameter_usage(ty)?;
 						}
 					}
 				}

--- a/precompiles/utils/macro/src/precompile/parse.rs
+++ b/precompiles/utils/macro/src/precompile/parse.rs
@@ -531,7 +531,7 @@ impl Precompile {
 			.selector_to_variant
 			.insert(selector, method_name.clone())
 		{
-			let msg = format!("Selector collision with method {}", previous.to_string());
+			let msg = format!("Selector collision with method {}", previous);
 			return Err(syn::Error::new(signature_lit.span(), msg));
 		}
 

--- a/precompiles/utils/macro/src/precompile_name_from_address.rs
+++ b/precompiles/utils/macro/src/precompile_name_from_address.rs
@@ -67,10 +67,10 @@ pub fn main(_: TokenStream, input: TokenStream) -> TokenStream {
 		})
 		.into()
 	} else {
-		return quote_spanned! {
+		quote_spanned! {
 			ty.span() => compile_error!("Expected tuple");
 		}
-		.into();
+		.into()
 	}
 }
 

--- a/precompiles/utils/macro/src/precompile_name_from_address.rs
+++ b/precompiles/utils/macro/src/precompile_name_from_address.rs
@@ -112,7 +112,7 @@ fn extract_precompile_name_and_prefix_for_precompile_at(
 							if let Ok(precompile_id) = int.base10_parse() {
 								if &path_segment_2.ident.to_string() == "CollectivePrecompile" {
 									if let Some(instance_ident) =
-										precompile_instance_ident(&path_segment_2)
+										precompile_instance_ident(path_segment_2)
 									{
 										return Some((instance_ident, precompile_id));
 									}

--- a/precompiles/utils/src/precompile_set.rs
+++ b/precompiles/utils/src/precompile_set.rs
@@ -570,7 +570,7 @@ where
 				Ok(mut recursion_level) => {
 					if *recursion_level > max_recursion_level {
 						return Some(Err(
-							revert("Precompile is called with too high nesting").into()
+							revert("Precompile is called with too high nesting")
 						));
 					}
 
@@ -578,7 +578,7 @@ where
 				}
 				// We don't hold the borrow and are in single-threaded code, thus we should
 				// not be able to fail borrowing in nested calls.
-				Err(_) => return Some(Err(revert("Couldn't check precompile nesting").into())),
+				Err(_) => return Some(Err(revert("Couldn't check precompile nesting"))),
 			}
 		}
 
@@ -599,7 +599,7 @@ where
 				}
 				// We don't hold the borrow and are in single-threaded code, thus we should
 				// not be able to fail borrowing in nested calls.
-				Err(_) => return Some(Err(revert("Couldn't check precompile nesting").into())),
+				Err(_) => return Some(Err(revert("Couldn't check precompile nesting"))),
 			}
 		}
 

--- a/precompiles/utils/src/precompile_set.rs
+++ b/precompiles/utils/src/precompile_set.rs
@@ -1091,7 +1091,7 @@ impl<R: pallet_evm::Config, P: PrecompileSetFragment> PrecompileSetBuilder<R, P>
 			.inner
 			.used_addresses()
 			.into_iter()
-			.map(|x| R::AddressMapping::into_account_id(x))
+			.map(R::AddressMapping::into_account_id)
 	}
 
 	pub fn summarize_checks(&self) -> Vec<PrecompileCheckSummary> {

--- a/precompiles/utils/src/precompile_set.rs
+++ b/precompiles/utils/src/precompile_set.rs
@@ -569,9 +569,7 @@ where
 			match self.current_recursion_level.try_borrow_mut() {
 				Ok(mut recursion_level) => {
 					if *recursion_level > max_recursion_level {
-						return Some(Err(
-							revert("Precompile is called with too high nesting")
-						));
+						return Some(Err(revert("Precompile is called with too high nesting")));
 					}
 
 					*recursion_level += 1;

--- a/precompiles/utils/src/solidity/codec/mod.rs
+++ b/precompiles/utils/src/solidity/codec/mod.rs
@@ -92,7 +92,7 @@ pub fn decode_arguments<T: Codec>(input: &[u8]) -> MayRevert<T> {
 		let input = writer.build();
 		decode(&input)
 	} else {
-		decode(&input)
+		decode(input)
 	}
 }
 

--- a/precompiles/utils/src/solidity/codec/xcm.rs
+++ b/precompiles/utils/src/solidity/codec/xcm.rs
@@ -137,10 +137,10 @@ pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> MayRevert<Option<
 		3 => Ok(Some(NetworkId::Kusama)),
 		4 => {
 			let mut block_number: [u8; 8] = Default::default();
-			block_number.copy_from_slice(&encoded_network_id.read_raw_bytes(8)?);
+			block_number.copy_from_slice(encoded_network_id.read_raw_bytes(8)?);
 
 			let mut block_hash: [u8; 32] = Default::default();
-			block_hash.copy_from_slice(&encoded_network_id.read_raw_bytes(32)?);
+			block_hash.copy_from_slice(encoded_network_id.read_raw_bytes(32)?);
 			Ok(Some(NetworkId::ByFork {
 				block_number: u64::from_be_bytes(block_number),
 				block_hash,
@@ -151,7 +151,7 @@ pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> MayRevert<Option<
 		7 => Ok(Some(NetworkId::Wococo)),
 		8 => {
 			let mut chain_id: [u8; 8] = Default::default();
-			chain_id.copy_from_slice(&encoded_network_id.read_raw_bytes(8)?);
+			chain_id.copy_from_slice(encoded_network_id.read_raw_bytes(8)?);
 			Ok(Some(NetworkId::Ethereum {
 				chain_id: u64::from_be_bytes(chain_id),
 			}))
@@ -185,14 +185,14 @@ impl Codec for Junction {
 			0 => {
 				// In the case of Junction::Parachain, we need 4 additional bytes
 				let mut data: [u8; 4] = Default::default();
-				data.copy_from_slice(&encoded_junction.read_raw_bytes(4)?);
+				data.copy_from_slice(encoded_junction.read_raw_bytes(4)?);
 				let para_id = u32::from_be_bytes(data);
 				Ok(Junction::Parachain(para_id))
 			}
 			1 => {
 				// In the case of Junction::AccountId32, we need 32 additional bytes plus NetworkId
 				let mut account: [u8; 32] = Default::default();
-				account.copy_from_slice(&encoded_junction.read_raw_bytes(32)?);
+				account.copy_from_slice(encoded_junction.read_raw_bytes(32)?);
 
 				let network = encoded_junction.read_till_end()?.to_vec();
 				Ok(Junction::AccountId32 {
@@ -203,7 +203,7 @@ impl Codec for Junction {
 			2 => {
 				// In the case of Junction::AccountIndex64, we need 8 additional bytes plus NetworkId
 				let mut index: [u8; 8] = Default::default();
-				index.copy_from_slice(&encoded_junction.read_raw_bytes(8)?);
+				index.copy_from_slice(encoded_junction.read_raw_bytes(8)?);
 				// Now we read the network
 				let network = encoded_junction.read_till_end()?.to_vec();
 				Ok(Junction::AccountIndex64 {
@@ -214,7 +214,7 @@ impl Codec for Junction {
 			3 => {
 				// In the case of Junction::AccountKey20, we need 20 additional bytes plus NetworkId
 				let mut account: [u8; 20] = Default::default();
-				account.copy_from_slice(&encoded_junction.read_raw_bytes(20)?);
+				account.copy_from_slice(encoded_junction.read_raw_bytes(20)?);
 
 				let network = encoded_junction.read_till_end()?.to_vec();
 				Ok(Junction::AccountKey20 {
@@ -228,7 +228,7 @@ impl Codec for Junction {
 			5 => {
 				// In the case of Junction::GeneralIndex, we need 16 additional bytes
 				let mut general_index: [u8; 16] = Default::default();
-				general_index.copy_from_slice(&encoded_junction.read_raw_bytes(16)?);
+				general_index.copy_from_slice(encoded_junction.read_raw_bytes(16)?);
 				Ok(Junction::GeneralIndex(u128::from_be_bytes(general_index)))
 			}
 			6 => {

--- a/precompiles/utils/src/solidity/codec/xcm.rs
+++ b/precompiles/utils/src/solidity/codec/xcm.rs
@@ -45,7 +45,7 @@ pub const JUNCTION_SIZE_LIMIT: u32 = 2u32.pow(16);
 
 pub(crate) fn network_id_to_bytes(network_id: Option<NetworkId>) -> Vec<u8> {
 	let mut encoded: Vec<u8> = Vec::new();
-	match network_id.clone() {
+	match network_id {
 		None => {
 			encoded.push(0u8);
 			encoded
@@ -335,7 +335,7 @@ impl Codec for Junctions {
 	}
 
 	fn write(writer: &mut Writer, value: Self) {
-		let encoded: Vec<Junction> = value.iter().map(|junction| junction.clone()).collect();
+		let encoded: Vec<Junction> = value.iter().map(|junction| *junction).collect();
 		Codec::write(writer, encoded);
 	}
 

--- a/precompiles/utils/src/substrate.rs
+++ b/precompiles/utils/src/substrate.rs
@@ -117,7 +117,7 @@ where
 		let dispatch_info = call.get_dispatch_info();
 
 		Self::reocrd_external_cost(handle, dispatch_info.weight, storage_growth)
-			.map_err(|e| TryDispatchError::Evm(e))?;
+			.map_err(TryDispatchError::Evm)?;
 
 		// Dispatch call.
 		// It may be possible to not record gas cost if the call returns Pays::No.
@@ -132,7 +132,7 @@ where
 			dispatch_info.weight,
 			post_dispatch_info.actual_weight,
 		)
-		.map_err(|e| TryDispatchError::Evm(e))?;
+		.map_err(TryDispatchError::Evm)?;
 
 		Ok(post_dispatch_info)
 	}

--- a/precompiles/utils/src/testing/execution.rs
+++ b/precompiles/utils/src/testing/execution.rs
@@ -49,7 +49,7 @@ impl<'p, P: PrecompileSet> PrecompilesTester<'p, P> {
 	) -> Self {
 		let to = to.into();
 		let mut handle = MockHandle::new(
-			to.clone(),
+			to,
 			Context {
 				address: to,
 				caller: from.into(),

--- a/precompiles/utils/src/testing/execution.rs
+++ b/precompiles/utils/src/testing/execution.rs
@@ -104,7 +104,7 @@ impl<'p, P: PrecompileSet> PrecompilesTester<'p, P> {
 
 	pub fn expect_log(mut self, log: Log) -> Self {
 		self.expected_logs = Some({
-			let mut logs = self.expected_logs.unwrap_or_else(Vec::new);
+			let mut logs = self.expected_logs.unwrap_or_default();
 			logs.push(PrettyLog(log));
 			logs
 		});

--- a/precompiles/utils/src/testing/modifier.rs
+++ b/precompiles/utils/src/testing/modifier.rs
@@ -32,7 +32,7 @@ impl<P: PrecompileSet> PrecompilesModifierTester<P> {
 	pub fn new(precompiles: P, from: impl Into<H160>, to: impl Into<H160>) -> Self {
 		let to = to.into();
 		let mut handle = MockHandle::new(
-			to.clone(),
+			to,
 			Context {
 				address: to,
 				caller: from.into(),

--- a/precompiles/utils/src/testing/solidity.rs
+++ b/precompiles/utils/src/testing/solidity.rs
@@ -219,7 +219,7 @@ fn get_selectors_from_reader<R: Read>(reader: R) -> Vec<SolidityFunction> {
 					solidity_struct = SolidityStruct::default();
 				}
 				(Stage::StructParams, Pair::First, _) => {
-					let param = try_lookup_custom_type(&word, &custom_types);
+					let param = try_lookup_custom_type(word, &custom_types);
 					solidity_struct.params.push(param);
 					pair.next();
 				}

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -45,7 +45,7 @@ fn u256_repeat_byte(byte: u8) -> U256 {
 fn display_bytes(bytes: &[u8]) {
 	bytes
 		.chunks_exact(32)
-		.map(|chunk| H256::from_slice(chunk))
+		.map(H256::from_slice)
 		.for_each(|hash| println!("{:?}", hash));
 }
 
@@ -573,7 +573,7 @@ fn write_vec_bytes() {
 
 	writer_output
 		.chunks_exact(32)
-		.map(|chunk| H256::from_slice(chunk))
+		.map(H256::from_slice)
 		.for_each(|hash| println!("{:?}", hash));
 
 	// We pad data to a multiple of 32 bytes.
@@ -629,7 +629,7 @@ fn read_vec_of_bytes() {
 
 	writer_output
 		.chunks_exact(32)
-		.map(|chunk| H256::from_slice(chunk))
+		.map(H256::from_slice)
 		.for_each(|hash| println!("{:?}", hash));
 
 	let mut reader = Reader::new(&writer_output);

--- a/precompiles/xcm-transactor/src/functions.rs
+++ b/precompiles/xcm-transactor/src/functions.rs
@@ -86,14 +86,14 @@ where
 				+ RemoteTransactInfoWithMaxWeight::max_encoded_len(),
 		)?;
 		let remote_transact_info: RemoteTransactInfoWithMaxWeight =
-			pallet_xcm_transactor::Pallet::<Runtime>::transact_info(&multilocation)
+			pallet_xcm_transactor::Pallet::<Runtime>::transact_info(multilocation)
 				.ok_or(revert("Transact Info not set"))?;
 
 		// fetch data from pallet
 		// storage item: AssetTypeUnitsPerSecond: Blake2_128(16) + MultiLocation + u128(16)
 		handle.record_db_read::<Runtime>(32 + MultiLocation::max_encoded_len())?;
 		let fee_per_second: u128 =
-			pallet_xcm_transactor::Pallet::<Runtime>::dest_asset_fee_per_second(&multilocation)
+			pallet_xcm_transactor::Pallet::<Runtime>::dest_asset_fee_per_second(multilocation)
 				.ok_or(revert("Fee Per Second not set"))?;
 
 		Ok((

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -66,7 +66,7 @@ impl sp_runtime::traits::Convert<AccountId, MultiLocation> for AccountIdToMultiL
 			0,
 			Junctions::X1(AccountKey20 {
 				network: None,
-				key: as_h160.as_fixed_bytes().clone(),
+				key: *as_h160.as_fixed_bytes(),
 			}),
 		)
 	}
@@ -380,7 +380,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
 					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -188,7 +188,7 @@ impl GasWeightMapping for MockGasWeightMapping {
 		Weight::from_parts(gas, 1)
 	}
 	fn weight_to_gas(weight: Weight) -> u64 {
-		weight.ref_time().into()
+		weight.ref_time()
 	}
 }
 

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -379,8 +379,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 		match self {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
+					let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -425,15 +425,10 @@ impl sp_runtime::traits::Convert<CurrencyId, Option<MultiLocation>> for Currency
 	}
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/xcm-utils/src/lib.rs
+++ b/precompiles/xcm-utils/src/lib.rs
@@ -139,7 +139,7 @@ where
 
 		// We will construct an asset with the max amount, and check how much we
 		// get in return to substract
-		let multiasset: xcm::latest::MultiAsset = (multilocation.clone(), u128::MAX).into();
+		let multiasset: xcm::latest::MultiAsset = (multilocation, u128::MAX).into();
 		let weight_per_second = 1_000_000_000_000u64;
 
 		let mut trader = <XcmConfig as xcm_executor::Config>::Trader::new();

--- a/precompiles/xcm-utils/src/mock.rs
+++ b/precompiles/xcm-utils/src/mock.rs
@@ -449,15 +449,10 @@ impl xcm_executor::Config for XcmConfig {
 	type Aliasers = Nothing;
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/xcm-utils/src/mock.rs
+++ b/precompiles/xcm-utils/src/mock.rs
@@ -133,7 +133,7 @@ impl sp_runtime::traits::Convert<AccountId, MultiLocation> for AccountIdToMultiL
 			0,
 			Junctions::X1(AccountKey20 {
 				network: None,
-				key: as_h160.as_fixed_bytes().clone(),
+				key: *as_h160.as_fixed_bytes(),
 			}),
 		)
 	}
@@ -346,7 +346,7 @@ impl SendXcm for TestSendXcm {
 	) -> SendResult<Self::Ticket> {
 		SENT_XCM.with(|q| {
 			q.borrow_mut()
-				.push((destination.clone().unwrap(), message.clone().unwrap()))
+				.push(((*destination).unwrap(), message.clone().unwrap()))
 		});
 		Ok(((), MultiAssets::new()))
 	}

--- a/precompiles/xcm-utils/src/mock.rs
+++ b/precompiles/xcm-utils/src/mock.rs
@@ -274,7 +274,7 @@ impl GasWeightMapping for MockGasWeightMapping {
 		Weight::from_parts(gas, 1)
 	}
 	fn weight_to_gas(weight: Weight) -> u64 {
-		weight.ref_time().into()
+		weight.ref_time()
 	}
 }
 
@@ -410,7 +410,7 @@ parameter_types! {
 
 	pub UniversalLocation: InteriorMultiLocation = Here;
 	pub Ancestry: InteriorMultiLocation =
-		X2(GlobalConsensus(RelayNetwork::get()), Parachain(ParachainId::get().into()).into());
+		X2(GlobalConsensus(RelayNetwork::get()), Parachain(ParachainId::get().into()));
 
 	pub const MaxAssetsIntoHolding: u32 = 64;
 }

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -243,7 +243,7 @@ where
 
 		let call = orml_xtokens::Call::<Runtime>::transfer_multiasset_with_fee {
 			asset: Box::new(VersionedMultiAsset::V3(MultiAsset {
-				id: AssetId::Concrete(asset.clone()),
+				id: AssetId::Concrete(asset),
 				fun: Fungibility::Fungible(amount),
 			})),
 			fee: Box::new(VersionedMultiAsset::V3(MultiAsset {

--- a/precompiles/xtokens/src/mock.rs
+++ b/precompiles/xtokens/src/mock.rs
@@ -361,7 +361,7 @@ impl sp_runtime::traits::Convert<AccountId, MultiLocation> for AccountIdToMultiL
 			1,
 			Junctions::X1(AccountKey20 {
 				network: None,
-				key: as_h160.as_fixed_bytes().clone(),
+				key: *as_h160.as_fixed_bytes(),
 			}),
 		)
 	}

--- a/precompiles/xtokens/src/mock.rs
+++ b/precompiles/xtokens/src/mock.rs
@@ -411,15 +411,10 @@ impl orml_xtokens::Config for Runtime {
 	type ReserveProvider = AbsoluteReserveProvider;
 }
 
+#[derive(Default)]
 pub(crate) struct ExtBuilder {
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
-}
-
-impl Default for ExtBuilder {
-	fn default() -> ExtBuilder {
-		ExtBuilder { balances: vec![] }
-	}
 }
 
 impl ExtBuilder {

--- a/precompiles/xtokens/src/tests.rs
+++ b/precompiles/xtokens/src/tests.rs
@@ -92,7 +92,7 @@ fn transfer_self_reserve_works() {
 					PCall::transfer {
 						currency_address: Address(SelfReserveAccount.into()),
 						amount: 500.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -139,7 +139,7 @@ fn transfer_to_reserve_works() {
 					PCall::transfer {
 						currency_address: Address(AssetAccount(0u128).into()),
 						amount: 500.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -186,7 +186,7 @@ fn transfer_to_reserve_with_unlimited_weight_works() {
 					PCall::transfer {
 						currency_address: Address(AssetAccount(0u128).into()),
 						amount: 500.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: u64::MAX,
 					},
 				)
@@ -235,7 +235,7 @@ fn transfer_to_reserve_with_fee_works() {
 						currency_address: Address(AssetAccount(0u128).into()),
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -290,7 +290,7 @@ fn transfer_non_reserve_to_non_reserve_works() {
 					PCall::transfer {
 						currency_address: Address(AssetAccount(1u128).into()),
 						amount: 500.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -339,7 +339,7 @@ fn transfer_non_reserve_to_non_reserve_with_fee_works() {
 						currency_address: Address(AssetAccount(1u128).into()),
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -392,9 +392,9 @@ fn transfer_multi_asset_to_reserve_works() {
 					Alice,
 					Precompile1,
 					PCall::transfer_multiasset {
-						asset: asset.clone(),
+						asset: asset,
 						amount: 500.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -440,9 +440,9 @@ fn transfer_multi_asset_self_reserve_works() {
 					Alice,
 					Precompile1,
 					PCall::transfer_multiasset {
-						asset: self_reserve.clone(),
+						asset: self_reserve,
 						amount: 500.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -487,10 +487,10 @@ fn transfer_multi_asset_self_reserve_with_fee_works() {
 					Alice,
 					Precompile1,
 					PCall::transfer_multiasset_with_fee {
-						asset: self_reserve.clone(),
+						asset: self_reserve,
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -499,7 +499,7 @@ fn transfer_multi_asset_self_reserve_with_fee_works() {
 				.execute_returns(());
 
 			let expected_asset: MultiAsset = MultiAsset {
-				id: AssetId::Concrete(self_reserve.clone()),
+				id: AssetId::Concrete(self_reserve),
 				fun: Fungibility::Fungible(500),
 			};
 			let expected_fee: MultiAsset = MultiAsset {
@@ -542,9 +542,9 @@ fn transfer_multi_asset_non_reserve_to_non_reserve() {
 					Alice,
 					Precompile1,
 					PCall::transfer_multiasset {
-						asset: asset_location.clone(),
+						asset: asset_location,
 						amount: 500.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -592,10 +592,10 @@ fn transfer_multi_asset_non_reserve_to_non_reserve_with_fee() {
 					Alice,
 					Precompile1,
 					PCall::transfer_multiasset_with_fee {
-						asset: asset_location.clone(),
+						asset: asset_location,
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -604,7 +604,7 @@ fn transfer_multi_asset_non_reserve_to_non_reserve_with_fee() {
 				.execute_returns(());
 
 			let expected_asset: MultiAsset = MultiAsset {
-				id: AssetId::Concrete(asset_location.clone()),
+				id: AssetId::Concrete(asset_location),
 				fun: Fungibility::Fungible(500),
 			};
 			let expected_fee: MultiAsset = MultiAsset {
@@ -649,7 +649,7 @@ fn transfer_multi_currencies() {
 					PCall::transfer_multi_currencies {
 						currencies: currencies.into(),
 						fee_item: 0,
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -708,12 +708,12 @@ fn transfer_multi_assets() {
 			);
 
 			let assets: Vec<EvmMultiAsset> = vec![
-				(asset_1_location.clone(), U256::from(500)).into(),
-				(asset_2_location.clone(), U256::from(500)).into(),
+				(asset_1_location, U256::from(500)).into(),
+				(asset_2_location, U256::from(500)).into(),
 			];
 
 			let multiassets = MultiAssets::from_sorted_and_deduplicated(vec![
-				(asset_1_location.clone(), 500).into(),
+				(asset_1_location, 500).into(),
 				(asset_2_location, 500).into(),
 			])
 			.unwrap();
@@ -726,7 +726,7 @@ fn transfer_multi_assets() {
 					PCall::transfer_multi_assets {
 						assets: assets.into(),
 						fee_item: 0,
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -775,7 +775,7 @@ fn transfer_multi_currencies_cannot_insert_more_than_max() {
 					PCall::transfer_multi_currencies {
 						currencies: currencies.into(),
 						fee_item: 0,
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -815,9 +815,9 @@ fn transfer_multi_assets_cannot_insert_more_than_max() {
 			);
 
 			let assets: Vec<EvmMultiAsset> = vec![
-				(asset_1_location.clone(), U256::from(500)).into(),
-				(asset_2_location.clone(), U256::from(500)).into(),
-				(asset_3_location.clone(), U256::from(500)).into(),
+				(asset_1_location, U256::from(500)).into(),
+				(asset_2_location, U256::from(500)).into(),
+				(asset_3_location, U256::from(500)).into(),
 			];
 
 			// We are transferring 3 assets, when max is 2
@@ -828,7 +828,7 @@ fn transfer_multi_assets_cannot_insert_more_than_max() {
 					PCall::transfer_multi_assets {
 						assets: assets.into(),
 						fee_item: 0,
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -864,8 +864,8 @@ fn transfer_multi_assets_is_not_sorted_error() {
 			);
 
 			let assets: Vec<EvmMultiAsset> = vec![
-				(asset_1_location.clone(), U256::from(500)).into(),
-				(asset_2_location.clone(), U256::from(500)).into(),
+				(asset_1_location, U256::from(500)).into(),
+				(asset_2_location, U256::from(500)).into(),
 			];
 
 			// We are transferring 3 assets, when max is 2
@@ -876,7 +876,7 @@ fn transfer_multi_assets_is_not_sorted_error() {
 					PCall::transfer_multi_assets {
 						assets: assets.into(),
 						fee_item: 0,
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)

--- a/precompiles/xtokens/src/tests.rs
+++ b/precompiles/xtokens/src/tests.rs
@@ -92,7 +92,7 @@ fn transfer_self_reserve_works() {
 					PCall::transfer {
 						currency_address: Address(SelfReserveAccount.into()),
 						amount: 500.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -139,7 +139,7 @@ fn transfer_to_reserve_works() {
 					PCall::transfer {
 						currency_address: Address(AssetAccount(0u128).into()),
 						amount: 500.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -186,7 +186,7 @@ fn transfer_to_reserve_with_unlimited_weight_works() {
 					PCall::transfer {
 						currency_address: Address(AssetAccount(0u128).into()),
 						amount: 500.into(),
-						destination: destination,
+						destination,
 						weight: u64::MAX,
 					},
 				)
@@ -235,7 +235,7 @@ fn transfer_to_reserve_with_fee_works() {
 						currency_address: Address(AssetAccount(0u128).into()),
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -290,7 +290,7 @@ fn transfer_non_reserve_to_non_reserve_works() {
 					PCall::transfer {
 						currency_address: Address(AssetAccount(1u128).into()),
 						amount: 500.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -339,7 +339,7 @@ fn transfer_non_reserve_to_non_reserve_with_fee_works() {
 						currency_address: Address(AssetAccount(1u128).into()),
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -392,9 +392,9 @@ fn transfer_multi_asset_to_reserve_works() {
 					Alice,
 					Precompile1,
 					PCall::transfer_multiasset {
-						asset: asset,
+						asset,
 						amount: 500.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -442,7 +442,7 @@ fn transfer_multi_asset_self_reserve_works() {
 					PCall::transfer_multiasset {
 						asset: self_reserve,
 						amount: 500.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -490,7 +490,7 @@ fn transfer_multi_asset_self_reserve_with_fee_works() {
 						asset: self_reserve,
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -544,7 +544,7 @@ fn transfer_multi_asset_non_reserve_to_non_reserve() {
 					PCall::transfer_multiasset {
 						asset: asset_location,
 						amount: 500.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -595,7 +595,7 @@ fn transfer_multi_asset_non_reserve_to_non_reserve_with_fee() {
 						asset: asset_location,
 						amount: 500.into(),
 						fee: 50.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -649,7 +649,7 @@ fn transfer_multi_currencies() {
 					PCall::transfer_multi_currencies {
 						currencies: currencies.into(),
 						fee_item: 0,
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -726,7 +726,7 @@ fn transfer_multi_assets() {
 					PCall::transfer_multi_assets {
 						assets: assets.into(),
 						fee_item: 0,
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -775,7 +775,7 @@ fn transfer_multi_currencies_cannot_insert_more_than_max() {
 					PCall::transfer_multi_currencies {
 						currencies: currencies.into(),
 						fee_item: 0,
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -828,7 +828,7 @@ fn transfer_multi_assets_cannot_insert_more_than_max() {
 					PCall::transfer_multi_assets {
 						assets: assets.into(),
 						fee_item: 0,
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -876,7 +876,7 @@ fn transfer_multi_assets_is_not_sorted_error() {
 					PCall::transfer_multi_assets {
 						assets: assets.into(),
 						fee_item: 0,
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)

--- a/primitives/rpc/evm-tracing-events/src/evm.rs
+++ b/primitives/rpc/evm-tracing-events/src/evm.rs
@@ -151,11 +151,7 @@ impl<'a> From<evm::tracing::Event<'a>> for EvmEvent {
 				context,
 			} => Self::Call {
 				code_address,
-				transfer: if let Some(transfer) = transfer {
-					Some(transfer.clone().into())
-				} else {
-					None
-				},
+				transfer: transfer.as_ref().map(|transfer| transfer.clone().into()),
 				input: input.to_vec(),
 				target_gas,
 				is_static,
@@ -242,11 +238,7 @@ impl<'a> From<evm::tracing::Event<'a>> for EvmEvent {
 				context,
 			} => Self::PrecompileSubcall {
 				code_address,
-				transfer: if let Some(transfer) = transfer {
-					Some(transfer.clone().into())
-				} else {
-					None
-				},
+				transfer: transfer.as_ref().map(|transfer| transfer.clone().into()),
 				input: input.to_vec(),
 				target_gas,
 				is_static,

--- a/primitives/rpc/evm-tracing-events/src/runtime.rs
+++ b/primitives/rpc/evm-tracing-events/src/runtime.rs
@@ -94,8 +94,8 @@ pub enum RuntimeEvent {
 
 #[cfg(feature = "evm-tracing")]
 impl RuntimeEvent {
-	pub fn from_evm_event<'a>(
-		i: evm_runtime::tracing::Event<'a>,
+	pub fn from_evm_event(
+		i: evm_runtime::tracing::Event<'_>,
 		filter: crate::StepEventFilter,
 	) -> Self {
 		match i {

--- a/primitives/xcm/src/asset_id_conversions.rs
+++ b/primitives/xcm/src/asset_id_conversions.rs
@@ -35,7 +35,7 @@ where
 	AssetIdInfoGetter: AssetTypeGetter<AssetId, AssetType>,
 {
 	fn convert(id: &MultiLocation) -> Option<AssetId> {
-		AssetIdInfoGetter::get_asset_id(id.clone().into())
+		AssetIdInfoGetter::get_asset_id((*id).into())
 	}
 	fn convert_back(what: &AssetId) -> Option<MultiLocation> {
 		AssetIdInfoGetter::get_asset_type(what.clone()).and_then(Into::into)
@@ -49,7 +49,7 @@ where
 	AssetIdInfoGetter: AssetTypeGetter<AssetId, AssetType>,
 {
 	fn convert_location(id: &MultiLocation) -> Option<AssetId> {
-		AssetIdInfoGetter::get_asset_id(id.clone().into())
+		AssetIdInfoGetter::get_asset_id((*id).into())
 	}
 }
 

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -189,7 +189,7 @@ impl XcmToEthereum for EthereumXcmTransactionV1 {
 					s: rs_id(),
 				}))
 			}
-			_ => return None,
+			_ => None,
 		}
 	}
 }

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -125,7 +125,7 @@ impl XcmToEthereum for EthereumXcmTransactionV1 {
 		let from_tuple_to_access_list = |t: &Vec<(H160, Vec<H256>)>| -> AccessList {
 			t.iter()
 				.map(|item| AccessListItem {
-					address: item.0.clone(),
+					address: item.0,
 					storage_keys: item.1.clone(),
 				})
 				.collect::<Vec<AccessListItem>>()
@@ -203,7 +203,7 @@ impl XcmToEthereum for EthereumXcmTransactionV2 {
 		let from_tuple_to_access_list = |t: &Vec<(H160, Vec<H256>)>| -> AccessList {
 			t.iter()
 				.map(|item| AccessListItem {
-					address: item.0.clone(),
+					address: item.0,
 					storage_keys: item.1.clone(),
 				})
 				.collect::<Vec<AccessListItem>>()
@@ -310,7 +310,7 @@ mod tests {
 		let from_tuple_to_access_list = |t: &Vec<(H160, Vec<H256>)>| -> AccessList {
 			t.iter()
 				.map(|item| AccessListItem {
-					address: item.0.clone(),
+					address: item.0,
 					storage_keys: item.1.clone(),
 				})
 				.collect::<Vec<AccessListItem>>()

--- a/primitives/xcm/src/fee_handlers.rs
+++ b/primitives/xcm/src/fee_handlers.rs
@@ -107,12 +107,12 @@ impl<
 					self.0 = weight;
 					self.1 = Some((id, amount, units_per_second));
 
-					return Ok(unused);
+					Ok(unused)
 				} else {
-					return Err(XcmError::TooExpensive);
-				};
+					Err(XcmError::TooExpensive)
+				}
 			}
-			_ => return Err(XcmError::TooExpensive),
+			_ => Err(XcmError::TooExpensive),
 		}
 	}
 

--- a/primitives/xcm/src/fee_handlers.rs
+++ b/primitives/xcm/src/fee_handlers.rs
@@ -124,11 +124,7 @@ impl<
 			let amount = units_per_second * (weight.ref_time() as u128)
 				/ (WEIGHT_REF_TIME_PER_SECOND as u128);
 			let amount = amount.min(prev_amount);
-			self.1 = Some((
-				id,
-				prev_amount.saturating_sub(amount),
-				units_per_second,
-			));
+			self.1 = Some((id, prev_amount.saturating_sub(amount), units_per_second));
 			Some(MultiAsset {
 				fun: Fungibility::Fungible(amount),
 				id: xcmAssetId::Concrete(id),

--- a/runtime/moonbase/src/asset_config.rs
+++ b/runtime/moonbase/src/asset_config.rs
@@ -326,7 +326,7 @@ impl AccountIdAssetIdConversion<AccountId, AssetId> for Runtime {
 			|| prefix_part == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX
 		{
 			data.copy_from_slice(id_part);
-			let asset_id: AssetId = u128::from_be_bytes(data).into();
+			let asset_id: AssetId = u128::from_be_bytes(data);
 			Some((prefix_part.to_vec(), asset_id))
 		} else {
 			None

--- a/runtime/moonbase/src/governance/tracks.rs
+++ b/runtime/moonbase/src/governance/tracks.rs
@@ -125,7 +125,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 			match system_origin {
 				frame_system::RawOrigin::Root => {
 					if let Some((track_id, _)) = Self::tracks()
-						.into_iter()
+						.iter()
 						.find(|(_, track)| track.name == "root")
 					{
 						Ok(*track_id)
@@ -136,7 +136,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 				_ => Err(()),
 			}
 		} else if let Ok(custom_origin) = custom_origins::Origin::try_from(id.clone()) {
-			if let Some((track_id, _)) = Self::tracks().into_iter().find(|(_, track)| {
+			if let Some((track_id, _)) = Self::tracks().iter().find(|(_, track)| {
 				if let Ok(track_custom_origin) = custom_origins::Origin::from_str(track.name) {
 					track_custom_origin == custom_origin
 				} else {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -719,7 +719,7 @@ impl pallet_parachain_staking::OnInactiveCollator<Runtime> for OnInactiveCollato
 		collator_id: AccountId,
 		round: pallet_parachain_staking::RoundIndex,
 	) -> Result<Weight, DispatchErrorWithPostInfo<PostDispatchInfo>> {
-		let extra_weight = if !MoonbeamOrbiters::is_orbiter(round, collator_id.clone()) {
+		let extra_weight = if !MoonbeamOrbiters::is_orbiter(round, collator_id) {
 			ParachainStaking::go_offline_inner(collator_id)?;
 			<Runtime as pallet_parachain_staking::Config>::WeightInfo::go_offline(
 				pallet_parachain_staking::MAX_CANDIDATES,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1579,7 +1579,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
 			.create_inherent_data()
 			.expect("Could not create the timestamp inherent data");
 
-		inherent_data.check_extrinsics(&block)
+		inherent_data.check_extrinsics(block)
 	}
 }
 

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -293,7 +293,7 @@ impl ExtBuilder {
 			for (asset_id, balances, owner) in local_assets.clone() {
 				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner.into()), asset_id.into(), account, balance)
+					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance)
 						.unwrap();
 				}
 			}

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -293,8 +293,7 @@ impl ExtBuilder {
 			for (asset_id, balances, owner) in local_assets.clone() {
 				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance)
-						.unwrap();
+					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance).unwrap();
 				}
 			}
 			// If any xcm assets specified, we register them here

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -359,7 +359,7 @@ pub fn set_parachain_inherent_data() {
 	};
 	let parachain_inherent_data = ParachainInherentData {
 		validation_data: vfp,
-		relay_chain_state: relay_chain_state,
+		relay_chain_state,
 		downward_messages: Default::default(),
 		horizontal_messages: Default::default(),
 	};

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -791,7 +791,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * UNIT
 								)]
@@ -800,7 +800,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * UNIT
 								)]
@@ -826,7 +826,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 				RuntimeCall::Utility(pallet_utility::Call::<Runtime>::batch {
 					calls: vec![RuntimeCall::CrowdloanRewards(
 						pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
-							rewards: vec![([4u8; 32].into(), Some(AccountId::from(ALICE)), 432000)]
+							rewards: vec![([4u8; 32], Some(AccountId::from(ALICE)), 432000)]
 						}
 					)]
 				})
@@ -1007,7 +1007,7 @@ fn claim_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * UNIT
 								)]
@@ -1016,7 +1016,7 @@ fn claim_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * UNIT
 								)]
@@ -1099,7 +1099,7 @@ fn is_contributor_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * UNIT
 								)]
@@ -1108,7 +1108,7 @@ fn is_contributor_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * UNIT
 								)]
@@ -1181,7 +1181,7 @@ fn reward_info_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * UNIT
 								)]
@@ -1190,7 +1190,7 @@ fn reward_info_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * UNIT
 								)]
@@ -1253,7 +1253,7 @@ fn update_reward_address_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * UNIT
 								)]
@@ -1262,7 +1262,7 @@ fn update_reward_address_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * UNIT
 								)]

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -1710,7 +1710,7 @@ fn xtokens_precompiles_transfer_native() {
 					XtokensPCall::transfer {
 						currency_address: Address(asset_precompile_address),
 						amount: { 500 * UNIT }.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -849,13 +849,13 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 			let per_block = (1_050_000 * UNIT) / vesting_period;
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE))
+				CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * UNIT) + per_block
 			);
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(DAVE))
+				CrowdloanRewards::accounts_payable(AccountId::from(DAVE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * UNIT) + per_block
@@ -972,7 +972,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			));
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(DAVE))
+				CrowdloanRewards::accounts_payable(AccountId::from(DAVE))
 					.unwrap()
 					.claimed_reward,
 				(900_000 * UNIT)
@@ -1064,7 +1064,7 @@ fn claim_via_precompile() {
 			let per_block = (1_050_000 * UNIT) / vesting_period;
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE))
+				CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * UNIT) + per_block
@@ -1303,9 +1303,9 @@ fn update_reward_address_via_precompile() {
 			})
 			.dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::root()));
 
-			assert!(CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE)).is_none());
+			assert!(CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE)).is_none());
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(ALICE))
+				CrowdloanRewards::accounts_payable(AccountId::from(ALICE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * UNIT)
@@ -2327,10 +2327,10 @@ fn transact_through_signed_cannot_send_to_local_chain() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error:")
-						&& from_utf8(&output).unwrap().contains("ErrorValidating")
+						&& from_utf8(output).unwrap().contains("ErrorValidating")
 				});
 		});
 }
@@ -2751,7 +2751,7 @@ fn deal_with_fees_handles_tip() {
 			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
 
 			// treasury should have received 20%
-			assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+			assert_eq!(Balances::free_balance(Treasury::account_id()), 220);
 
 			// verify 80% burned
 			let total_supply_after = Balances::total_issuance();

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -1710,7 +1710,7 @@ fn xtokens_precompiles_transfer_native() {
 					XtokensPCall::transfer {
 						currency_address: Address(asset_precompile_address),
 						amount: { 500 * UNIT }.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -2054,7 +2054,7 @@ fn root_can_change_default_xcm_vers() {
 					origin_of(AccountId::from(ALICE)),
 					moonbase_runtime::xcm_config::CurrencyId::ForeignAsset(source_id),
 					100_000_000_000_000,
-					Box::new(xcm::VersionedMultiLocation::V3(dest.clone())),
+					Box::new(xcm::VersionedMultiLocation::V3(dest)),
 					WeightLimit::Limited(4000000000.into())
 				),
 				orml_xtokens::Error::<Runtime>::XcmExecutionFailed

--- a/runtime/moonbase/tests/xcm_mock/mod.rs
+++ b/runtime/moonbase/tests/xcm_mock/mod.rs
@@ -188,8 +188,8 @@ pub fn statemint_ext(para_id: u32) -> sp_io::TestExternalities {
 
 	pallet_balances::GenesisConfig::<Runtime> {
 		balances: vec![
-			(RELAYALICE.into(), INITIAL_BALANCE),
-			(RELAYBOB.into(), INITIAL_BALANCE),
+			(RELAYALICE, INITIAL_BALANCE),
+			(RELAYBOB, INITIAL_BALANCE),
 		],
 	}
 	.assimilate_storage(&mut t)

--- a/runtime/moonbase/tests/xcm_mock/mod.rs
+++ b/runtime/moonbase/tests/xcm_mock/mod.rs
@@ -187,10 +187,7 @@ pub fn statemint_ext(para_id: u32) -> sp_io::TestExternalities {
 		.unwrap();
 
 	pallet_balances::GenesisConfig::<Runtime> {
-		balances: vec![
-			(RELAYALICE, INITIAL_BALANCE),
-			(RELAYBOB, INITIAL_BALANCE),
-		],
+		balances: vec![(RELAYALICE, INITIAL_BALANCE), (RELAYBOB, INITIAL_BALANCE)],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -1205,7 +1205,7 @@ pub(crate) fn para_events() -> Vec<RuntimeEvent> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| Some(e))
+		.filter_map(Some)
 		.collect::<Vec<_>>()
 }
 

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -1059,8 +1059,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 		match self {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
+					let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}
@@ -1075,10 +1074,9 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 		call: xcm_primitives::HrmpAvailableCalls,
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
-			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a, b, c),
-			)
-			.encode()),
+			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => {
+				Ok(RelayCall::Hrmp(HrmpCall::InitOpenChannel(a, b, c)).encode())
+			}
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -862,14 +862,14 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 
 	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
 		// Mark the asset as destroying
-		Assets::start_destroy(RuntimeOrigin::root(), asset.into())?;
+		Assets::start_destroy(RuntimeOrigin::root(), asset)?;
 
 		Ok(())
 	}
 
 	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
 		// Mark the asset as destroying
-		LocalAssets::start_destroy(RuntimeOrigin::root(), asset.into())?;
+		LocalAssets::start_destroy(RuntimeOrigin::root(), asset)?;
 
 		Ok(())
 	}
@@ -877,7 +877,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
 		RuntimeCall::Assets(
 			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
-				id: asset.into(),
+				id: asset,
 			},
 		)
 		.get_dispatch_info()

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -601,7 +601,7 @@ pub mod mock_msg_queue {
 					let mut id = [0u8; 32];
 					id.copy_from_slice(hash.as_ref());
 					match T::XcmExecutor::execute_xcm(location, xcm, id, max_weight) {
-						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Error(e) => (Err(e), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
 						// As far as the caller is concerned, this was dispatched without error, so
 						// we just report the weight used.
@@ -1060,7 +1060,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
 					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}
@@ -1076,17 +1076,17 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
 			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a.clone(), b.clone(), c.clone()),
+				HrmpCall::InitOpenChannel(a, b, c),
 			)
 			.encode()),
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CancelOpenRequest(a, b) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b)).encode())
 			}
 		}
 	}

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -876,9 +876,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 
 	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
 		RuntimeCall::Assets(
-			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
-				id: asset,
-			},
+			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy { id: asset },
 		)
 		.get_dispatch_info()
 		.weight

--- a/runtime/moonbase/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbase/tests/xcm_mock/relay_chain.rs
@@ -355,7 +355,7 @@ pub(crate) fn relay_events() -> Vec<RuntimeEvent> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| Some(e))
+		.filter_map(Some)
 		.collect::<Vec<_>>()
 }
 

--- a/runtime/moonbase/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbase/tests/xcm_mock/statemint_like.rs
@@ -417,7 +417,7 @@ pub mod mock_msg_queue {
 					let mut id = [0u8; 32];
 					id.copy_from_slice(hash.as_ref());
 					match T::XcmExecutor::execute_xcm(location, xcm, id, max_weight) {
-						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Error(e) => (Err(e), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
 						// As far as the caller is concerned, this was dispatched without error, so
 						// we just report the weight used.

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -2423,10 +2423,7 @@ fn empty_account_should_not_be_reset() {
 			123
 		));
 		// Verify account asset balance is Zero.
-		assert_eq!(
-			parachain::Assets::balance(source_id, &evm_account_id),
-			0
-		);
+		assert_eq!(parachain::Assets::balance(source_id, &evm_account_id), 0);
 		// Because we no longer have consumer references, we can set the balance to Zero.
 		// This would reset the account if our ED were to be > than Zero.
 		assert_ok!(ParaBalances::force_set_balance(
@@ -2870,10 +2867,7 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(
-				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
-					.clone()
-			),
+			Box::new(VersionedMultiLocation::V3(parachain_beneficiary_from_relay).clone()),
 			Box::new((Here, 200).into()),
 			0,
 		));
@@ -2918,10 +2912,7 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 		assert_ok!(StatemintChainPalletXcm::reserve_transfer_assets(
 			statemint_like::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
-			Box::new(
-				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
-					.clone()
-			),
+			Box::new(VersionedMultiLocation::V3(parachain_beneficiary_from_statemint).clone()),
 			Box::new(
 				(
 					X2(

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -78,7 +78,7 @@ fn receive_relay_asset_from_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -134,7 +134,7 @@ fn send_relay_asset_to_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -240,7 +240,7 @@ fn send_relay_asset_to_para_b() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -258,7 +258,7 @@ fn send_relay_asset_to_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -323,7 +323,7 @@ fn send_para_a_asset_to_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -409,7 +409,7 @@ fn send_para_a_asset_from_para_b_to_para_c() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -444,7 +444,7 @@ fn send_para_a_asset_from_para_b_to_para_c() {
 			Parachain(3),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -504,7 +504,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -538,7 +538,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a() {
 			Parachain(1),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -597,7 +597,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a_with_new_reanchoring() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -718,7 +718,7 @@ fn receive_relay_asset_with_trader() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 100).into()),
 			0,
 		));
@@ -768,7 +768,7 @@ fn send_para_a_asset_to_para_b_with_trader() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -843,7 +843,7 @@ fn send_para_a_asset_to_para_b_with_trader_and_fee() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -918,7 +918,7 @@ fn error_when_not_paying_enough() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 5).into()),
 			0,
 		));
@@ -987,7 +987,7 @@ fn transact_through_derivative_multilocation() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1139,7 +1139,7 @@ fn transact_through_derivative_with_custom_fee_weight() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1293,7 +1293,7 @@ fn transact_through_derivative_with_custom_fee_weight_refund() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000009100u128).into()),
 			0,
 		));
@@ -1459,7 +1459,7 @@ fn transact_through_sovereign() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1609,7 +1609,7 @@ fn transact_through_sovereign_with_custom_fee_weight() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1761,7 +1761,7 @@ fn transact_through_sovereign_with_custom_fee_weight_refund() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000009100u128).into()),
 			0,
 		));
@@ -1943,7 +1943,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2063,7 +2063,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_para_b() {
 		));
 		// Wrap version, which sets VersionedStorage
 		assert_ok!(<ParachainPalletXcm as WrapVersion>::wrap_version(
-			&MultiLocation::new(1, X1(Parachain(2))).into(),
+			&MultiLocation::new(1, X1(Parachain(2))),
 			mock_message
 		));
 
@@ -2095,7 +2095,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -2196,7 +2196,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2222,7 +2222,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2274,7 +2274,7 @@ fn receive_assets_with_sufficients_true_allows_non_funded_account_to_receive_ass
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2334,7 +2334,7 @@ fn evm_account_receiving_assets_should_handle_sufficients_ref_count() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2406,7 +2406,7 @@ fn empty_account_should_not_be_reset() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2424,7 +2424,7 @@ fn empty_account_should_not_be_reset() {
 		));
 		// Verify account asset balance is Zero.
 		assert_eq!(
-			parachain::Assets::balance(source_id, &evm_account_id.into()),
+			parachain::Assets::balance(source_id, &evm_account_id),
 			0
 		);
 		// Because we no longer have consumer references, we can set the balance to Zero.
@@ -2531,7 +2531,7 @@ fn test_statemint_like() {
 		assert_ok!(StatemintChainPalletXcm::reserve_transfer_assets(
 			statemint_like::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new(
 				(
 					X2(
@@ -2611,7 +2611,7 @@ fn send_para_a_local_asset_to_para_b() {
 				Parachain(2),
 				AccountKey20 {
 					network: None,
-					key: PARAALICE.into(),
+					key: PARAALICE,
 				},
 			),
 		};
@@ -2716,7 +2716,7 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_dev() {
 				Parachain(2),
 				AccountKey20 {
 					network: None,
-					key: PARAALICE.into(),
+					key: PARAALICE,
 				},
 			),
 		};
@@ -2749,7 +2749,7 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_dev() {
 				Parachain(1),
 				AccountKey20 {
 					network: None,
-					key: PARAALICE.into(),
+					key: PARAALICE,
 				},
 			),
 		};
@@ -2873,7 +2873,6 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 			Box::new(
 				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
 					.clone()
-					.into()
 			),
 			Box::new((Here, 200).into()),
 			0,
@@ -2922,7 +2921,6 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 			Box::new(
 				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
 					.clone()
-					.into()
 			),
 			Box::new(
 				(
@@ -3845,7 +3843,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 	let eth_tx =
 		xcm_primitives::EthereumXcmTransaction::V2(xcm_primitives::EthereumXcmTransactionV2 {
 			gas_limit: U256::from(21000),
-			action: pallet_ethereum::TransactionAction::Call(transfer_recipient.into()),
+			action: pallet_ethereum::TransactionAction::Call(transfer_recipient),
 			value: U256::from(100),
 			input: BoundedVec::<
 				u8,

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -635,7 +635,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a_with_new_reanchoring() {
 	let reanchored_para_a_balances = MultiLocation::new(0, X1(PalletInstance(1u8)));
 
 	let message = xcm::VersionedXcm::<()>::V3(Xcm(vec![
-		WithdrawAsset((reanchored_para_a_balances.clone(), 100).into()),
+		WithdrawAsset((reanchored_para_a_balances, 100).into()),
 		ClearOrigin,
 		BuyExecution {
 			fees: (reanchored_para_a_balances, 100).into(),
@@ -2196,7 +2196,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2274,7 +2274,7 @@ fn receive_assets_with_sufficients_true_allows_non_funded_account_to_receive_ass
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2334,7 +2334,7 @@ fn evm_account_receiving_assets_should_handle_sufficients_ref_count() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2406,7 +2406,7 @@ fn empty_account_should_not_be_reset() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -3305,7 +3305,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3315,7 +3315,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3347,7 +3347,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		// free execution, full amount received
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3414,7 +3414,7 @@ fn transact_through_signed_multilocation_para_to_para_refund() {
 	ParaA::execute_with(|| {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3446,7 +3446,7 @@ fn transact_through_signed_multilocation_para_to_para_refund() {
 		// free execution, full amount received
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000009100u128,
 		));
 		// derived account has all funds
@@ -3517,7 +3517,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3527,7 +3527,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3559,7 +3559,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3645,7 +3645,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3655,7 +3655,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3687,7 +3687,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3769,7 +3769,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3779,7 +3779,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3812,7 +3812,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -325,7 +325,7 @@ impl AccountIdAssetIdConversion<AccountId, AssetId> for Runtime {
 			|| prefix_part == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX
 		{
 			data.copy_from_slice(id_part);
-			let asset_id: AssetId = u128::from_be_bytes(data).into();
+			let asset_id: AssetId = u128::from_be_bytes(data);
 			Some((prefix_part.to_vec(), asset_id))
 		} else {
 			None

--- a/runtime/moonbeam/src/governance/tracks.rs
+++ b/runtime/moonbeam/src/governance/tracks.rs
@@ -125,7 +125,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 			match system_origin {
 				frame_system::RawOrigin::Root => {
 					if let Some((track_id, _)) = Self::tracks()
-						.into_iter()
+						.iter()
 						.find(|(_, track)| track.name == "root")
 					{
 						Ok(*track_id)
@@ -136,7 +136,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 				_ => Err(()),
 			}
 		} else if let Ok(custom_origin) = custom_origins::Origin::try_from(id.clone()) {
-			if let Some((track_id, _)) = Self::tracks().into_iter().find(|(_, track)| {
+			if let Some((track_id, _)) = Self::tracks().iter().find(|(_, track)| {
 				if let Ok(track_custom_origin) = custom_origins::Origin::from_str(track.name) {
 					track_custom_origin == custom_origin
 				} else {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1619,7 +1619,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
 			.create_inherent_data()
 			.expect("Could not create the timestamp inherent data");
 
-		inherent_data.check_extrinsics(&block)
+		inherent_data.check_extrinsics(block)
 	}
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -706,7 +706,7 @@ impl pallet_parachain_staking::OnInactiveCollator<Runtime> for OnInactiveCollato
 		collator_id: AccountId,
 		round: pallet_parachain_staking::RoundIndex,
 	) -> Result<Weight, DispatchErrorWithPostInfo<PostDispatchInfo>> {
-		let extra_weight = if !MoonbeamOrbiters::is_orbiter(round, collator_id.clone()) {
+		let extra_weight = if !MoonbeamOrbiters::is_orbiter(round, collator_id) {
 			ParachainStaking::go_offline_inner(collator_id)?;
 			<Runtime as pallet_parachain_staking::Config>::WeightInfo::go_offline(
 				pallet_parachain_staking::MAX_CANDIDATES,

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -296,7 +296,7 @@ impl ExtBuilder {
 			for (asset_id, balances, owner) in local_assets.clone() {
 				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner.into()), asset_id.into(), account, balance)
+					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance)
 						.unwrap();
 				}
 			}

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -296,8 +296,7 @@ impl ExtBuilder {
 			for (asset_id, balances, owner) in local_assets.clone() {
 				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance)
-						.unwrap();
+					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance).unwrap();
 				}
 			}
 			// If any xcm assets specified, we register them here

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -362,7 +362,7 @@ pub fn set_parachain_inherent_data() {
 	};
 	let parachain_inherent_data = ParachainInherentData {
 		validation_data: vfp,
-		relay_chain_state: relay_chain_state,
+		relay_chain_state,
 		downward_messages: Default::default(),
 		horizontal_messages: Default::default(),
 	};

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -836,11 +836,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 				RuntimeCall::Utility(pallet_utility::Call::<Runtime>::batch {
 					calls: vec![RuntimeCall::CrowdloanRewards(
 						pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
-							rewards: vec![(
-								[4u8; 32],
-								Some(AccountId::from(ALICE)),
-								43_200_000
-							)]
+							rewards: vec![([4u8; 32], Some(AccountId::from(ALICE)), 43_200_000)]
 						}
 					)]
 				})

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -863,13 +863,13 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 			let per_block = (105_000_000 * GLMR) / vesting_period;
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE))
+				CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE))
 					.unwrap()
 					.claimed_reward,
 				(45_000_000 * GLMR) + per_block
 			);
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(DAVE))
+				CrowdloanRewards::accounts_payable(AccountId::from(DAVE))
 					.unwrap()
 					.claimed_reward,
 				(45_000_000 * GLMR) + per_block
@@ -984,7 +984,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			));
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(DAVE))
+				CrowdloanRewards::accounts_payable(AccountId::from(DAVE))
 					.unwrap()
 					.claimed_reward,
 				(900_000 * GLMR)
@@ -1078,7 +1078,7 @@ fn claim_via_precompile() {
 			let per_block = (1_050_000 * GLMR) / vesting_period;
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE))
+				CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * GLMR) + per_block
@@ -1317,9 +1317,9 @@ fn update_reward_address_via_precompile() {
 			})
 			.dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::root()));
 
-			assert!(CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE)).is_none());
+			assert!(CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE)).is_none());
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(ALICE))
+				CrowdloanRewards::accounts_payable(AccountId::from(ALICE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * GLMR)
@@ -2255,10 +2255,10 @@ fn transact_through_signed_cannot_send_to_local_chain() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error:")
-						&& from_utf8(&output).unwrap().contains("ErrorValidating")
+						&& from_utf8(output).unwrap().contains("ErrorValidating")
 				});
 		});
 }
@@ -2382,7 +2382,7 @@ fn call_xtokens_with_fee() {
 			};
 			let source_id: moonbeam_runtime::AssetId = source_location.clone().into();
 
-			let before_balance = Assets::balance(source_id, &AccountId::from(ALICE));
+			let before_balance = Assets::balance(source_id, AccountId::from(ALICE));
 
 			// We are able to transfer with fee
 			assert_ok!(XTokens::transfer_with_fee(
@@ -2394,7 +2394,7 @@ fn call_xtokens_with_fee() {
 				WeightLimit::Limited(4000000000.into())
 			));
 
-			let after_balance = Assets::balance(source_id, &AccountId::from(ALICE));
+			let after_balance = Assets::balance(source_id, AccountId::from(ALICE));
 			// At least these much (plus fees) should have been charged
 			assert_eq!(before_balance - 100_000_000_000_000 - 100, after_balance);
 		});
@@ -2638,7 +2638,7 @@ fn deal_with_fees_handles_tip() {
 			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
 
 			// treasury should have received 20%
-			assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+			assert_eq!(Balances::free_balance(Treasury::account_id()), 220);
 
 			// verify 80% burned
 			let total_supply_after = Balances::total_issuance();

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -1680,7 +1680,7 @@ fn root_can_change_default_xcm_vers() {
 					origin_of(AccountId::from(ALICE)),
 					CurrencyId::ForeignAsset(source_id),
 					100_000_000_000_000,
-					Box::new(xcm::VersionedMultiLocation::V3(dest.clone())),
+					Box::new(xcm::VersionedMultiLocation::V3(dest)),
 					WeightLimit::Limited(4000000000.into())
 				),
 				orml_xtokens::Error::<Runtime>::XcmExecutionFailed
@@ -2010,7 +2010,7 @@ fn xtokens_precompile_transfer() {
 					XtokensPCall::transfer {
 						currency_address: Address(asset_precompile_address.into()),
 						amount: 500_000_000_000_000u128.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -2062,7 +2062,7 @@ fn xtokens_precompile_transfer_multiasset() {
 						// We want to transfer the relay token
 						asset: MultiLocation::parent(),
 						amount: 500_000_000_000_000u128.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -2167,7 +2167,7 @@ fn make_sure_polkadot_xcm_cannot_be_called() {
 			.into();
 			assert_noop!(
 				RuntimeCall::PolkadotXcm(pallet_xcm::Call::<Runtime>::reserve_transfer_assets {
-					dest: Box::new(VersionedMultiLocation::V3(dest.clone())),
+					dest: Box::new(VersionedMultiLocation::V3(dest)),
 					beneficiary: Box::new(VersionedMultiLocation::V3(dest)),
 					assets: Box::new(VersionedMultiAssets::V3(multiassets)),
 					fee_asset_item: 0,
@@ -2390,7 +2390,7 @@ fn call_xtokens_with_fee() {
 				CurrencyId::ForeignAsset(source_id),
 				100_000_000_000_000,
 				100,
-				Box::new(xcm::VersionedMultiLocation::V3(dest.clone())),
+				Box::new(xcm::VersionedMultiLocation::V3(dest)),
 				WeightLimit::Limited(4000000000.into())
 			));
 

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -798,7 +798,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									150_000_000 * GLMR
 								)]
@@ -807,7 +807,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									150_000_000 * GLMR
 								)]
@@ -837,7 +837,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 					calls: vec![RuntimeCall::CrowdloanRewards(
 						pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 							rewards: vec![(
-								[4u8; 32].into(),
+								[4u8; 32],
 								Some(AccountId::from(ALICE)),
 								43_200_000
 							)]
@@ -1019,7 +1019,7 @@ fn claim_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * GLMR
 								)]
@@ -1028,7 +1028,7 @@ fn claim_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * GLMR
 								)]
@@ -1113,7 +1113,7 @@ fn is_contributor_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000_000 * GLMR
 								)]
@@ -1122,7 +1122,7 @@ fn is_contributor_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000_000 * GLMR
 								)]
@@ -1195,7 +1195,7 @@ fn reward_info_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * GLMR
 								)]
@@ -1204,7 +1204,7 @@ fn reward_info_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * GLMR
 								)]
@@ -1267,7 +1267,7 @@ fn update_reward_address_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * GLMR
 								)]
@@ -1276,7 +1276,7 @@ fn update_reward_address_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * GLMR
 								)]

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2010,7 +2010,7 @@ fn xtokens_precompile_transfer() {
 					XtokensPCall::transfer {
 						currency_address: Address(asset_precompile_address.into()),
 						amount: 500_000_000_000_000u128.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)
@@ -2062,7 +2062,7 @@ fn xtokens_precompile_transfer_multiasset() {
 						// We want to transfer the relay token
 						asset: MultiLocation::parent(),
 						amount: 500_000_000_000_000u128.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)

--- a/runtime/moonbeam/tests/xcm_mock/mod.rs
+++ b/runtime/moonbeam/tests/xcm_mock/mod.rs
@@ -188,8 +188,8 @@ pub fn statemint_ext(para_id: u32) -> sp_io::TestExternalities {
 
 	pallet_balances::GenesisConfig::<Runtime> {
 		balances: vec![
-			(RELAYALICE.into(), INITIAL_BALANCE),
-			(RELAYBOB.into(), INITIAL_BALANCE),
+			(RELAYALICE, INITIAL_BALANCE),
+			(RELAYBOB, INITIAL_BALANCE),
 		],
 	}
 	.assimilate_storage(&mut t)

--- a/runtime/moonbeam/tests/xcm_mock/mod.rs
+++ b/runtime/moonbeam/tests/xcm_mock/mod.rs
@@ -187,10 +187,7 @@ pub fn statemint_ext(para_id: u32) -> sp_io::TestExternalities {
 		.unwrap();
 
 	pallet_balances::GenesisConfig::<Runtime> {
-		balances: vec![
-			(RELAYALICE, INITIAL_BALANCE),
-			(RELAYBOB, INITIAL_BALANCE),
-		],
+		balances: vec![(RELAYALICE, INITIAL_BALANCE), (RELAYBOB, INITIAL_BALANCE)],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -857,7 +857,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
 		RuntimeCall::Assets(
 			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
-				id: asset.into(),
+				id: asset,
 			},
 		)
 		.get_dispatch_info()

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -856,9 +856,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 
 	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
 		RuntimeCall::Assets(
-			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
-				id: asset,
-			},
+			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy { id: asset },
 		)
 		.get_dispatch_info()
 		.weight

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -1186,7 +1186,7 @@ pub(crate) fn para_events() -> Vec<RuntimeEvent> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| Some(e))
+		.filter_map(Some)
 		.collect::<Vec<_>>()
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -582,7 +582,7 @@ pub mod mock_msg_queue {
 					let mut id = [0u8; 32];
 					id.copy_from_slice(hash.as_ref());
 					match T::XcmExecutor::execute_xcm(location, xcm, id, max_weight) {
-						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Error(e) => (Err(e), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
 						// As far as the caller is concerned, this was dispatched without error, so
 						// we just report the weight used.
@@ -1040,7 +1040,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
 					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}
@@ -1056,17 +1056,17 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
 			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a.clone(), b.clone(), c.clone()),
+				HrmpCall::InitOpenChannel(a, b, c),
 			)
 			.encode()),
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CancelOpenRequest(a, b) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b)).encode())
 			}
 		}
 	}

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -1039,8 +1039,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 		match self {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
+					let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}
@@ -1055,10 +1054,9 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 		call: xcm_primitives::HrmpAvailableCalls,
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
-			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a, b, c),
-			)
-			.encode()),
+			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => {
+				Ok(RelayCall::Hrmp(HrmpCall::InitOpenChannel(a, b, c)).encode())
+			}
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}

--- a/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
@@ -355,7 +355,7 @@ pub(crate) fn relay_events() -> Vec<RuntimeEvent> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| Some(e))
+		.filter_map(Some)
 		.collect::<Vec<_>>()
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
@@ -417,7 +417,7 @@ pub mod mock_msg_queue {
 					let mut id = [0u8; 32];
 					id.copy_from_slice(hash.as_ref());
 					match T::XcmExecutor::execute_xcm(location, xcm, id, max_weight) {
-						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Error(e) => (Err(e), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
 						// As far as the caller is concerned, this was dispatched without error, so
 						// we just report the weight used.

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -82,7 +82,7 @@ fn receive_relay_asset_from_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -138,7 +138,7 @@ fn send_relay_asset_to_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -242,7 +242,7 @@ fn send_relay_asset_to_para_b() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -260,7 +260,7 @@ fn send_relay_asset_to_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -325,7 +325,7 @@ fn send_para_a_asset_to_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -411,7 +411,7 @@ fn send_para_a_asset_from_para_b_to_para_c() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -445,7 +445,7 @@ fn send_para_a_asset_from_para_b_to_para_c() {
 			Parachain(3),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -505,7 +505,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -540,7 +540,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a() {
 			Parachain(1),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -610,7 +610,7 @@ fn receive_relay_asset_with_trader() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 100).into()),
 			0,
 		));
@@ -660,7 +660,7 @@ fn send_para_a_asset_to_para_b_with_trader() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -735,7 +735,7 @@ fn send_para_a_asset_to_para_b_with_trader_and_fee() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -810,7 +810,7 @@ fn error_when_not_paying_enough() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 5).into()),
 			0,
 		));
@@ -879,7 +879,7 @@ fn transact_through_derivative_multilocation() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1021,7 +1021,7 @@ fn transact_through_derivative_with_custom_fee_weight() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1175,7 +1175,7 @@ fn transact_through_derivative_with_custom_fee_weight_refund() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000009100u128).into()),
 			0,
 		));
@@ -1341,7 +1341,7 @@ fn transact_through_sovereign() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1491,7 +1491,7 @@ fn transact_through_sovereign_with_custom_fee_weight() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1643,7 +1643,7 @@ fn transact_through_sovereign_with_custom_fee_weight_refund() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000009100u128).into()),
 			0,
 		));
@@ -1825,7 +1825,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -1927,7 +1927,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -1953,7 +1953,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2005,7 +2005,7 @@ fn receive_assets_with_sufficients_true_allows_non_funded_account_to_receive_ass
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2065,7 +2065,7 @@ fn evm_account_receiving_assets_should_handle_sufficients_ref_count() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2137,7 +2137,7 @@ fn empty_account_should_not_be_reset() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2155,7 +2155,7 @@ fn empty_account_should_not_be_reset() {
 		));
 		// Verify account asset balance is Zero.
 		assert_eq!(
-			parachain::Assets::balance(source_id, &evm_account_id.into()),
+			parachain::Assets::balance(source_id, &evm_account_id),
 			0
 		);
 		// Because we no longer have consumer references, we can set the balance to Zero.
@@ -2263,7 +2263,7 @@ fn test_statemint_like() {
 		assert_ok!(StatemintChainPalletXcm::reserve_transfer_assets(
 			statemint_like::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new(
 				(
 					X2(
@@ -2342,7 +2342,7 @@ fn send_para_a_local_asset_to_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -2445,7 +2445,7 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_glmr() 
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -2478,7 +2478,7 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_glmr() 
 			Parachain(1),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -2601,7 +2601,6 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 			Box::new(
 				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
 					.clone()
-					.into()
 			),
 			Box::new((Here, 200).into()),
 			0,
@@ -2650,7 +2649,6 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 			Box::new(
 				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
 					.clone()
-					.into()
 			),
 			Box::new(
 				(
@@ -3574,7 +3572,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 	let eth_tx =
 		xcm_primitives::EthereumXcmTransaction::V2(xcm_primitives::EthereumXcmTransactionV2 {
 			gas_limit: U256::from(21000),
-			action: pallet_ethereum::TransactionAction::Call(transfer_recipient.into()),
+			action: pallet_ethereum::TransactionAction::Call(transfer_recipient),
 			value: U256::from(100),
 			input: BoundedVec::<
 				u8,

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -2154,10 +2154,7 @@ fn empty_account_should_not_be_reset() {
 			123
 		));
 		// Verify account asset balance is Zero.
-		assert_eq!(
-			parachain::Assets::balance(source_id, &evm_account_id),
-			0
-		);
+		assert_eq!(parachain::Assets::balance(source_id, &evm_account_id), 0);
 		// Because we no longer have consumer references, we can set the balance to Zero.
 		// This would reset the account if our ED were to be > than Zero.
 		assert_ok!(ParaBalances::force_set_balance(
@@ -2598,10 +2595,7 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(
-				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
-					.clone()
-			),
+			Box::new(VersionedMultiLocation::V3(parachain_beneficiary_from_relay).clone()),
 			Box::new((Here, 200).into()),
 			0,
 		));
@@ -2646,10 +2640,7 @@ fn send_statemint_asset_from_para_a_to_statemint_with_relay_fee() {
 		assert_ok!(StatemintChainPalletXcm::reserve_transfer_assets(
 			statemint_like::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
-			Box::new(
-				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
-					.clone()
-			),
+			Box::new(VersionedMultiLocation::V3(parachain_beneficiary_from_statemint).clone()),
 			Box::new(
 				(
 					X2(

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -1927,7 +1927,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2005,7 +2005,7 @@ fn receive_assets_with_sufficients_true_allows_non_funded_account_to_receive_ass
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2065,7 +2065,7 @@ fn evm_account_receiving_assets_should_handle_sufficients_ref_count() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2137,7 +2137,7 @@ fn empty_account_should_not_be_reset() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -3034,7 +3034,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3044,7 +3044,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3076,7 +3076,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		// free execution, full amount received
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3143,7 +3143,7 @@ fn transact_through_signed_multilocation_para_to_para_refund() {
 	ParaA::execute_with(|| {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3175,7 +3175,7 @@ fn transact_through_signed_multilocation_para_to_para_refund() {
 		// free execution, full amount received
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000009100u128,
 		));
 		// derived account has all funds
@@ -3246,7 +3246,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3256,7 +3256,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3288,7 +3288,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3374,7 +3374,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3384,7 +3384,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3416,7 +3416,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3498,7 +3498,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3508,7 +3508,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3541,7 +3541,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds

--- a/runtime/moonriver/src/asset_config.rs
+++ b/runtime/moonriver/src/asset_config.rs
@@ -326,7 +326,7 @@ impl AccountIdAssetIdConversion<AccountId, AssetId> for Runtime {
 			|| prefix_part == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX
 		{
 			data.copy_from_slice(id_part);
-			let asset_id: AssetId = u128::from_be_bytes(data).into();
+			let asset_id: AssetId = u128::from_be_bytes(data);
 			Some((prefix_part.to_vec(), asset_id))
 		} else {
 			None

--- a/runtime/moonriver/src/governance/tracks.rs
+++ b/runtime/moonriver/src/governance/tracks.rs
@@ -125,7 +125,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 			match system_origin {
 				frame_system::RawOrigin::Root => {
 					if let Some((track_id, _)) = Self::tracks()
-						.into_iter()
+						.iter()
 						.find(|(_, track)| track.name == "root")
 					{
 						Ok(*track_id)
@@ -136,7 +136,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 				_ => Err(()),
 			}
 		} else if let Ok(custom_origin) = custom_origins::Origin::try_from(id.clone()) {
-			if let Some((track_id, _)) = Self::tracks().into_iter().find(|(_, track)| {
+			if let Some((track_id, _)) = Self::tracks().iter().find(|(_, track)| {
 				if let Ok(track_custom_origin) = custom_origins::Origin::from_str(track.name) {
 					track_custom_origin == custom_origin
 				} else {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -708,7 +708,7 @@ impl pallet_parachain_staking::OnInactiveCollator<Runtime> for OnInactiveCollato
 		collator_id: AccountId,
 		round: pallet_parachain_staking::RoundIndex,
 	) -> Result<Weight, DispatchErrorWithPostInfo<PostDispatchInfo>> {
-		let extra_weight = if !MoonbeamOrbiters::is_orbiter(round, collator_id.clone()) {
+		let extra_weight = if !MoonbeamOrbiters::is_orbiter(round, collator_id) {
 			ParachainStaking::go_offline_inner(collator_id)?;
 			<Runtime as pallet_parachain_staking::Config>::WeightInfo::go_offline(
 				pallet_parachain_staking::MAX_CANDIDATES,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1628,7 +1628,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
 			.create_inherent_data()
 			.expect("Could not create the timestamp inherent data");
 
-		inherent_data.check_extrinsics(&block)
+		inherent_data.check_extrinsics(block)
 	}
 }
 

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -303,7 +303,7 @@ impl ExtBuilder {
 			for (asset_id, balances, owner) in local_assets.clone() {
 				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner.into()), asset_id.into(), account, balance)
+					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance)
 						.unwrap();
 				}
 			}

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -369,7 +369,7 @@ pub fn set_parachain_inherent_data() {
 	};
 	let parachain_inherent_data = ParachainInherentData {
 		validation_data: vfp,
-		relay_chain_state: relay_chain_state,
+		relay_chain_state,
 		downward_messages: Default::default(),
 		horizontal_messages: Default::default(),
 	};

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -303,8 +303,7 @@ impl ExtBuilder {
 			for (asset_id, balances, owner) in local_assets.clone() {
 				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance)
-						.unwrap();
+					LocalAssets::mint(origin_of(owner), asset_id.into(), account, balance).unwrap();
 				}
 			}
 			// If any xcm assets specified, we register them here

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -1655,7 +1655,7 @@ fn root_can_change_default_xcm_vers() {
 					origin_of(AccountId::from(ALICE)),
 					CurrencyId::ForeignAsset(source_id),
 					100_000_000_000_000,
-					Box::new(xcm::VersionedMultiLocation::V3(dest.clone())),
+					Box::new(xcm::VersionedMultiLocation::V3(dest)),
 					WeightLimit::Limited(4000000000.into())
 				),
 				orml_xtokens::Error::<Runtime>::XcmExecutionFailed
@@ -1982,7 +1982,7 @@ fn xtokens_precompiles_transfer() {
 					XtokensPCall::transfer {
 						currency_address: Address(asset_precompile_address.into()),
 						amount: 500_000_000_000_000u128.into(),
-						destination: destination.clone(),
+						destination: destination,
 						weight: 4_000_000,
 					},
 				)
@@ -2073,7 +2073,7 @@ fn make_sure_polkadot_xcm_cannot_be_called() {
 			.into();
 			assert_noop!(
 				RuntimeCall::PolkadotXcm(pallet_xcm::Call::<Runtime>::reserve_transfer_assets {
-					dest: Box::new(VersionedMultiLocation::V3(dest.clone())),
+					dest: Box::new(VersionedMultiLocation::V3(dest)),
 					beneficiary: Box::new(VersionedMultiLocation::V3(dest)),
 					assets: Box::new(VersionedMultiAssets::V3(multiassets)),
 					fee_asset_item: 0,
@@ -2296,7 +2296,7 @@ fn call_xtokens_with_fee() {
 				CurrencyId::ForeignAsset(source_id),
 				100_000_000_000_000,
 				100,
-				Box::new(xcm::VersionedMultiLocation::V3(dest.clone())),
+				Box::new(xcm::VersionedMultiLocation::V3(dest)),
 				WeightLimit::Limited(4000000000.into())
 			),);
 

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -780,7 +780,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * MOVR
 								)]
@@ -789,7 +789,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * MOVR
 								)]
@@ -815,7 +815,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 				RuntimeCall::Utility(pallet_utility::Call::<Runtime>::batch {
 					calls: vec![RuntimeCall::CrowdloanRewards(
 						pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
-							rewards: vec![([4u8; 32].into(), Some(AccountId::from(ALICE)), 432000)]
+							rewards: vec![([4u8; 32], Some(AccountId::from(ALICE)), 432000)]
 						}
 					)]
 				})
@@ -995,7 +995,7 @@ fn claim_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * MOVR
 								)]
@@ -1004,7 +1004,7 @@ fn claim_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * MOVR
 								)]
@@ -1089,7 +1089,7 @@ fn is_contributor_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * MOVR
 								)]
@@ -1098,7 +1098,7 @@ fn is_contributor_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * MOVR
 								)]
@@ -1171,7 +1171,7 @@ fn reward_info_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * MOVR
 								)]
@@ -1180,7 +1180,7 @@ fn reward_info_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * MOVR
 								)]
@@ -1243,7 +1243,7 @@ fn update_reward_address_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[4u8; 32].into(),
+									[4u8; 32],
 									Some(AccountId::from(CHARLIE)),
 									1_500_000 * MOVR
 								)]
@@ -1252,7 +1252,7 @@ fn update_reward_address_via_precompile() {
 						RuntimeCall::CrowdloanRewards(
 							pallet_crowdloan_rewards::Call::<Runtime>::initialize_reward_vec {
 								rewards: vec![(
-									[5u8; 32].into(),
+									[5u8; 32],
 									Some(AccountId::from(DAVE)),
 									1_500_000 * MOVR
 								)]

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -1982,7 +1982,7 @@ fn xtokens_precompiles_transfer() {
 					XtokensPCall::transfer {
 						currency_address: Address(asset_precompile_address.into()),
 						amount: 500_000_000_000_000u128.into(),
-						destination: destination,
+						destination,
 						weight: 4_000_000,
 					},
 				)

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -838,13 +838,13 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 			let per_block = (1_050_000 * MOVR) / vesting_period;
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE))
+				CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * MOVR) + per_block
 			);
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(DAVE))
+				CrowdloanRewards::accounts_payable(AccountId::from(DAVE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * MOVR) + per_block
@@ -960,7 +960,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			));
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(DAVE))
+				CrowdloanRewards::accounts_payable(AccountId::from(DAVE))
 					.unwrap()
 					.claimed_reward,
 				(900_000 * MOVR)
@@ -1054,7 +1054,7 @@ fn claim_via_precompile() {
 			let per_block = (1_050_000 * MOVR) / vesting_period;
 
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE))
+				CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * MOVR) + per_block
@@ -1293,9 +1293,9 @@ fn update_reward_address_via_precompile() {
 			})
 			.dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::root()));
 
-			assert!(CrowdloanRewards::accounts_payable(&AccountId::from(CHARLIE)).is_none());
+			assert!(CrowdloanRewards::accounts_payable(AccountId::from(CHARLIE)).is_none());
 			assert_eq!(
-				CrowdloanRewards::accounts_payable(&AccountId::from(ALICE))
+				CrowdloanRewards::accounts_payable(AccountId::from(ALICE))
 					.unwrap()
 					.claimed_reward,
 				(450_000 * MOVR)
@@ -2249,10 +2249,10 @@ fn transact_through_signed_cannot_send_to_local_chain() {
 					},
 				)
 				.execute_reverts(|output| {
-					from_utf8(&output)
+					from_utf8(output)
 						.unwrap()
 						.contains("Dispatched call failed with error:")
-						&& from_utf8(&output).unwrap().contains("ErrorValidating")
+						&& from_utf8(output).unwrap().contains("ErrorValidating")
 				});
 		});
 }
@@ -2288,7 +2288,7 @@ fn call_xtokens_with_fee() {
 			};
 			let source_id: moonriver_runtime::AssetId = source_location.clone().into();
 
-			let before_balance = Assets::balance(source_id, &AccountId::from(ALICE));
+			let before_balance = Assets::balance(source_id, AccountId::from(ALICE));
 
 			// We are able to transfer with fee
 			assert_ok!(XTokens::transfer_with_fee(
@@ -2300,7 +2300,7 @@ fn call_xtokens_with_fee() {
 				WeightLimit::Limited(4000000000.into())
 			),);
 
-			let after_balance = Assets::balance(source_id, &AccountId::from(ALICE));
+			let after_balance = Assets::balance(source_id, AccountId::from(ALICE));
 			// At least these much (plus fees) should have been charged
 			assert_eq!(before_balance - 100_000_000_000_000 - 100, after_balance);
 		});
@@ -2544,7 +2544,7 @@ fn deal_with_fees_handles_tip() {
 			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
 
 			// treasury should have received 20%
-			assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+			assert_eq!(Balances::free_balance(Treasury::account_id()), 220);
 
 			// verify 80% burned
 			let total_supply_after = Balances::total_issuance();

--- a/runtime/moonriver/tests/xcm_mock/mod.rs
+++ b/runtime/moonriver/tests/xcm_mock/mod.rs
@@ -187,10 +187,7 @@ pub fn statemine_ext(para_id: u32) -> sp_io::TestExternalities {
 		.unwrap();
 
 	pallet_balances::GenesisConfig::<Runtime> {
-		balances: vec![
-			(RELAYALICE, INITIAL_BALANCE),
-			(RELAYBOB, INITIAL_BALANCE),
-		],
+		balances: vec![(RELAYALICE, INITIAL_BALANCE), (RELAYBOB, INITIAL_BALANCE)],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/runtime/moonriver/tests/xcm_mock/mod.rs
+++ b/runtime/moonriver/tests/xcm_mock/mod.rs
@@ -188,8 +188,8 @@ pub fn statemine_ext(para_id: u32) -> sp_io::TestExternalities {
 
 	pallet_balances::GenesisConfig::<Runtime> {
 		balances: vec![
-			(RELAYALICE.into(), INITIAL_BALANCE),
-			(RELAYBOB.into(), INITIAL_BALANCE),
+			(RELAYALICE, INITIAL_BALANCE),
+			(RELAYBOB, INITIAL_BALANCE),
 		],
 	}
 	.assimilate_storage(&mut t)

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -595,7 +595,7 @@ pub mod mock_msg_queue {
 					let mut id = [0u8; 32];
 					id.copy_from_slice(hash.as_ref());
 					match T::XcmExecutor::execute_xcm(location, xcm, id, max_weight) {
-						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Error(e) => (Err(e), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
 						// As far as the caller is concerned, this was dispatched without error, so
 						// we just report the weight used.
@@ -1050,7 +1050,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
 					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}
@@ -1066,17 +1066,17 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
 			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a.clone(), b.clone(), c.clone()),
+				HrmpCall::InitOpenChannel(a, b, c),
 			)
 			.encode()),
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CancelOpenRequest(a, b) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b)).encode())
 			}
 		}
 	}

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -1049,8 +1049,7 @@ impl xcm_primitives::UtilityEncodeCall for MockTransactors {
 		match self {
 			MockTransactors::Relay => match call {
 				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
+					let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 					call.append(&mut b.clone());
 					call
 				}
@@ -1065,10 +1064,9 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 		call: xcm_primitives::HrmpAvailableCalls,
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
-			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a, b, c),
-			)
-			.encode()),
+			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => {
+				Ok(RelayCall::Hrmp(HrmpCall::InitOpenChannel(a, b, c)).encode())
+			}
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -1198,7 +1198,7 @@ pub(crate) fn para_events() -> Vec<RuntimeEvent> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| Some(e))
+		.filter_map(Some)
 		.collect::<Vec<_>>()
 }
 

--- a/runtime/moonriver/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonriver/tests/xcm_mock/relay_chain.rs
@@ -355,7 +355,7 @@ pub(crate) fn relay_events() -> Vec<RuntimeEvent> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| Some(e))
+		.filter_map(Some)
 		.collect::<Vec<_>>()
 }
 

--- a/runtime/moonriver/tests/xcm_mock/statemine_like.rs
+++ b/runtime/moonriver/tests/xcm_mock/statemine_like.rs
@@ -417,7 +417,7 @@ pub mod mock_msg_queue {
 					let mut id = [0u8; 32];
 					id.copy_from_slice(hash.as_ref());
 					match T::XcmExecutor::execute_xcm(location, xcm, id, max_weight) {
-						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Error(e) => (Err(e), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
 						// As far as the caller is concerned, this was dispatched without error, so
 						// we just report the weight used.

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -636,7 +636,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a_with_new_reanchoring() {
 	let reanchored_para_a_balances = MultiLocation::new(0, X1(PalletInstance(1u8)));
 
 	let message = xcm::VersionedXcm::<()>::V3(Xcm(vec![
-		WithdrawAsset((reanchored_para_a_balances.clone(), 100).into()),
+		WithdrawAsset((reanchored_para_a_balances, 100).into()),
 		ClearOrigin,
 		BuyExecution {
 			fees: (reanchored_para_a_balances, 100).into(),
@@ -679,7 +679,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a_with_new_reanchoring() {
 	let reanchored_para_a_balances = MultiLocation::new(0, X1(PalletInstance(1u8)));
 
 	let message = xcm::VersionedXcm::<()>::V3(Xcm(vec![
-		WithdrawAsset((reanchored_para_a_balances.clone(), 100).into()),
+		WithdrawAsset((reanchored_para_a_balances, 100).into()),
 		ClearOrigin,
 		BuyExecution {
 			fees: (reanchored_para_a_balances, 100).into(),
@@ -2230,7 +2230,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2308,7 +2308,7 @@ fn receive_assets_with_sufficients_true_allows_non_funded_account_to_receive_ass
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2368,7 +2368,7 @@ fn evm_account_receiving_assets_should_handle_sufficients_ref_count() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2440,7 +2440,7 @@ fn empty_account_should_not_be_reset() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest.clone()).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -3340,7 +3340,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3350,7 +3350,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3382,7 +3382,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 		// free execution, full amount received
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3449,7 +3449,7 @@ fn transact_through_signed_multilocation_para_to_para_refund() {
 	ParaA::execute_with(|| {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3481,7 +3481,7 @@ fn transact_through_signed_multilocation_para_to_para_refund() {
 		// free execution, full amount received
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000009100u128,
 		));
 		// derived account has all funds
@@ -3552,7 +3552,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3562,7 +3562,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3594,7 +3594,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3680,7 +3680,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3690,7 +3690,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3722,7 +3722,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds
@@ -3804,7 +3804,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 		assert_ok!(XcmTransactor::set_transact_info(
 			parachain::RuntimeOrigin::root(),
 			// ParaB
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_location.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_location)),
 			// Para charges 1000 for every instruction, and we have 3, so 3
 			3.into(),
 			20000000000.into(),
@@ -3814,7 +3814,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 		// Root can set transact info
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
-			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances.clone())),
+			Box::new(xcm::VersionedMultiLocation::V3(para_b_balances)),
 			parachain::ParaTokensPerSecond::get().1 as u128,
 		));
 		ancestry = parachain::UniversalLocation::get().into();
@@ -3847,7 +3847,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 	ParaB::execute_with(|| {
 		assert_ok!(ParaBalances::transfer(
 			parachain::RuntimeOrigin::signed(PARAALICE.into()),
-			derived.clone(),
+			derived,
 			4000000104u128,
 		));
 		// derived account has all funds

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -2457,10 +2457,7 @@ fn empty_account_should_not_be_reset() {
 			123
 		));
 		// Verify account asset balance is Zero.
-		assert_eq!(
-			parachain::Assets::balance(source_id, &evm_account_id),
-			0
-		);
+		assert_eq!(parachain::Assets::balance(source_id, &evm_account_id), 0);
 		// Because we no longer have consumer references, we can set the balance to Zero.
 		// This would reset the account if our ED were to be > than Zero.
 		assert_ok!(ParaBalances::force_set_balance(
@@ -2904,10 +2901,7 @@ fn send_statemint_asset_from_para_a_to_statemine_with_relay_fee() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(
-				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
-					.clone()
-			),
+			Box::new(VersionedMultiLocation::V3(parachain_beneficiary_from_relay).clone()),
 			Box::new((Here, 200).into()),
 			0,
 		));
@@ -2952,10 +2946,7 @@ fn send_statemint_asset_from_para_a_to_statemine_with_relay_fee() {
 		assert_ok!(StatemineChainPalletXcm::reserve_transfer_assets(
 			statemine_like::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
-			Box::new(
-				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
-					.clone()
-			),
+			Box::new(VersionedMultiLocation::V3(parachain_beneficiary_from_statemint).clone()),
 			Box::new(
 				(
 					X2(

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -80,7 +80,7 @@ fn receive_relay_asset_from_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -136,7 +136,7 @@ fn send_relay_asset_to_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -240,7 +240,7 @@ fn send_relay_asset_to_para_b() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -257,7 +257,7 @@ fn send_relay_asset_to_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -322,7 +322,7 @@ fn send_para_a_asset_to_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -409,7 +409,7 @@ fn send_para_a_asset_from_para_b_to_para_c() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -443,7 +443,7 @@ fn send_para_a_asset_from_para_b_to_para_c() {
 			Parachain(3),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -504,7 +504,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -538,7 +538,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a() {
 			Parachain(1),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -598,7 +598,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a_with_new_reanchoring() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -762,7 +762,7 @@ fn receive_relay_asset_with_trader() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 100).into()),
 			0,
 		));
@@ -812,7 +812,7 @@ fn send_para_a_asset_to_para_b_with_trader() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -887,7 +887,7 @@ fn send_para_a_asset_to_para_b_with_trader_and_fee() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -962,7 +962,7 @@ fn error_when_not_paying_enough() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 5).into()),
 			0,
 		));
@@ -1031,7 +1031,7 @@ fn transact_through_derivative_multilocation() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1173,7 +1173,7 @@ fn transact_through_derivative_with_custom_fee_weight() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1327,7 +1327,7 @@ fn transact_through_derivative_with_custom_fee_weight_refund() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000009100u128).into()),
 			0,
 		));
@@ -1493,7 +1493,7 @@ fn transact_through_sovereign() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1643,7 +1643,7 @@ fn transact_through_sovereign_with_custom_fee_weight() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000003100u128).into()),
 			0,
 		));
@@ -1795,7 +1795,7 @@ fn transact_through_sovereign_with_custom_fee_weight_refund() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 4000009100u128).into()),
 			0,
 		));
@@ -1977,7 +1977,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_relay() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2097,7 +2097,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_para_b() {
 		));
 		// Wrap version, which sets VersionedStorage
 		assert_ok!(<ParachainPalletXcm as WrapVersion>::wrap_version(
-			&MultiLocation::new(1, X1(Parachain(2))).into(),
+			&MultiLocation::new(1, X1(Parachain(2))),
 			mock_message
 		));
 
@@ -2129,7 +2129,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_para_b() {
 			Parachain(2),
 			AccountKey20 {
 				network: None,
-				key: PARAALICE.into(),
+				key: PARAALICE,
 			},
 		),
 	};
@@ -2230,7 +2230,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2256,7 +2256,7 @@ fn receive_asset_with_no_sufficients_not_possible_if_non_existent_account() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2308,7 +2308,7 @@ fn receive_assets_with_sufficients_true_allows_non_funded_account_to_receive_ass
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2368,7 +2368,7 @@ fn evm_account_receiving_assets_should_handle_sufficients_ref_count() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2440,7 +2440,7 @@ fn empty_account_should_not_be_reset() {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
 			relay_chain::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(Parachain(1).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new((Here, 123).into()),
 			0,
 		));
@@ -2458,7 +2458,7 @@ fn empty_account_should_not_be_reset() {
 		));
 		// Verify account asset balance is Zero.
 		assert_eq!(
-			parachain::Assets::balance(source_id, &evm_account_id.into()),
+			parachain::Assets::balance(source_id, &evm_account_id),
 			0
 		);
 		// Because we no longer have consumer references, we can set the balance to Zero.
@@ -2565,7 +2565,7 @@ fn test_statemine_like() {
 		assert_ok!(StatemineChainPalletXcm::reserve_transfer_assets(
 			statemine_like::RuntimeOrigin::signed(RELAYALICE),
 			Box::new(MultiLocation::new(1, X1(Parachain(1))).into()),
-			Box::new(VersionedMultiLocation::V3(dest).clone().into()),
+			Box::new(VersionedMultiLocation::V3(dest).clone()),
 			Box::new(
 				(
 					X2(
@@ -2645,7 +2645,7 @@ fn send_para_a_local_asset_to_para_b() {
 				Parachain(2),
 				AccountKey20 {
 					network: None,
-					key: PARAALICE.into(),
+					key: PARAALICE,
 				},
 			),
 		};
@@ -2750,7 +2750,7 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_dev() {
 				Parachain(2),
 				AccountKey20 {
 					network: None,
-					key: PARAALICE.into(),
+					key: PARAALICE,
 				},
 			),
 		};
@@ -2783,7 +2783,7 @@ fn send_para_a_local_asset_to_para_b_and_send_it_back_together_with_some_dev() {
 				Parachain(1),
 				AccountKey20 {
 					network: None,
-					key: PARAALICE.into(),
+					key: PARAALICE,
 				},
 			),
 		};
@@ -2907,7 +2907,6 @@ fn send_statemint_asset_from_para_a_to_statemine_with_relay_fee() {
 			Box::new(
 				VersionedMultiLocation::V3(parachain_beneficiary_from_relay)
 					.clone()
-					.into()
 			),
 			Box::new((Here, 200).into()),
 			0,
@@ -2956,7 +2955,6 @@ fn send_statemint_asset_from_para_a_to_statemine_with_relay_fee() {
 			Box::new(
 				VersionedMultiLocation::V3(parachain_beneficiary_from_statemint)
 					.clone()
-					.into()
 			),
 			Box::new(
 				(
@@ -3880,7 +3878,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 	let eth_tx =
 		xcm_primitives::EthereumXcmTransaction::V2(xcm_primitives::EthereumXcmTransactionV2 {
 			gas_limit: U256::from(21000),
-			action: pallet_ethereum::TransactionAction::Call(transfer_recipient.into()),
+			action: pallet_ethereum::TransactionAction::Call(transfer_recipient),
 			value: U256::from(100),
 			input: BoundedVec::<
 				u8,

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -148,7 +148,7 @@ impl pallet_evm_precompile_relay_encoder::StakeEncodeCall for KusamaEncoder {
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::SetPayee(a) => {
-				RelayCall::Stake(StakeCall::SetPayee(a.into())).encode()
+				RelayCall::Stake(StakeCall::SetPayee(a)).encode()
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::SetController => {
@@ -156,7 +156,7 @@ impl pallet_evm_precompile_relay_encoder::StakeEncodeCall for KusamaEncoder {
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Rebond(a) => {
-				RelayCall::Stake(StakeCall::Rebond(a.into())).encode()
+				RelayCall::Stake(StakeCall::Rebond(a)).encode()
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Nominate(a) => {
@@ -355,7 +355,7 @@ mod tests {
 		assert_eq!(
 			<KusamaEncoder as StakeEncodeCall>::encode_call(
 				pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Nominate(vec![
-					relay_account.into()
+					relay_account
 				])
 			),
 			expected_encoded
@@ -477,8 +477,8 @@ mod tests {
 			<KusamaEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
 				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(
 					1000u32.into(),
-					100u32.into(),
-					100u32.into()
+					100u32,
+					100u32
 				)
 			),
 			Ok(expected_encoded)

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -104,10 +104,9 @@ impl xcm_primitives::HrmpEncodeCall for KusamaEncoder {
 		call: xcm_primitives::HrmpAvailableCalls,
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
-			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a, b, c),
-			)
-			.encode()),
+			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => {
+				Ok(RelayCall::Hrmp(HrmpCall::InitOpenChannel(a, b, c)).encode())
+			}
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -89,7 +89,7 @@ impl xcm_primitives::UtilityEncodeCall for KusamaEncoder {
 	fn encode_call(self, call: xcm_primitives::UtilityAvailableCalls) -> Vec<u8> {
 		match call {
 			xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-				let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+				let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 				// If we encode directly we inject the call length,
 				// so we just append the inner call after encoding the outer
 				call.append(&mut b.clone());
@@ -105,17 +105,17 @@ impl xcm_primitives::HrmpEncodeCall for KusamaEncoder {
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
 			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a.clone(), b.clone(), c.clone()),
+				HrmpCall::InitOpenChannel(a, b, c),
 			)
 			.encode()),
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CancelOpenRequest(a, b) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b)).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -475,11 +475,7 @@ mod tests {
 
 		assert_eq!(
 			<KusamaEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
-				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(
-					1000u32.into(),
-					100u32,
-					100u32
-				)
+				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(1000u32.into(), 100u32, 100u32)
 			),
 			Ok(expected_encoded)
 		);

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -90,7 +90,7 @@ impl xcm_primitives::UtilityEncodeCall for PolkadotEncoder {
 	fn encode_call(self, call: xcm_primitives::UtilityAvailableCalls) -> Vec<u8> {
 		match call {
 			xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-				let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+				let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 				// If we encode directly we inject the call length,
 				// so we just append the inner call after encoding the outer
 				call.append(&mut b.clone());
@@ -106,17 +106,17 @@ impl xcm_primitives::HrmpEncodeCall for PolkadotEncoder {
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
 			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a.clone(), b.clone(), c.clone()),
+				HrmpCall::InitOpenChannel(a, b, c),
 			)
 			.encode()),
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CancelOpenRequest(a, b) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b)).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -105,10 +105,9 @@ impl xcm_primitives::HrmpEncodeCall for PolkadotEncoder {
 		call: xcm_primitives::HrmpAvailableCalls,
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
-			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a, b, c),
-			)
-			.encode()),
+			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => {
+				Ok(RelayCall::Hrmp(HrmpCall::InitOpenChannel(a, b, c)).encode())
+			}
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -476,11 +476,7 @@ mod tests {
 
 		assert_eq!(
 			<PolkadotEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
-				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(
-					1000u32.into(),
-					100u32,
-					100u32
-				)
+				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(1000u32.into(), 100u32, 100u32)
 			),
 			Ok(expected_encoded)
 		);

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -149,7 +149,7 @@ impl pallet_evm_precompile_relay_encoder::StakeEncodeCall for PolkadotEncoder {
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::SetPayee(a) => {
-				RelayCall::Stake(StakeCall::SetPayee(a.into())).encode()
+				RelayCall::Stake(StakeCall::SetPayee(a)).encode()
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::SetController => {
@@ -157,7 +157,7 @@ impl pallet_evm_precompile_relay_encoder::StakeEncodeCall for PolkadotEncoder {
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Rebond(a) => {
-				RelayCall::Stake(StakeCall::Rebond(a.into())).encode()
+				RelayCall::Stake(StakeCall::Rebond(a)).encode()
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Nominate(a) => {
@@ -356,7 +356,7 @@ mod tests {
 		assert_eq!(
 			<PolkadotEncoder as StakeEncodeCall>::encode_call(
 				pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Nominate(vec![
-					relay_account.into()
+					relay_account
 				])
 			),
 			expected_encoded
@@ -478,8 +478,8 @@ mod tests {
 			<PolkadotEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
 				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(
 					1000u32.into(),
-					100u32.into(),
-					100u32.into()
+					100u32,
+					100u32
 				)
 			),
 			Ok(expected_encoded)

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -475,11 +475,7 @@ mod tests {
 
 		assert_eq!(
 			<WestendEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
-				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(
-					1000u32.into(),
-					100u32,
-					100u32
-				)
+				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(1000u32.into(), 100u32, 100u32)
 			),
 			Ok(expected_encoded)
 		);

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -105,10 +105,9 @@ impl xcm_primitives::HrmpEncodeCall for WestendEncoder {
 		call: xcm_primitives::HrmpAvailableCalls,
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
-			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a, b, c),
-			)
-			.encode()),
+			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => {
+				Ok(RelayCall::Hrmp(HrmpCall::InitOpenChannel(a, b, c)).encode())
+			}
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -148,7 +148,7 @@ impl pallet_evm_precompile_relay_encoder::StakeEncodeCall for WestendEncoder {
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::SetPayee(a) => {
-				RelayCall::Stake(StakeCall::SetPayee(a.into())).encode()
+				RelayCall::Stake(StakeCall::SetPayee(a)).encode()
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::SetController => {
@@ -156,7 +156,7 @@ impl pallet_evm_precompile_relay_encoder::StakeEncodeCall for WestendEncoder {
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Rebond(a) => {
-				RelayCall::Stake(StakeCall::Rebond(a.into())).encode()
+				RelayCall::Stake(StakeCall::Rebond(a)).encode()
 			}
 
 			pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Nominate(a) => {
@@ -355,7 +355,7 @@ mod tests {
 		assert_eq!(
 			<WestendEncoder as StakeEncodeCall>::encode_call(
 				pallet_evm_precompile_relay_encoder::AvailableStakeCalls::Nominate(vec![
-					relay_account.into()
+					relay_account
 				])
 			),
 			expected_encoded
@@ -477,8 +477,8 @@ mod tests {
 			<WestendEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
 				xcm_primitives::HrmpAvailableCalls::InitOpenChannel(
 					1000u32.into(),
-					100u32.into(),
-					100u32.into()
+					100u32,
+					100u32
 				)
 			),
 			Ok(expected_encoded)

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -90,7 +90,7 @@ impl xcm_primitives::UtilityEncodeCall for WestendEncoder {
 	fn encode_call(self, call: xcm_primitives::UtilityAvailableCalls) -> Vec<u8> {
 		match call {
 			xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-				let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+				let mut call = RelayCall::Utility(UtilityCall::AsDerivative(a)).encode();
 				// If we encode directly we inject the call length,
 				// so we just append the inner call after encoding the outer
 				call.append(&mut b.clone());
@@ -106,17 +106,17 @@ impl xcm_primitives::HrmpEncodeCall for WestendEncoder {
 	) -> Result<Vec<u8>, xcm::latest::Error> {
 		match call {
 			xcm_primitives::HrmpAvailableCalls::InitOpenChannel(a, b, c) => Ok(RelayCall::Hrmp(
-				HrmpCall::InitOpenChannel(a.clone(), b.clone(), c.clone()),
+				HrmpCall::InitOpenChannel(a, b, c),
 			)
 			.encode()),
 			xcm_primitives::HrmpAvailableCalls::AcceptOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::AcceptOpenChannel(a)).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
 			xcm_primitives::HrmpAvailableCalls::CancelOpenRequest(a, b) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b.clone())).encode())
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenRequest(a.clone(), b)).encode())
 			}
 		}
 	}


### PR DESCRIPTION
### What does it do?

Removes
- redundant `clone()` calls
- needless borrows
- redundant field names in struct initialization
- useless conversions
- needless returns
- redundant closures
- needless lifetime
- derivable impls
- redundant to_string in format args
- manual map

Replaces
- `unwrap_or_else` with `unwrap_or_default`
- `into_iter` with `iter`