### PR TITLE
build release runtime with production profile

### DIFF
--- a/scripts/build-runtime-srtool.sh
+++ b/scripts/build-runtime-srtool.sh
@@ -13,6 +13,7 @@ CMD="docker run \
   -e CARGO_NET_GIT_FETCH_WITH_CLI=true \
   -e PACKAGE=${GH_WORKFLOW_MATRIX_CHAIN}-runtime \
   -e RUNTIME_DIR=runtime/${GH_WORKFLOW_MATRIX_CHAIN} \
+  -e PROFILE=production
   -v ${PWD}:/build \
   -v /home/${USER}/srtool/.ssh:/home/builder/.ssh \
   -v /home/${USER}/srtool/entrypoint.sh:/srtool/entrypoint.sh \

--- a/scripts/build-runtime-srtool.sh
+++ b/scripts/build-runtime-srtool.sh
@@ -13,7 +13,7 @@ CMD="docker run \
   -e CARGO_NET_GIT_FETCH_WITH_CLI=true \
   -e PACKAGE=${GH_WORKFLOW_MATRIX_CHAIN}-runtime \
   -e RUNTIME_DIR=runtime/${GH_WORKFLOW_MATRIX_CHAIN} \
-  -e PROFILE=production
+  -e PROFILE=production \
   -v ${PWD}:/build \
   -v /home/${USER}/srtool/.ssh:/home/builder/.ssh \
   -v /home/${USER}/srtool/entrypoint.sh:/srtool/entrypoint.sh \


### PR DESCRIPTION
### What does it do?

We now generate the weights with the production profile, so we need to build the release runtime with the same profile (see https://github.com/paritytech/polkadot-sdk/issues/2111)


### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
