### PR TITLE
Fix effectiveGasPrice computation for eth_getTransactionReceipt 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "evm",
  "frame-support",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8606,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8662,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "environmental",
  "evm",
@@ -8688,7 +8688,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8782,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "fp-evm",
 ]
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "fp-evm",
  "num",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9237,7 +9237,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "evm",
  "frame-support",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8606,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8662,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "environmental",
  "evm",
@@ -8688,7 +8688,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8782,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "fp-evm",
 ]
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "fp-evm",
  "num",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9237,7 +9237,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#00bd4a668658cfb0ea4c89373e7b168f11efbf69"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0-elfedy-fix-tr#25be8e7d8508e4a2d3724d3d3149a0767c7618d8"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,36 +225,36 @@ ethereum-types = { version = "0.14", default-features = false }
 evm = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
 evm-gasometer = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
 evm-runtime = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-fp-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-fp-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-fp-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-fp-self-contained = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-pallet-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false, features = [
+fp-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+fp-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+fp-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+fp-self-contained = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false, features = [
 	"forbid-evm-reentrancy",
 ] }
-pallet-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false, features = [
+pallet-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false, features = [
 	"forbid-evm-reentrancy",
 ] }
-pallet-evm-chain-id = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-pallet-evm-precompile-blake2 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-evm-precompile-blake2 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
 
 # Frontier (client)
-fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
-fc-db = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
-fc-api = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
-fc-mapping-sync = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
-fc-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", features = [
+fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fc-db = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fc-api = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fc-mapping-sync = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fc-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", features = [
 	"rpc-binary-search-estimate",
 ] }
-fc-rpc-core = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
-fc-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
-fp-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
-fp-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fc-rpc-core = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fc-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fp-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fp-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
 
 # Cumulus (wasm)
 cumulus-pallet-dmp-queue = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-v1.3.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,36 +225,36 @@ ethereum-types = { version = "0.14", default-features = false }
 evm = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
 evm-gasometer = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
 evm-runtime = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-fp-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-fp-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-fp-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-fp-self-contained = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-pallet-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false, features = [
+fp-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+fp-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+fp-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+fp-self-contained = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-ethereum = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false, features = [
 	"forbid-evm-reentrancy",
 ] }
-pallet-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false, features = [
+pallet-evm = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false, features = [
 	"forbid-evm-reentrancy",
 ] }
-pallet-evm-chain-id = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-pallet-evm-precompile-blake2 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-evm-precompile-blake2 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", default-features = false }
 
 # Frontier (client)
-fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
-fc-db = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
-fc-api = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
-fc-mapping-sync = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
-fc-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0", features = [
+fc-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fc-db = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fc-api = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fc-mapping-sync = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fc-rpc = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr", features = [
 	"rpc-binary-search-estimate",
 ] }
-fc-rpc-core = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
-fc-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
-fp-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
-fp-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0" }
+fc-rpc-core = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fc-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fp-consensus = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
+fp-storage = { git = "https://github.com/moonbeam-foundation/frontier", branch = "moonbeam-polkadot-v1.3.0-elfedy-fix-tr" }
 
 # Cumulus (wasm)
 cumulus-pallet-dmp-queue = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-v1.3.0", default-features = false }

