### PR TITLE
Remove old migrations

### DIFF
--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -28,36 +28,10 @@ use frame_support::{
 };
 use pallet_author_slot_filter::Config as AuthorSlotFilterConfig;
 use pallet_migrations::{GetMigrations, Migration};
-use pallet_moonbeam_orbiters::CollatorsPool;
+use sp_core::Get;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::traits::Zero;
 use sp_std::{marker::PhantomData, prelude::*};
-
-pub struct PreimageMigrationHashToBoundedCall<T>(PhantomData<T>);
-impl<T> Migration for PreimageMigrationHashToBoundedCall<T>
-where
-	T: pallet_preimage::Config<Hash = PreimageHash> + frame_system::Config,
-{
-	fn friendly_name(&self) -> &str {
-		"MM_PreimageMigrationHashToBoundedCall"
-	}
-
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		pallet_preimage::migration::v1::Migration::<T>::on_runtime_upgrade()
-	}
-
-	/// Run a standard pre-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
-		pallet_preimage::migration::v1::Migration::<T>::pre_upgrade()
-	}
-
-	/// Run a standard post-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self, state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		pallet_preimage::migration::v1::Migration::<T>::post_upgrade(state)
-	}
-}
 
 pub struct PalletReferendaMigrateV0ToV1<T>(pub PhantomData<T>);
 impl<T> Migration for PalletReferendaMigrateV0ToV1<T>
@@ -82,74 +56,6 @@ where
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(&self, state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
 		pallet_referenda::migration::v1::MigrateV0ToV1::<T>::post_upgrade(state)
-	}
-}
-
-use pallet_xcm_transactor::{relay_indices::*, RelayIndices};
-use sp_core::Get;
-pub struct PopulateRelayIndices<T>(pub RelayChainIndices, pub PhantomData<T>);
-impl<T: pallet_xcm_transactor::Config> Migration for PopulateRelayIndices<T> {
-	fn friendly_name(&self) -> &str {
-		"MM_PopulateRelayIndices"
-	}
-
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		// insert input into storage
-		RelayIndices::<T>::put(self.0);
-		T::DbWeight::get().writes(1)
-	}
-
-	/// Run a standard pre-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
-		// check storage is default pre migration
-		assert_eq!(RelayIndices::<T>::get(), Default::default());
-		Ok(Vec::new())
-	}
-
-	/// Run a standard post-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self, _state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		// check storage matches input post migration
-		assert_eq!(RelayIndices::<T>::get(), self.0);
-		Ok(())
-	}
-}
-
-pub struct RemoveMinBondForOrbiterCollators<T>(pub PhantomData<T>);
-impl<T> Migration for RemoveMinBondForOrbiterCollators<T>
-where
-	T: pallet_moonbeam_orbiters::Config,
-	T: pallet_parachain_staking::Config,
-	T: frame_system::Config,
-{
-	fn friendly_name(&self) -> &str {
-		"MM_RemoveMinBondForOrbiterCollators"
-	}
-
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		let mut weight = Weight::zero();
-		CollatorsPool::<T>::iter_keys().for_each(|collator| {
-			log::info!("Setting the bond for collator {:?} to zero", collator);
-			weight += <pallet_parachain_staking::Pallet<T>>::set_candidate_bond_to_zero(&collator);
-		});
-		weight
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
-		Ok(vec![])
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self, _state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		CollatorsPool::<T>::iter_keys().for_each(|collator| {
-			log::info!("Checking collator: {:?}", collator);
-			let state = <pallet_parachain_staking::Pallet<T>>::candidate_info(&collator)
-				.expect("collator should have candidate info");
-			assert!(state.bond.is_zero(), "collator bond should be zero");
-		});
-		Ok(())
 	}
 }
 
@@ -333,8 +239,8 @@ where
 		//	PalletAssetManagerMigrateXcmV2ToV3::<Runtime>(Default::default());
 		//let xcm_transactor_to_xcm_v3 =
 		//	PalletXcmTransactorMigrateXcmV2ToV3::<Runtime>(Default::default());
-		let remove_min_bond_for_old_orbiter_collators =
-			RemoveMinBondForOrbiterCollators::<Runtime>(Default::default());
+		//let remove_min_bond_for_old_orbiter_collators =
+		//	RemoveMinBondForOrbiterCollators::<Runtime>(Default::default());
 		let missing_balances_migrations = MissingBalancesMigrations::<Runtime>(Default::default());
 		let fix_pallet_versions =
 			FixIncorrectPalletVersions::<Runtime, Treasury, OpenTech>(Default::default());
