### PR TITLE
Migrate pallets old versions 

### DIFF
--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -20,8 +20,9 @@
 //! the "Migration" trait declared in the pallet-migrations crate.
 
 use frame_support::{
+	ensure,
 	pallet_prelude::GetStorageVersion,
-	traits::{Hash as PreimageHash, OnRuntimeUpgrade, PalletInfoAccess},
+	traits::{Hash as PreimageHash, OnRuntimeUpgrade, PalletInfoAccess, StorageVersion},
 	weights::Weight,
 };
 use pallet_author_slot_filter::Config as AuthorSlotFilterConfig;
@@ -154,19 +155,79 @@ where
 	}
 }
 
-pub struct ReferendaMigrations<Runtime, Council, Tech>(PhantomData<(Runtime, Council, Tech)>);
-
-impl<Runtime, Council, Tech> GetMigrations for ReferendaMigrations<Runtime, Council, Tech>
+pub struct MissingBalancesMigrations<T>(PhantomData<T>);
+impl<T> Migration for MissingBalancesMigrations<T>
 where
-	Runtime: pallet_author_mapping::Config,
-	Runtime: pallet_parachain_staking::Config,
-	Runtime: pallet_scheduler::Config<Hash = PreimageHash>,
-	Runtime: AuthorSlotFilterConfig,
-	Council: GetStorageVersion + PalletInfoAccess + 'static,
-	Tech: GetStorageVersion + PalletInfoAccess + 'static,
-	Runtime: pallet_democracy::Config<Hash = PreimageHash>,
-	Runtime: pallet_preimage::Config<Hash = PreimageHash>,
+	T: pallet_balances::Config,
+	<T as frame_system::Config>::AccountId: Default,
+{
+	fn friendly_name(&self) -> &str {
+		"MM_MissingBalancesMigrations"
+	}
+
+	fn migrate(&self, _available_weight: Weight) -> Weight {
+		pallet_balances::migration::MigrateToTrackInactive::<T, ()>::on_runtime_upgrade();
+		pallet_balances::migration::ResetInactive::<T, ()>::on_runtime_upgrade();
+		pallet_balances::migration::MigrateToTrackInactive::<T, ()>::on_runtime_upgrade()
+	}
+}
+
+pub struct FixIncorrectPalletVersions<Runtime, Treasury, OpenTech>(
+	pub PhantomData<(Runtime, Treasury, OpenTech)>,
+);
+impl<Runtime, Treasury, OpenTech> Migration
+	for FixIncorrectPalletVersions<Runtime, Treasury, OpenTech>
+where
+	Treasury: GetStorageVersion + PalletInfoAccess,
+	OpenTech: GetStorageVersion + PalletInfoAccess,
+	Runtime: frame_system::Config,
 	Runtime: pallet_referenda::Config,
