### PR TITLE
Enable debug-assertions for non-production profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,12 +451,13 @@ inherits = "release"
 lto = true
 
 [profile.release]
-# Moonbeam runtime requires unwinding.
+debug-assertions = true # Enable debug-assert! for non-production profiles
 opt-level = 3
+# Moonbeam runtime requires unwinding.
 panic = "unwind"
 
 [profile.testnet]
 debug = 1               # debug symbols are useful for profilers
-debug-assertions = true
+debug-assertions = true # Enable debug-assert! for non-production profiles
 inherits = "release"
 overflow-checks = true


### PR DESCRIPTION
### What does it do?

Parity use a lot `debug_assert!` in polkaodt-sdk codebase to check potentials bugs and inconsistencies in there tests, but we don't catch them in our tests currently because we run our tests with the release profile taht doesn't include debug-assertions by default, the goal of this PR is to enable debug-assertions for the binaries that we use for our tests

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
