### PR TITLE
Update Smoke Tests for RT2600

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@moonbeam-network/api-augment": "^0.2500.0",
+    "@moonbeam-network/api-augment": "^0.2600.0",
     "@moonwall/cli": "^4.2.10",
     "@moonwall/util": "^4.2.10",
     "@polkadot/api": "^10.10.1",

--- a/test/pnpm-lock.yaml
+++ b/test/pnpm-lock.yaml
@@ -80,8 +80,8 @@ dependencies:
 
 devDependencies:
   '@moonbeam-network/api-augment':
-    specifier: ^0.2500.0
-    version: 0.2500.0
+    specifier: ^0.2600.0
+    version: 0.2600.0
   '@moonwall/cli':
     specifier: ^4.2.10
     version: 4.2.10(@types/node@20.8.10)(@vitest/ui@1.0.0-beta.2)(typescript@5.2.2)
@@ -1341,6 +1341,11 @@ packages:
 
   /@moonbeam-network/api-augment@0.2500.0:
     resolution: {integrity: sha512-HOHQE9FCw9Pft+t5bWKe+c5+mKJ/5ZD1UztJlGBMxg4NRLCdZiKxdbPBiv2OTpRsBRq5v6PD2LaTFayRjXZYNQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /@moonbeam-network/api-augment@0.2600.0:
+    resolution: {integrity: sha512-Hnn7mw8Im+X8GgbX11EjydbPM5MTQSG6yHs7JE2mPYCgSf6PkqUqOil5F4nACI4hMn6rM6GTTdRXscu0ztiNvQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 

--- a/test/suites/smoke/test-relay-indices.ts
+++ b/test/suites/smoke/test-relay-indices.ts
@@ -230,7 +230,8 @@ describeSuite({
           log(`Skipping test for paraApiVersion ${paraApiVersion}`);
           return;
         }
-        const inputCall = relayApi.tx.balances.transfer(ALITH_SESSION_ADDRESS, 1000);
+
+        const inputCall = relayApi.tx.balances.transferAllowDeath(ALITH_SESSION_ADDRESS, 1000);
         const callHex = relayApi.tx.utility.asDerivative(0, inputCall).method.toHex();
         const resp = await xcmTransactorV1.encodeUtilityAsDerivative(
           0,
@@ -257,7 +258,7 @@ describeSuite({
           return; // TODO: replace with skip() when added to vitest;
         }
 
-        const inputCall = relayApi.tx.balances.transfer(ALITH_SESSION_ADDRESS, 1000);
+        const inputCall = relayApi.tx.balances.transferAllowDeath(ALITH_SESSION_ADDRESS, 1000);
         const callHex = relayApi.tx.utility.asDerivative(0, inputCall).method.toHex();
         const resp = await xcmTransactorV2.encodeUtilityAsDerivative(
           0,

--- a/test/suites/smoke/test-staking-rewards.ts
+++ b/test/suites/smoke/test-staking-rewards.ts
@@ -84,13 +84,16 @@ describeSuite({
       timeout: FIVE_MINS,
       test: async function () {
         const results = await limiter.schedule(() => {
+          const specVersion = paraApi.consts.system.version.specVersion.toNumber();
           const allTasks = atStakeSnapshot.map(async (coll, index) => {
             const [
               {
                 args: [_, accountId],
               },
-              { bond, total, delegations },
+              value,
             ] = coll;
+            // @ts-expect-error - changed to optional between RT versions
+            const { bond, total, delegations } = specVersion < 2600 ? value : value.unwrap();
             const candidateInfo = (
               await limiter.schedule(() =>
                 predecessorApiAt.query.parachainStaking.candidateInfo(accountId as AccountId20)
@@ -412,8 +415,10 @@ describeSuite({
         {
           args: [_, accountId],
         },
-        { bond, total, delegations },
+        value,
       ] of atStake) {
+        // @ts-expect-error - changed to optional between RT versions
+        const { bond, total, delegations } = specVersion < 2600 ? value : value.unwrap();
         const collatorId = accountId.toHex();
         collators.add(collatorId);
         const points = await apiAtPriorRewarded.query.parachainStaking.awardedPts(


### PR DESCRIPTION
### What does it do?
Updates some of the smoke tests to be compatible with RT2600 changes:
- `balances.transfer` call in relayIndices test, updated to the allowDeath label
- `parachainStaking.atStake` storage query will now unwrap optional value if applicable

### What value does it bring to the blockchain users?
Better state monitoring of live networks