+{
+	fn friendly_name(&self) -> &str {
+		"MM_SetCollectivePalletVersions"
+	}
+
+	fn migrate(&self, _available_weight: Weight) -> Weight {
+		log::info!("Setting collective pallet versions to 4");
+		StorageVersion::new(4).put::<Treasury>();
+		StorageVersion::new(4).put::<OpenTech>();
+		log::info!("Setting referenda pallet version to 1");
+		StorageVersion::new(1).put::<pallet_referenda::Pallet<Runtime>>();
+		Runtime::DbWeight::get().writes(2)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
+		ensure!(
+			<Treasury as GetStorageVersion>::on_chain_storage_version() == 0,
+			"TreasuryCouncilCollective storage version should be 0"
+		);
+		ensure!(
+			<OpenTech as GetStorageVersion>::on_chain_storage_version() == 0,
+			"OpenTechCommitteeCollective storage version should be 0"
+		);
+		Ok(vec![])
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(&self, _state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		ensure!(
+			<Treasury as GetStorageVersion>::on_chain_storage_version() == 4,
+			"Treasury storage version should be 4"
+		);
+		ensure!(
+			<OpenTech as GetStorageVersion>::on_chain_storage_version() == 4,
+			"OpenTech storage version should be 4"
+		);
+		Ok(())
+	}
+}
+
+pub struct ReferendaMigrations<Runtime>(PhantomData<Runtime>);
+
+impl<Runtime> GetMigrations for ReferendaMigrations<Runtime>
+where
+	Runtime: pallet_referenda::Config<Hash = PreimageHash>,
 {
 	fn get_migrations() -> Vec<Box<dyn Migration>> {
 		let pallet_referenda_migrate_v0_to_v1 =
@@ -175,9 +236,12 @@ where
 	}
 }
 
-pub struct CommonMigrations<Runtime, Council, Tech>(PhantomData<(Runtime, Council, Tech)>);
+pub struct CommonMigrations<Runtime, Council, Tech, Treasury, OpenTech>(
+	PhantomData<(Runtime, Council, Tech, Treasury, OpenTech)>,
+);
 
-impl<Runtime, Council, Tech> GetMigrations for CommonMigrations<Runtime, Council, Tech>
+impl<Runtime, Council, Tech, Treasury, OpenTech> GetMigrations
+	for CommonMigrations<Runtime, Council, Tech, Treasury, OpenTech>
 where
 	Runtime: pallet_author_mapping::Config,
 	Runtime: pallet_parachain_staking::Config,
@@ -185,12 +249,17 @@ where
 	Runtime: AuthorSlotFilterConfig,
 	Council: GetStorageVersion + PalletInfoAccess + 'static,
 	Tech: GetStorageVersion + PalletInfoAccess + 'static,
+	Treasury: GetStorageVersion + PalletInfoAccess + 'static,
+	OpenTech: GetStorageVersion + PalletInfoAccess + 'static,
 	Runtime: pallet_democracy::Config<Hash = PreimageHash>,
 	Runtime: pallet_preimage::Config<Hash = PreimageHash>,
 	Runtime: pallet_asset_manager::Config,
 	<Runtime as pallet_asset_manager::Config>::ForeignAssetType: From<xcm::v3::MultiLocation>,
 	Runtime: pallet_xcm_transactor::Config,
 	Runtime: pallet_moonbeam_orbiters::Config,
+	Runtime: pallet_balances::Config,
+	Runtime: pallet_referenda::Config,
+	Runtime::AccountId: Default,
 {
 	fn get_migrations() -> Vec<Box<dyn Migration>> {
 		// let migration_author_mapping_twox_to_blake = AuthorMappingTwoXToBlake::<Runtime> {
@@ -258,6 +327,10 @@ where
 		//	PalletXcmTransactorMigrateXcmV2ToV3::<Runtime>(Default::default());
 		let remove_min_bond_for_old_orbiter_collators =
 			RemoveMinBondForOrbiterCollators::<Runtime>(Default::default());
+		let missing_balances_migrations = MissingBalancesMigrations::<Runtime>(Default::default());
+		let fix_pallet_versions =
+			FixIncorrectPalletVersions::<Runtime, Treasury, OpenTech>(Default::default());
+
 		vec![
 			// completed in runtime 800
 			// Box::new(migration_author_mapping_twox_to_blake),
@@ -305,6 +378,8 @@ where
 			//Box::new(asset_manager_to_xcm_v3),
 			//Box::new(xcm_transactor_to_xcm_v3),
 			Box::new(remove_min_bond_for_old_orbiter_collators),
+			Box::new(missing_balances_migrations),
+			Box::new(fix_pallet_versions),
 		]
 	}
 }

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -20,7 +20,6 @@
 //! the "Migration" trait declared in the pallet-migrations crate.
 
 use frame_support::{
-	ensure,
 	pallet_prelude::GetStorageVersion,
 	traits::{Hash as PreimageHash, OnRuntimeUpgrade, PalletInfoAccess, StorageVersion},
 	weights::Weight,
@@ -28,6 +27,8 @@ use frame_support::{
 use pallet_author_slot_filter::Config as AuthorSlotFilterConfig;
 use pallet_migrations::{GetMigrations, Migration};
 use pallet_moonbeam_orbiters::CollatorsPool;
+#[cfg(feature = "try-runtime")]
+use frame_support::ensure;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::traits::Zero;
 use sp_std::{marker::PhantomData, prelude::*};

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -207,6 +207,10 @@ where
 			<OpenTech as GetStorageVersion>::on_chain_storage_version() == 0,
 			"OpenTechCommitteeCollective storage version should be 0"
 		);
+		ensure!(
+			<pallet_referenda::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == 0,
+			"Referenda storage version should be 0"
+		);
 		Ok(vec![])
 	}
 
@@ -219,6 +223,10 @@ where
 		ensure!(
 			<OpenTech as GetStorageVersion>::on_chain_storage_version() == 4,
 			"OpenTech storage version should be 4"
+		);
+		ensure!(
+			<pallet_referenda::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == 1,
+			"Referenda storage version should be 1"
 		);
 		Ok(())
 	}

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -185,7 +185,7 @@ where
 	Runtime: pallet_referenda::Config,
 {
 	fn friendly_name(&self) -> &str {
-		"MM_SetCollectivePalletVersions"
+		"MM_FixIncorrectPalletVersions"
 	}
 
 	fn migrate(&self, _available_weight: Weight) -> Weight {

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -19,6 +19,8 @@
 //! This module acts as a registry where each migration is defined. Each migration should implement
 //! the "Migration" trait declared in the pallet-migrations crate.
 
+#[cfg(feature = "try-runtime")]
+use frame_support::ensure;
 use frame_support::{
 	pallet_prelude::GetStorageVersion,
 	traits::{Hash as PreimageHash, OnRuntimeUpgrade, PalletInfoAccess, StorageVersion},
@@ -27,8 +29,6 @@ use frame_support::{
 use pallet_author_slot_filter::Config as AuthorSlotFilterConfig;
 use pallet_migrations::{GetMigrations, Migration};
 use pallet_moonbeam_orbiters::CollatorsPool;
-#[cfg(feature = "try-runtime")]
-use frame_support::ensure;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::traits::Zero;
 use sp_std::{marker::PhantomData, prelude::*};
@@ -208,7 +208,8 @@ where
 			"OpenTechCommitteeCollective storage version should be 0"
 		);
 		ensure!(
-			<pallet_referenda::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == 0,
+			<pallet_referenda::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version()
+				== 0,
 			"Referenda storage version should be 0"
 		);
 		Ok(vec![])
@@ -225,7 +226,8 @@ where
 			"OpenTech storage version should be 4"
 		);
 		ensure!(
-			<pallet_referenda::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == 1,
+			<pallet_referenda::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version()
+				== 1,
 			"Referenda storage version should be 1"
 		);
 		Ok(())

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1067,12 +1067,10 @@ impl pallet_migrations::Config for Runtime {
 			Runtime,
 			CouncilCollective,
 			TechCommitteeCollective,
+			TreasuryCouncilCollective,
+			OpenTechCommitteeCollective,
 		>,
-		moonbeam_runtime_common::migrations::ReferendaMigrations<
-			Runtime,
-			CouncilCollective,
-			TechCommitteeCollective,
-		>,
+		moonbeam_runtime_common::migrations::ReferendaMigrations<Runtime>,
 		TransactorRelayIndexMigration<Runtime>,
 	);
 	type XcmExecutionManager = XcmExecutionManager;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1076,6 +1076,8 @@ impl pallet_migrations::Config for Runtime {
 			Runtime,
 			CouncilCollective,
 			TechCommitteeCollective,
+			TreasuryCouncilCollective,
+			OpenTechCommitteeCollective,
 		>,
 		TransactorRelayIndexMigration<Runtime>,
 	);

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1080,12 +1080,10 @@ impl pallet_migrations::Config for Runtime {
 			Runtime,
 			CouncilCollective,
 			TechCommitteeCollective,
+			TreasuryCouncilCollective,
+			OpenTechCommitteeCollective,
 		>,
-		moonbeam_runtime_common::migrations::ReferendaMigrations<
-			Runtime,
-			CouncilCollective,
-			TechCommitteeCollective,
-		>,
+		moonbeam_runtime_common::migrations::ReferendaMigrations<Runtime>,
 		TransactorRelayIndexMigration<Runtime>,
 	);
 	type XcmExecutionManager = XcmExecutionManager;


### PR DESCRIPTION
### What does it do?

Fixes the incorrect pallet versions for the following pallets:

`TreasuryCouncilCollective` 0 -> 4
`OpenTechCommitteeCollective` 0 -> 4
`Balances` 0 -> 1
`Referenda` 0 -> 1

The incorrect versions causes `try-runtime-cli` to raise errors. 

It also applies 2 existing migrations to the `pallet_balances`, which 
- first, deactivates the balance for the XCM teleport account (not used in moonbeam)
- then kills the inactive issuances

Here is the relevant log:
```
2023-11-08 09:19:42 [🌗] performing migration MM_MissingBalancesMigrations, available weight: Weight(ref_time: 496328193830, proof_size: 5176120)
2023-11-08 09:19:42 [🌗] Migrating storage from version StorageVersion(0)
2023-11-08 09:19:42 [🌗] Total balance to be deactivated = 49126913761788105000
2023-11-08 09:19:42 [🌗] Storage to version 1
2023-11-08 09:19:42 [🌗] Killing inactive issuance 4455285130501229342817269
2023-11-08 09:19:42 [🌗] Storage to version 0
2023-11-08 09:19:42 [🌗] Migrating storage from version StorageVersion(0)
2023-11-08 09:19:42 [🌗] Total balance to be deactivated = 49126913761788105000
2023-11-08 09:19:42 [🌗] Storage to version 1
2023-11-08 09:19:42 [🌗] performing migration MM_SetCollectivePalletVersions, available weight: Weight(ref_time: 495953193830, proof_size: 5176120)
2023-11-08 09:19:42 [🌗] Setting collective pallet versions to 4
2023-11-08 09:19:42 [🌗] Setting referenda pallet version to 1
```

The upgrade was tested with a fork.
