### PR TITLE
Take holds into account for balance-consistency smoke test

### DIFF
--- a/test/suites/smoke/test-balances-consistency.ts
+++ b/test/suites/smoke/test-balances-consistency.ts
@@ -668,6 +668,31 @@ describeSuite({
           });
       });
 
+      await new Promise((resolve, reject) => {
+        apiAt.query.balances.holds
+          .entries()
+          .then((holds) => {
+            holds.forEach((holdsOf) => {
+              const accountId = holdsOf[0].toHex().slice(-40);
+              //console.log(holdsOf[1]);
+              holdsOf[1].forEach((holdOf) => {
+                if (holdOf.id.isPreimage) {
+                  updateReserveMap(accountId, {
+                    [ReserveType.Preimage]: holdOf.amount.toBigInt(),
+                  });
+                } else {
+                  throw `Unknown hold id ${holdOf.id}`;
+                }
+              });
+            });
+            resolve("holds scraped");
+          })
+          .catch((error) => {
+            console.error("Error fetching holds:", error);
+            reject(error);
+          });
+      });
+
       if (specVersion >= 2401) {
         await new Promise((resolve, reject) => {
           apiAt.query.multisig.multisigs
@@ -907,7 +932,7 @@ describeSuite({
       }
 
       //3) Collect and process locks failures
-      // Loose check because we don't have a way to clever way to verify expired but unclaimed locks
+      // Loose check because we don't have a clever way to verify expired but unclaimed locks
       locksMap.forEach((value, key) => {
         if (expectedLocksMap.has(key)) {
           if (expectedLocksMap.get(key)!.total! > value.total) {


### PR DESCRIPTION
### What does it do?
`S300C100` Smoke test fails in new runtime due to some reserve amount being added to `hold`, so test needs to be adapted to that change by looking at `holds` and adding  them to the expected reserves.
