### PR TITLE
restore changleog generation during releease

### DIFF
--- a/tools/github/generate-release-body.ts
+++ b/tools/github/generate-release-body.ts
@@ -46,7 +46,7 @@ async function main() {
   const newTag = argv.to;
 
   // TODO: this section should be optional with default to ["polkadot-sdk", "frontier"]
-  const moduleLinks = [].map((repoName) => ({
+  const moduleLinks = ["polkadot-sdk", "frontier"].map((repoName) => ({
     name: repoName,
     link: getCompareLink(repoName, previousTag, newTag),
   }));

--- a/tools/github/generate-runtimes-body.ts
+++ b/tools/github/generate-runtimes-body.ts
@@ -99,8 +99,7 @@ async function main() {
     getRuntimeInfo(argv["srtool-report-folder"], runtimeName)
   );
 
-  // TODO: this section should be optional with default to ["polkadot-sdk", "frontier"]
-  const moduleLinks = [].map((repoName) => ({
+  const moduleLinks = ["polkadot-sdk", "frontier"].map((repoName) => ({
     name: repoName,
     link: getCompareLink(repoName, previousTag, newTag),
   }));


### PR DESCRIPTION
### What does it do?

changelog generation was disabled for the polkadot repositories consolidation
