### PR TITLE
Filter out new treasury dispatchables

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1187,6 +1187,12 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// this can be seen as an additional security
 			RuntimeCall::EVM(_) => false,
 			RuntimeCall::Democracy(pallet_democracy::Call::propose { .. }) => false,
+			RuntimeCall::Treasury(
+				pallet_treasury::Call::spend { .. }
+				| pallet_treasury::Call::payout { .. }
+				| pallet_treasury::Call::check_status { .. }
+				| pallet_treasury::Call::void_spend { .. },
+			) => false,
 			_ => true,
 		}
 	}

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1173,6 +1173,12 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// this can be seen as an additional security
 			RuntimeCall::EVM(_) => false,
 			RuntimeCall::Democracy(pallet_democracy::Call::propose { .. }) => false,
+			RuntimeCall::Treasury(
+				pallet_treasury::Call::spend { .. }
+				| pallet_treasury::Call::payout { .. }
+				| pallet_treasury::Call::check_status { .. }
+				| pallet_treasury::Call::void_spend { .. },
+			) => false,
 			_ => true,
 		}
 	}

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1176,6 +1176,12 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// this can be seen as an additional security
 			RuntimeCall::EVM(_) => false,
 			RuntimeCall::Democracy(pallet_democracy::Call::propose { .. }) => false,
+			RuntimeCall::Treasury(
+				pallet_treasury::Call::spend { .. }
+				| pallet_treasury::Call::payout { .. }
+				| pallet_treasury::Call::check_status { .. }
+				| pallet_treasury::Call::void_spend { .. },
+			) => false,
 			_ => true,
 		}
 	}


### PR DESCRIPTION
### What does it do?

The 4 new treasury dispatchables  can only be used to send non-native tokens. As our current configuration for pallet treasury does not allow this new functionality to be used, we're filtering out these new dispatchables for the time being.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