--- a/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
+++ b/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
@@ -17,7 +17,7 @@ describeSuite({
       id: "T01",
       title:
         "should have correct effectiveGasPrice when fee multiplier changes in consecutive blocks",
-      test: async function() {
+      test: async function () {
         const prevBlockNextFeeMultiplier = (
           await polkadotJs.query.transactionPayment.nextFeeMultiplier()
         ).toBigInt();

--- a/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
+++ b/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
@@ -4,7 +4,7 @@ import { BALTATHAR_ADDRESS, createViemTransaction, extractFee } from "@moonwall/
 
 describeSuite({
   id: "D1206",
-  title: "Gas - Eth Transaction Receipt",
+  title: "Ethereum RPC - eth_getTransactionReceipt",
   foundationMethods: "dev",
   testCases: ({ it, context, log }) => {
     let polkadotJs: ApiPromise;

--- a/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
+++ b/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
@@ -16,8 +16,8 @@ describeSuite({
     it({
       id: "T01",
       title:
-        "should have correct effectiveGasPrice calculation when fee multiplier is different in consecutive blocks",
-      test: async function () {
+        "should have correct effectiveGasPrice when fee multiplier changes in consecutive blocks",
+      test: async function() {
         const prevBlockNextFeeMultiplier = (
           await polkadotJs.query.transactionPayment.nextFeeMultiplier()
         ).toBigInt();

--- a/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
+++ b/test/suites/dev/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
@@ -1,0 +1,54 @@
+import { describeSuite, expect, beforeAll } from "@moonwall/cli";
+import { ApiPromise } from "@polkadot/api";
+import { BALTATHAR_ADDRESS, createViemTransaction, extractFee } from "@moonwall/util";
+
+describeSuite({
+  id: "D1206",
+  title: "Gas - Eth Transaction Receipt",
+  foundationMethods: "dev",
+  testCases: ({ it, context, log }) => {
+    let polkadotJs: ApiPromise;
+
+    beforeAll(() => {
+      polkadotJs = context.polkadotJs();
+    });
+
+    it({
+      id: "T01",
+      title:
+        "should have correct effectiveGasPrice calculation when fee multiplier is different in consecutive blocks",
+      test: async function () {
+        const prevBlockNextFeeMultiplier = (
+          await polkadotJs.query.transactionPayment.nextFeeMultiplier()
+        ).toBigInt();
+
+        const { result } = await context.createBlock(
+          await createViemTransaction(context, {
+            gas: 21_000n,
+            maxFeePerGas: 1_000_000_000_000_000n,
+            maxPriorityFeePerGas: 1n,
+            type: "eip1559",
+            to: BALTATHAR_ADDRESS,
+          })
+        );
+        const txHash = result?.hash;
+        const txFee = extractFee(result?.events)!.amount.toBigInt();
+
+        const txReceipt = await context.viem().getTransactionReceipt({ hash: txHash });
+        const txReceiptFee = txReceipt.effectiveGasPrice * txReceipt.gasUsed;
+
+        const txBlockNextFeeMultiplier = (
+          await polkadotJs.query.transactionPayment.nextFeeMultiplier()
+        ).toBigInt();
+
+        // NOTE: fee multiplier needs to be different to ensure the test does not
+        // yield a false positive. If some conditions make these values equal, some
+        // extra transactions need to be added to the second block to make the
+        // values differ.
+        expect(prevBlockNextFeeMultiplier).not.toEqual(txBlockNextFeeMultiplier);
+
+        expect(txReceiptFee).toEqual(txFee);
+      },
+    });
+  },
+});


### PR DESCRIPTION
### What does it do?
Fixes wrong value for `effectiveGasPrice` on `eth_getTransactionReceipt` which is using `NextFeeMultiplier` from the block the transaction happened vs the `NextFeeMultiplier` on the previous block which is the actual value used to compute the base fee for the transaction. 

### Is there something left for follow-up PRs?
There might be other places where `gas_price` runtime call with the hash of the block is used to get the base fee. Those places should also be updated for the sake of consistency, maybe abstracting the computation of the base fee. Example: https://github.com/moonbeam-foundation/frontier/blob/2f509926db8df03aa6f831d48fcf18a3c456cc49/client/rpc/src/eth/block.rs#L114

### What alternative implementations were considered?
`eth_getTransactionReceipt` rpc call makes a runtime call to moonbeam internally, there is the argument of implementing the fix on moonbeam via that runtime call vs patching frontier.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
https://github.com/moonbeam-foundation/frontier/pull/199

### What value does it bring to the blockchain users?
RPC users will get the actual effectiveGasPrice used by the transaction.