### PR TITLE
chore: Fix typo s/verison/version/

### DIFF
--- a/moonbeam-types-bundle/README.md
+++ b/moonbeam-types-bundle/README.md
@@ -148,7 +148,7 @@ each runtime version.
 ## Print Types
 
 To print and save types JSON for a specific version run:
-`ts-node generateJSON.ts <verison number>`
+`ts-node generateJSON.ts <version number>`
 
 To print and save the latest:
 `ts-node generateJSON.ts latest`


### PR DESCRIPTION
### What does it do?

Just fix typo s/verison/version/
