### PR TITLE
Disable coverage gathering during cargo build

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -105,6 +105,8 @@ jobs:
         shell: bash
         run: |
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C instrument-coverage -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
+          # Disable coverage when building
+          echo "LLVM_PROFILE_FILE=/dev/null" >> $GITHUB_ENV
       - name: Setup grcov
         run: |
           wget https://github.com/mozilla/grcov/releases/download/v${{ env.GRCOV_VERSION }}/grcov-x86_64-unknown-linux-gnu.tar.bz2
@@ -116,9 +118,10 @@ jobs:
         uses: ./.github/workflow-templates/cargo-build
         with:
           features: evm-tracing
-      - name: Clean-up possible coverage generated during builds
+      - name: Enable coverage gathering
         run: |
-          rm default_*.profraw
+          # Enable coverage when running tests
+          echo "LLVM_PROFILE_FILE=$(pwd)/proffiles/default_%m_%p.profraw" >> $GITHUB_ENV
       - name: Unit tests
         run: |
           # curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
@@ -134,14 +137,6 @@ jobs:
       - name: Retrieve coverage
         id: coverage
         run: |
-          mkdir -p /tmp/proffiles
-
-          find . -type f -name \*.profraw -exec ls -l {}  \;
-
-          echo "Copying profraw files to /tmp/proffiles"
-          find . -name \*.profraw -exec mv {} /tmp/proffiles/ \;
-
-          mv /tmp/proffiles proffiles
           du -sh proffiles
 
           echo "Executing grcov"


### PR DESCRIPTION
Prevents the creation of junk `.profraw` files in the `~/.cargo` folder. Now coverage is enabled after cargo build, and `.profraw` files are written directly to the `proffiles` folder.