### PR TITLE
Update moonbeam-vrf to Rust 2021

### DIFF
--- a/client/vrf/Cargo.toml
+++ b/client/vrf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "moonbeam-vrf"
 authors = { workspace = true }
-edition = "2018"
+edition = "2021"
 homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
 repository = { workspace = true }


### PR DESCRIPTION
Update moonbeam-vrf to Rust 2021 edition. All other crates are already using `edition = 2021`. Using an older edition can lead to confusing compile errors when working on this crate.