### PR TITLE
Enforce minimum [pnpm, node] versions when running typescript tests

### DIFF
--- a/test/.npmrc
+++ b/test/.npmrc
@@ -2,3 +2,4 @@ ignore-workspace-root-check = true
 strict-peer-dependencies = false
 registry = https://registry.npmjs.org/
 auto-install-peers = true
+engine-strict=true

--- a/test/package.json
+++ b/test/package.json
@@ -66,5 +66,9 @@
     "prettier": "2.8.8",
     "typescript": "5.3.3",
     "yargs": "17.7.2"
+  },
+  "engines": {
+    "pnpm": ">=8.6",
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
### What does it do?

It is a small improvement to the typescript test setup. This change will enforce minimum versions for [`pnpm`, `nodejs`] when running the typescript tests.

### What important points reviewers should know?

The minimum versions included in the commit are the same ones used in the CI pipeline.

### What value does it bring to the blockchain users?

I was not able to run the tests with older versions (pnpm 7 and nodejs 16), having version checks may help other users when running the tests