### PR TITLE
[Moonriver] Use proper weigher for XCM Transactor pallet

### DIFF
--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -643,7 +643,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmSender = XcmRouter;
 	type SelfLocation = SelfLocation;
-	type Weigher = xcm_builder::FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type Weigher = XcmWeigher;
 	type UniversalLocation = UniversalLocation;
 	type BaseXcmWeight = BaseXcmWeight;
 	type AssetTransactor = AssetTransactors;


### PR DESCRIPTION
### What does it do?

Modifies the `Weigher` config of `pallet-xcm-transactor` inside _Moonriver_ for it to use the proper benchmarked weights for XCM instructions.
