### PR TITLE
Fake VRF for ethereum pending blocks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -673,18 +673,18 @@ jobs:
           pnpm moonwall test zombie_${{ matrix.chain }}
       - name: "Run zombie RPC test"
         run: |
-              cd test
-              pnpm install
-    
-              ## Generate old spec using latest published node, modify it, and generate raw spec
-              chmod uog+x tmp/moonbeam_rt
-              tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
-              pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json 
-              tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
-    
-              ## Start zombie network and run tests
-              chmod uog+x ../target/release/moonbeam
-              pnpm moonwall test zombie_${{ matrix.chain }}_rpc
+          cd test
+          pnpm install
+
+          ## Generate old spec using latest published node, modify it, and generate raw spec
+          chmod uog+x tmp/moonbeam_rt
+          tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
+          pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json 
+          tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
+
+          ## Start zombie network and run tests
+          chmod uog+x ../target/release/moonbeam
+          pnpm moonwall test zombie_${{ matrix.chain }}_rpc
       - name: Zip and Upload Node Logs on Failure
         if: failure()
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -672,7 +672,7 @@ jobs:
           chmod uog+x ../target/release/moonbeam
           pnpm moonwall test zombie_${{ matrix.chain }}
       - name: "Run zombie RPC test"
-            run: |
+        run: |
               cd test
               pnpm install
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -671,6 +671,20 @@ jobs:
           ## Start zombie network and run tests
           chmod uog+x ../target/release/moonbeam
           pnpm moonwall test zombie_${{ matrix.chain }}
+      - name: "Run zombie RPC test"
+            run: |
+              cd test
+              pnpm install
+    
+              ## Generate old spec using latest published node, modify it, and generate raw spec
+              chmod uog+x tmp/moonbeam_rt
+              tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
+              pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json 
+              tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
+    
+              ## Start zombie network and run tests
+              chmod uog+x ../target/release/moonbeam
+              pnpm moonwall test zombie_${{ matrix.chain }}_rpc
       - name: Zip and Upload Node Logs on Failure
         if: failure()
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "evm",
  "frame-support",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8436,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "environmental",
  "evm",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8612,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fp-evm",
 ]
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fp-evm",
  "num",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "evm",
  "frame-support",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8436,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "environmental",
  "evm",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8612,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fp-evm",
 ]
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fp-evm",
  "num",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#916a6c8bfe89a8696ffee32c850eda0ec4daa284"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#338864216139fd6da3d3ba30d9375ffb614b6be1"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7520,7 +7520,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -7550,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8041,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8078,7 +8078,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9302,7 +9302,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9603,8 +9603,9 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
+ "environmental",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14162,7 +14163,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -17995,7 +17996,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#caa31fa405387f445a3265a108310e63a1f83efe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.1.0#6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe"
 dependencies = [
  "sp-runtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "evm",
  "frame-support",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8436,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "environmental",
  "evm",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8612,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fp-evm",
 ]
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fp-evm",
  "num",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bba7443a69dd5976b28817e36e10a3091b4c12d9"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.1.0#bf5885a982041cc744ecbb62a2afc13d56d464dc"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -456,6 +456,10 @@ macro_rules! impl_runtime_apis_plus_common {
 						pallet_ethereum::CurrentTransactionStatuses::<Runtime>::get()
 					)
 				 }