@@ -385,7 +291,7 @@ where
 			//Box::new(preimage_migration_hash_to_bounded_call),
 			//Box::new(asset_manager_to_xcm_v3),
 			//Box::new(xcm_transactor_to_xcm_v3),
-			Box::new(remove_min_bond_for_old_orbiter_collators),
+			//Box::new(remove_min_bond_for_old_orbiter_collators),
 			Box::new(missing_balances_migrations),
 			Box::new(fix_pallet_versions),
 		]

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1041,23 +1041,6 @@ impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositFactor = ConstU128<{ currency::deposit(0, 56) }>;
 }
 
-use pallet_migrations::{GetMigrations, Migration};
-pub struct TransactorRelayIndexMigration<Runtime>(sp_std::marker::PhantomData<Runtime>);
-
-impl<Runtime> GetMigrations for TransactorRelayIndexMigration<Runtime>
-where
-	Runtime: pallet_xcm_transactor::Config,
-{
-	fn get_migrations() -> Vec<Box<dyn Migration>> {
-		vec![Box::new(
-			moonbeam_runtime_common::migrations::PopulateRelayIndices::<Runtime>(
-				moonbeam_relay_encoder::westend::WESTEND_RELAY_INDICES,
-				Default::default(),
-			),
-		)]
-	}
-}
-
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	// TODO wire up our correct list of migrations here. Maybe this shouldn't be in
@@ -1071,7 +1054,6 @@ impl pallet_migrations::Config for Runtime {
 			OpenTechCommitteeCollective,
 		>,
 		moonbeam_runtime_common::migrations::ReferendaMigrations<Runtime>,
-		TransactorRelayIndexMigration<Runtime>,
 	);
 	type XcmExecutionManager = XcmExecutionManager;
 }

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1053,23 +1053,6 @@ impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositFactor = ConstU128<{ currency::deposit(0, 56) }>;
 }
 
-use pallet_migrations::{GetMigrations, Migration};
-pub struct TransactorRelayIndexMigration<Runtime>(sp_std::marker::PhantomData<Runtime>);
-
-impl<Runtime> GetMigrations for TransactorRelayIndexMigration<Runtime>
-where
-	Runtime: pallet_xcm_transactor::Config,
-{
-	fn get_migrations() -> Vec<Box<dyn Migration>> {
-		vec![Box::new(
-			moonbeam_runtime_common::migrations::PopulateRelayIndices::<Runtime>(
-				moonbeam_relay_encoder::polkadot::POLKADOT_RELAY_INDICES,
-				Default::default(),
-			),
-		)]
-	}
-}
-
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type MigrationsList = (
@@ -1080,7 +1063,6 @@ impl pallet_migrations::Config for Runtime {
 			TreasuryCouncilCollective,
 			OpenTechCommitteeCollective,
 		>,
-		TransactorRelayIndexMigration<Runtime>,
 	);
 	type XcmExecutionManager = XcmExecutionManager;
 }

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1056,23 +1056,6 @@ impl pallet_proxy::Config for Runtime {
 	type AnnouncementDepositFactor = ConstU128<{ currency::deposit(0, 56) }>;
 }
 
-use pallet_migrations::{GetMigrations, Migration};
-pub struct TransactorRelayIndexMigration<Runtime>(sp_std::marker::PhantomData<Runtime>);
-
-impl<Runtime> GetMigrations for TransactorRelayIndexMigration<Runtime>
-where
-	Runtime: pallet_xcm_transactor::Config,
-{
-	fn get_migrations() -> Vec<Box<dyn Migration>> {
-		vec![Box::new(
-			moonbeam_runtime_common::migrations::PopulateRelayIndices::<Runtime>(
-				moonbeam_relay_encoder::kusama::KUSAMA_RELAY_INDICES,
-				Default::default(),
-			),
-		)]
-	}
-}
-
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type MigrationsList = (
@@ -1084,7 +1067,6 @@ impl pallet_migrations::Config for Runtime {
 			OpenTechCommitteeCollective,
 		>,
 		moonbeam_runtime_common::migrations::ReferendaMigrations<Runtime>,
-		TransactorRelayIndexMigration<Runtime>,
 	);
 	type XcmExecutionManager = XcmExecutionManager;
 }


### PR DESCRIPTION
### What does it do?

Removes the following migrations that were already applied in previous runtime upgrades:

- `PreimageMigrationHashToBoundedCall`
- `TransactorRelayIndexMigration`  (and its related `PopulateRelayIndices`)
- `RemoveMinBondForOrbiterCollators`