+
+				 fn initialize_pending_block(header: &<Block as BlockT>::Header) {
+					pallet_randomness::vrf::using_fake_vrf(|| Executive::initialize_block(header))
+				}
 			}
 
 			impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {

--- a/test/configs/zombieAlphanetRpc.json
+++ b/test/configs/zombieAlphanetRpc.json
@@ -32,7 +32,7 @@
         {
           "name": "alith",
           "ws_port": 33345,
-          "command": "tmp/moonbeam",
+          "command": "../target/release/moonbeam",
           "args": [
             "--no-hardware-benchmarks",
             "--force-authoring",
@@ -45,7 +45,7 @@
           "validator": false,
           "ws_port": 33048,
           "p2p_port": 33049,
-          "command": "tmp/moonbeam",
+          "command": "../target/release/moonbeam",
           "args": [
             "--no-hardware-benchmarks",
             "-lparachain=debug",

--- a/test/configs/zombieAlphanetRpc.json
+++ b/test/configs/zombieAlphanetRpc.json
@@ -1,0 +1,65 @@
+{
+  "settings": {
+    "timeout": 1000,
+    "provider": "native"
+  },
+  "relaychain": {
+    "chain": "rococo-local",
+    "default_command": "tmp/polkadot",
+    "default_args": [
+      "--no-hardware-benchmarks",
+      "-lparachain=debug",
+      "--database=paritydb"
+    ],
+    "nodes": [
+      {
+        "name": "alice",
+        "ws_port": 33356,
+        "validator": true
+      },
+      {
+        "name": "bob",
+        "validator": true
+      }
+    ]
+  },
+  "parachains": [
+    {
+      "id": 1000,
+      "chain": "moonbase-local",
+      "chain_spec_path": "tmp/moonbase-raw-spec.json",
+      "collators": [
+        {
+          "name": "alith",
+          "ws_port": 33345,
+          "command": "tmp/moonbeam",
+          "args": [
+            "--no-hardware-benchmarks",
+            "--force-authoring",
+            "-lparachain=debug",
+            "--database=paritydb"
+          ]
+        },
+        {
+          "name": "RPC1",
+          "validator": false,
+          "ws_port": 33048,
+          "p2p_port": 33049,
+          "command": "tmp/moonbeam",
+          "args": [
+            "--no-hardware-benchmarks",
+            "-lparachain=debug",
+            "--database=paritydb"
+          ]
+        }
+      ]
+    }
+  ],
+  "types": {
+    "Header": {
+      "number": "u64",
+      "parent_hash": "Hash",
+      "post_state": "Hash"
+    }
+  }
+}

--- a/test/configs/zombieMoonbeamRpc.json
+++ b/test/configs/zombieMoonbeamRpc.json
@@ -1,0 +1,65 @@
+{
+  "settings": {
+    "timeout": 1000,
+    "provider": "native"
+  },
+  "relaychain": {
+    "chain": "rococo-local",
+    "default_command": "tmp/polkadot",
+    "default_args": [
+      "--no-hardware-benchmarks",
+      "-lparachain=debug",
+      "--database=paritydb"
+    ],
+    "nodes": [
+      {
+        "name": "alice",
+        "ws_port": 33356,
+        "validator": true
+      },
+      {
+        "name": "bob",
+        "validator": true
+      }
+    ]
+  },
+  "parachains": [
+    {
+      "id": 1000,
+      "chain": "moonbeam-local",
+      "chain_spec_path": "tmp/moonbeam-raw-spec.json",
+      "collators": [
+        {
+          "name": "alith",
+          "command": "../target/release/moonbeam",
+          "ws_port": 33345,
+          "args": [
+            "--no-hardware-benchmarks",
+            "--force-authoring",
+            "-lparachain=debug",
+            "--database=paritydb"
+          ]
+        },
+        {
+          "name": "RPC1",
+          "validator": false,
+          "ws_port": 33048,
+          "p2p_port": 33049,
+          "command": "../target/release/moonbeam",
+          "args": [
+            "--no-hardware-benchmarks",
+            "-lparachain=debug",
+            "--database=paritydb"
+          ]
+        }
+      ]
+    }
+  ],
+  "types": {
+    "Header": {
+      "number": "u64",
+      "parent_hash": "Hash",
+      "post_state": "Hash"
+    }
+  }
+}

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -53,6 +53,41 @@
       }
     },
     {
+      "name": "zombie_moonbase_rpc",
+      "testFileDir": ["suites/para-rpc"],
+      "include": ["**/*moonbase*", "**/*common*"],
+      "runScripts": ["download-polkadot.sh"],
+      "foundation": {
+        "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
+        "type": "zombie",
+        "zombieSpec": {
+          "configPath": "./configs/zombieAlphanetRpc.json"
+        }
+      },
+      "connections": [
+        {
+          "name": "ethers",
+          "type": "ethers",
+          "endpoints": ["ws://127.0.0.1:33048"]
+        },
+        {
+          "name": "viem",
+          "type": "viem",
+          "endpoints": ["ws://127.0.0.1:33048"]
+        },
+        {
+          "name": "parachain",
+          "type": "polkadotJs",
+          "endpoints": ["ws://127.0.0.1:33048"]
+        },
+        {
+          "name": "relaychain",
+          "type": "polkadotJs",
+          "endpoints": ["ws://127.0.0.1:33356"]
+        }
+      ]
+    },
+    {
       "name": "zombie_common",
       "testFileDir": ["suites/para"],
       "include": ["**/*common*"],

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -45,7 +45,7 @@
       "include": ["**/*moonbeam*", "**/*common*"],
       "runScripts": ["download-polkadot.sh"],
       "foundation": {
-        "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbeam_runtime.compact.compressed.wasm",
+        "rtUpgradePath": "../target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm",
         "type": "zombie",
         "zombieSpec": {
           "configPath": "./configs/zombieMoonbeamRpc.json"

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -40,6 +40,41 @@
       }
     },
     {
+      "name": "zombie_moonbeam_rpc",
+      "testFileDir": ["suites/para-rpc"],
+      "include": ["**/*moonbeam*", "**/*common*"],
+      "runScripts": ["download-polkadot.sh"],
+      "foundation": {
+        "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbeam_runtime.compact.compressed.wasm",
+        "type": "zombie",
+        "zombieSpec": {
+          "configPath": "./configs/zombieMoonbeamRpc.json"
+        }
+      },
+      "connections": [
+        {
+          "name": "ethers",
+          "type": "ethers",
+          "endpoints": ["ws://127.0.0.1:33048"]
+        },
+        {
+          "name": "viem",
+          "type": "viem",
+          "endpoints": ["ws://127.0.0.1:33048"]
+        },
+        {
+          "name": "parachain",
+          "type": "polkadotJs",
+          "endpoints": ["ws://127.0.0.1:33048"]
+        },
+        {
+          "name": "relaychain",
+          "type": "polkadotJs",
+          "endpoints": ["ws://127.0.0.1:33356"]
+        }
+      ]
+    },
+    {
       "name": "zombie_moonbase",
       "testFileDir": ["suites/para"],
       "include": ["**/*moonbase*", "**/*common*"],

--- a/test/suites/para-rpc/test_moonbase.ts
+++ b/test/suites/para-rpc/test_moonbase.ts
@@ -1,0 +1,159 @@
+import "@moonbeam-network/api-augment";
+import { MoonwallContext, beforeAll, describeSuite, expect } from "@moonwall/cli";
+import {
+  ALITH_PRIVATE_KEY,
+  BALTATHAR_ADDRESS,
+  CHARLETH_PRIVATE_KEY,
+  MIN_GAS_PRICE,
+  charleth,
+  createRawTransfer,
+  generateKeyringPair,
+  sendRawTransaction,
+} from "@moonwall/util";
+import { ApiPromise } from "@polkadot/api";
+import { ethers } from "ethers";
+import fs from "node:fs";
+
+describeSuite({
+  id: "ZAN",
+  title: "Zombie AlphaNet Upgrade Test",
+  foundationMethods: "zombie",
+  testCases: function ({ it, context, log }) {
+    let paraApi: ApiPromise;
+    let relayApi: ApiPromise;
+
+    beforeAll(async () => {
+      paraApi = context.polkadotJs("parachain");
+      relayApi = context.polkadotJs("relaychain");
+
+      const relayNetwork = relayApi.consts.system.version.specName.toString();
+      expect(relayNetwork, "Relay API incorrect").to.contain("rococo");
+      
+      const paraNetwork = paraApi.consts.system.version.specName.toString();
+      expect(paraNetwork, "Para API incorrect").to.contain("moonbase");
+      
+      const currentBlock = (await paraApi.rpc.chain.getBlock()).block.header.number.toNumber();
+      expect(currentBlock, "Parachain not producing blocks").to.be.greaterThan(0);
+    }, 120000);
+
+    it({
+      id: "T01",
+      title: "Blocks are being produced on parachain",
+      test: async function () {
+        const blockNum = (await paraApi.rpc.chain.getBlock()).block.header.number.toNumber();
+        expect(blockNum).to.be.greaterThan(0);
+      },
+    });
+
+    it({
+      id: "T02",
+      title: "Chain can be upgraded",
+      timeout: 600000,
+      test: async function () {
+        const blockNumberBefore = (
+          await paraApi.rpc.chain.getBlock()
+        ).block.header.number.toNumber();
+        const currentCode = (await paraApi.rpc.state.getStorage(":code")) as any;
+        const codeString = currentCode.toString();
+
+        const wasm = fs.readFileSync(MoonwallContext.getContext().rtUpgradePath!);
+        const rtHex = `0x${wasm.toString("hex")}`;
+
+        if (rtHex === codeString) {
+          log("Runtime already upgraded, skipping test");
+          return;
+        } else {
+          log("Runtime not upgraded, proceeding with test");
+          log("Current runtime hash: " + rtHex.slice(0, 10) + "..." + rtHex.slice(-10));
+          log("New runtime hash: " + codeString.slice(0, 10) + "..." + codeString.slice(-10));
+        }
+
+        await context.upgradeRuntime({ logger: log });
+        await context.waitBlock(2);
+        const blockNumberAfter = (
+          await paraApi.rpc.chain.getBlock()
+        ).block.header.number.toNumber();
+        log(`Before: #${blockNumberBefore}, After: #${blockNumberAfter}`);
+        expect(blockNumberAfter, "Block number did not increase").to.be.greaterThan(
+          blockNumberBefore
+        );
+      },
+    });
+
+    it({
+      id: "T03",
+      title: "Can connect to parachain and execute a transaction",
+      timeout: 60000,
+      test: async function () {
+        const balBefore = (await paraApi.query.system.account(BALTATHAR_ADDRESS)).data.free;
+
+        log("Please wait, this will take at least 30s for transaction to complete");
+
+        context.waitBlock(5);
+
+        await new Promise((resolve) => {
+          paraApi.tx.balances
+            .transfer(BALTATHAR_ADDRESS, ethers.parseEther("2"))
+            .signAndSend(charleth, ({ status, events }) => {
+              if (status.isInBlock) {
+                log("Transaction is in block");
+              }
+              if (status.isFinalized) {
+                log("Transaction is finalized!");
+                resolve(events);
+              }
+            });
+        });
+
+        const balAfter = (await paraApi.query.system.account(BALTATHAR_ADDRESS)).data.free;
+        expect(balBefore.lt(balAfter)).to.be.true;
+      },
+    });
+
+    it({
+      id: "T04",
+      title: "Tags are present on emulated Ethereum blocks",
+      test: async function () {
+        expect(
+          (await context.ethers().provider!.getBlock("safe"))!.number,
+          "Safe tag is not present"
+        ).to.be.greaterThan(0);
+        expect(
+          (await context.ethers().provider!.getBlock("finalized"))!.number,
+          "Finalized tag is not present"
+        ).to.be.greaterThan(0);
+        expect(
+          (await context.ethers().provider!.getBlock("latest"))!.number,
+          "Latest tag is not present"
+        ).to.be.greaterThan(0);
+        // log(await ethersSigner.provider.getTransactionCount(ALITH_ADDRESS, "latest"));
+        // await context
+        //   .ethers()
+        //   .sendTransaction({ to: BALTATHAR_ADDRESS, value: ethers.parseEther("1") });
+        // log(await ethersSigner.provider.getTransactionCount(ALITH_ADDRESS, "pending"));
+      },
+    });
+
+    it({
+      id: "T05",
+      title: "RPC Provider can procude a pending ethereum block",
+      test: async function () {
+        const randomAccount = generateKeyringPair();
+        const randomAddress = randomAccount.address as `0x${string}`;
+
+        const rawTx = (await createRawTransfer(context as any, randomAddress, 512n, {
+          privateKey: ALITH_PRIVATE_KEY,
+          gasPrice: MIN_GAS_PRICE,
+          gas: 21000n,
+          txnType: "legacy",
+        })) as `0x${string}`;
+        log(rawTx);
+        await sendRawTransaction(context, rawTx);
+
+        expect(
+          await context.viem().getBalance({ address: randomAddress, blockTag: "pending" })
+        ).toBe(512n);
+      },
+    });
+  },
+});

--- a/test/suites/para-rpc/test_moonbase.ts
+++ b/test/suites/para-rpc/test_moonbase.ts
@@ -28,10 +28,10 @@ describeSuite({
 
       const relayNetwork = relayApi.consts.system.version.specName.toString();
       expect(relayNetwork, "Relay API incorrect").to.contain("rococo");
-      
+
       const paraNetwork = paraApi.consts.system.version.specName.toString();
       expect(paraNetwork, "Para API incorrect").to.contain("moonbase");
-      
+
       const currentBlock = (await paraApi.rpc.chain.getBlock()).block.header.number.toNumber();
       expect(currentBlock, "Parachain not producing blocks").to.be.greaterThan(0);
     }, 120000);

--- a/test/suites/para-rpc/test_moonbase.ts
+++ b/test/suites/para-rpc/test_moonbase.ts
@@ -136,7 +136,7 @@ describeSuite({
 
     it({
       id: "T05",
-      title: "RPC Provider can procude a pending ethereum block",
+      title: "RPC Provider can produce a pending ethereum block",
       test: async function () {
         const randomAccount = generateKeyringPair();
         const randomAddress = randomAccount.address as `0x${string}`;

--- a/test/suites/para-rpc/test_moonbase.ts
+++ b/test/suites/para-rpc/test_moonbase.ts
@@ -3,7 +3,6 @@ import { MoonwallContext, beforeAll, describeSuite, expect } from "@moonwall/cli
 import {
   ALITH_PRIVATE_KEY,
   BALTATHAR_ADDRESS,
-  CHARLETH_PRIVATE_KEY,
   MIN_GAS_PRICE,
   charleth,
   createRawTransfer,

--- a/test/suites/para-rpc/test_moonbeam.ts
+++ b/test/suites/para-rpc/test_moonbeam.ts
@@ -1,0 +1,160 @@
+import "@moonbeam-network/api-augment";
+import { MoonwallContext, beforeAll, describeSuite, expect } from "@moonwall/cli";
+import {
+  ALITH_PRIVATE_KEY,
+  BALTATHAR_ADDRESS,
+  MIN_GAS_PRICE,
+  charleth,
+  createRawTransfer,
+  generateKeyringPair,
+  sendRawTransaction,
+} from "@moonwall/util";
+import { ApiPromise } from "@polkadot/api";
+import { Signer, ethers } from "ethers";
+import fs from "node:fs";
+
+describeSuite({
+  id: "ZAN",
+  title: "Zombie AlphaNet Upgrade Test",
+  foundationMethods: "zombie",
+  testCases: function ({ it, context, log }) {
+    let paraApi: ApiPromise;
+    let relayApi: ApiPromise;
+    let ethersSigner: Signer;
+
+    beforeAll(async () => {
+      paraApi = context.polkadotJs("parachain");
+      relayApi = context.polkadotJs("relaychain");
+      ethersSigner = context.ethers()!;
+
+      const relayNetwork = relayApi.consts.system.version.specName.toString();
+      expect(relayNetwork, "Relay API incorrect").to.contain("rococo");
+
+      const paraNetwork = paraApi.consts.system.version.specName.toString();
+      expect(paraNetwork, "Para API incorrect").to.contain("moonbeam");
+
+      const currentBlock = (await paraApi.rpc.chain.getBlock()).block.header.number.toNumber();
+      expect(currentBlock, "Parachain not producing blocks").to.be.greaterThan(0);
+    }, 120000);
+    it({
+      id: "T01",
+      title: "Blocks are being produced on parachain",
+      test: async function () {
+        const blockNum = (await paraApi.rpc.chain.getBlock()).block.header.number.toNumber();
+        expect(blockNum).to.be.greaterThan(0);
+      },
+    });
+
+    it({
+      id: "T02",
+      title: "Chain can be upgraded",
+      timeout: 600000,
+      test: async function () {
+        const blockNumberBefore = (
+          await paraApi.rpc.chain.getBlock()
+        ).block.header.number.toNumber();
+        const currentCode = (await paraApi.rpc.state.getStorage(":code")) as any;
+        const codeString = currentCode.toString();
+
+        const wasm = fs.readFileSync(MoonwallContext.getContext().rtUpgradePath!);
+        const rtHex = `0x${wasm.toString("hex")}`;
+
+        if (rtHex === codeString) {
+          log("Runtime already upgraded, skipping test");
+          return;
+        }
+
+        await context.upgradeRuntime({
+          logger: log,
+          runtimeName: "moonbeam",
+          localPath: MoonwallContext.getContext().rtUpgradePath,
+          useGovernance: true,
+          waitMigration: true,
+          runtimeTag: "local",
+        });
+        await context.waitBlock(2);
+        const blockNumberAfter = (
+          await paraApi.rpc.chain.getBlock()
+        ).block.header.number.toNumber();
+        log(`Before: #${blockNumberBefore}, After: #${blockNumberAfter}`);
+        expect(blockNumberAfter, "Block number did not increase").to.be.greaterThan(
+          blockNumberBefore
+        );
+      },
+    });
+
+    it({
+      id: "T03",
+      title: "Can connect to parachain and execute a transaction",
+      timeout: 60000,
+      test: async function () {
+        const balBefore = (await paraApi.query.system.account(BALTATHAR_ADDRESS)).data.free;
+
+        log("Please wait, this will take at least 30s for transaction to complete");
+
+        await new Promise((resolve) => {
+          paraApi.tx.balances
+            .transfer(BALTATHAR_ADDRESS, ethers.parseEther("2"))
+            .signAndSend(charleth, ({ status, events }) => {
+              if (status.isInBlock) {
+                log("Transaction is in block");
+              }
+              if (status.isFinalized) {
+                log("Transaction is finalized!");
+                resolve(events);
+              }
+            });
+        });
+
+        const balAfter = (await paraApi.query.system.account(BALTATHAR_ADDRESS)).data.free;
+        expect(balBefore.lt(balAfter)).to.be.true;
+      },
+    });
+
+    it({
+      id: "T04",
+      title: "Tags are present on emulated Ethereum blocks",
+      test: async function () {
+        expect(
+          (await ethersSigner.provider!.getBlock("safe"))!.number,
+          "Safe tag is not present"
+        ).to.be.greaterThan(0);
+        expect(
+          (await ethersSigner.provider!.getBlock("finalized"))!.number,
+          "Finalized tag is not present"
+        ).to.be.greaterThan(0);
+        expect(
+          (await ethersSigner.provider!.getBlock("latest"))!.number,
+          "Latest tag is not present"
+        ).to.be.greaterThan(0);
+        // log(await ethersSigner.provider.getTransactionCount(ALITH_ADDRESS, "latest"));
+        // await context
+        //   .ethers()
+        //   .sendTransaction({ to: BALTATHAR_ADDRESS, value: ethers.parseEther("1") });
+        // log(await ethersSigner.provider.getTransactionCount(ALITH_ADDRESS, "pending"));
+      },
+    });
+
+    it({
+      id: "T05",
+      title: "RPC Provider can produce a pending ethereum block",
+      test: async function () {
+        const randomAccount = generateKeyringPair();
+        const randomAddress = randomAccount.address as `0x${string}`;
+
+        const rawTx = (await createRawTransfer(context as any, randomAddress, 512n, {
+          privateKey: ALITH_PRIVATE_KEY,
+          gasPrice: MIN_GAS_PRICE,
+          gas: 21000n,
+          txnType: "legacy",
+        })) as `0x${string}`;
+        log(rawTx);
+        await sendRawTransaction(context, rawTx);
+
+        expect(
+          await context.viem().getBalance({ address: randomAddress, blockTag: "pending" })
+        ).toBe(512n);
+      },
+    });
+  },
+});

--- a/test/suites/para-rpc/test_moonbeam.ts
+++ b/test/suites/para-rpc/test_moonbeam.ts
@@ -144,7 +144,7 @@ describeSuite({
 
         const rawTx = (await createRawTransfer(context as any, randomAddress, 512n, {
           privateKey: ALITH_PRIVATE_KEY,
-          gasPrice: MIN_GAS_PRICE,
+          gasPrice: MIN_GAS_PRICE * 1_000n,
           gas: 21000n,
           txnType: "legacy",
         })) as `0x${string}`;


### PR DESCRIPTION
### What does it do?

Create a fake VRF mechanism for ethereum pending blocks.

The main changes are in frontier and moonkit.

#### Frontier changes

Add a new runtime api `initialize_pending_block` and use it in `pending_runtime_api`

https://github.com/moonbeam-foundation/frontier/commit/338864216139fd6da3d3ba30d9375ffb614b6be1

#### Moonkit changes

Add a new fake VRF functionality in pallet randomness thought an environmental

https://github.com/Moonsong-Labs/moonkit/commit/6c6cfed71768a4fa39d4a4e6030d2667ebc4bcfe

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
