### PR TITLE
Use Forked Binaries for zombie upgrade test

### DIFF
--- a/.github/workflow-templates/dev-tests/action.yml
+++ b/.github/workflow-templates/dev-tests/action.yml
@@ -18,7 +18,7 @@ runs:
         version: 8.6.12
     - uses: actions/setup-node@v3
       with:
-        node-version: 20.10
+        node-version: 20.10.0
         cache: "pnpm"
         cache-dependency-path: test/pnpm-lock.yaml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -615,9 +615,15 @@ jobs:
           docker rm -f moonbeam_container
       - name: "TEMPORARY: Download forked polkadot-bins"
         run: |
-          wget https://opslayer-dev-artifacts.s3.us-east-2.amazonaws.com/bins/moonbeam/polkadot/1.3.0/polkadot -O test/tmp/polkadot-forked-1.3
-          chmod +x test/tmp/polkadot-forked-1.3
-      - name: "Run zombie upgrade test"
+
+          # When we remove this step, re-add "runScripts": ["download-polkadot.sh"]," to moonwall config
+          cd test/tmp
+          wget https://opslayer-dev-artifacts.s3.us-east-2.amazonaws.com/bins/moonbeam/polkadot/1.3.0/polkadot
+          wget https://opslayer-dev-artifacts.s3.us-east-2.amazonaws.com/bins/moonbeam/polkadot/1.3.0/polkadot-execute-worker
+          wget https://opslayer-dev-artifacts.s3.us-east-2.amazonaws.com/bins/moonbeam/polkadot/1.3.0/polkadot-prepare-worker
+
+          chmod +x test/tmp/polkadot-*
+      - name: Prepare Chainspecs
         run: |
           cd test
           pnpm install
@@ -627,6 +633,10 @@ jobs:
           tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
           pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json
           tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
+
+      - name: "Run zombie upgrade test"
+        run: |
+          cd test
 
           ## Start zombie network and run tests
           chmod uog+x ../target/release/moonbeam
@@ -634,13 +644,6 @@ jobs:
       - name: "Run zombie RPC test"
         run: |
           cd test
-          pnpm install
-
-          ## Generate old spec using latest published node, modify it, and generate raw spec
-          chmod uog+x tmp/moonbeam_rt
-          tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
-          pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json
-          tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
 
           ## Start zombie network and run tests
           chmod uog+x ../target/release/moonbeam

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -615,6 +615,10 @@ jobs:
           docker create --name moonbeam_container $DOCKER_TAG bash
           docker cp moonbeam_container:moonbeam/moonbeam test/tmp/moonbeam_rt
           docker rm -f moonbeam_container
+      - name: "TEMPORARY: Download forked polkadot-bins"
+        run: |
+          wget https://opslayer-dev-artifacts.s3.us-east-2.amazonaws.com/bins/moonbeam/polkadot/1.3.0/polkadot -O test/tmp/polkadot-forked-1.3
+          chmod +x test/tmp/polkadot-forked-1.3
       - name: "Run zombie upgrade test"
         run: |
           cd test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,10 +201,10 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8.6.12
-      - name: Use Node.js 20.10
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.10
+          node-version: 20.10.0
           cache: "pnpm"
           cache-dependency-path: test/pnpm-lock.yaml
       - name: Run Eslint check
@@ -417,10 +417,10 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 8.6.12
-      - name: Use Node.js 20.10
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.10
+          node-version: 20.10.0
           cache: "pnpm"
           cache-dependency-path: test/pnpm-lock.yaml
       - run: |
@@ -461,9 +461,7 @@ jobs:
   docker-moonbeam:
     runs-on: ubuntu-latest
     needs: ["set-tags", "build"]
-    if: |
-      ${{! needs.set-tags.outputs.image_exists }} && 
-      ${{! github.event.pull_request.head.repo.fork }}
+    if: ${{ !needs.set-tags.outputs.image_exists && !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -543,7 +541,7 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.10
+          node-version: 20.10.0
           cache: "pnpm"
           cache-dependency-path: test/pnpm-lock.yaml
       - name: Create local folders
@@ -591,7 +589,7 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.10
+          node-version: 20.10.0
       - name: Create local folders
         run: |
           mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/
@@ -627,7 +625,7 @@ jobs:
           ## Generate old spec using latest published node, modify it, and generate raw spec
           chmod uog+x tmp/moonbeam_rt
           tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
-          pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json 
+          pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json
           tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
 
           ## Start zombie network and run tests
@@ -641,7 +639,7 @@ jobs:
           ## Generate old spec using latest published node, modify it, and generate raw spec
           chmod uog+x tmp/moonbeam_rt
           tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
-          pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json 
+          pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json
           tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
 
           ## Start zombie network and run tests

--- a/.github/workflows/client-release-issue.yml
+++ b/.github/workflows/client-release-issue.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.10.0
       - name: Download Original Tools
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
     runs-on:
       labels: bare-metal
     needs: ["set-tags"]
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 60
     env:
       RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -87,10 +87,10 @@ jobs:
         with:
           name: binaries
           path: build
-      - name: Use Node.js 18.x
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.10.0
       - name: Download Original Tools
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -135,10 +135,10 @@ jobs:
         with:
           name: moonbeam-runtime
           path: build
-      - name: Use Node.js 18.x
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.10.0
       - name: Download Original Tools
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.sha }}
-      - name: Use Node.js 20.10
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.10
+          node-version: 20.10.0
       - name: Build typescript API
         run: |
           cd typescript-api
@@ -37,10 +37,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.sha }}
-      - name: Use Node.js 20.10
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.10
+          node-version: 20.10.0
       - name: Upgrade polkadotjs for tests
         run: |
           cd test

--- a/.github/workflows/runtime-release-issue.yml
+++ b/.github/workflows/runtime-release-issue.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.10.0
       - name: Download Original Tools
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/upgrade-typescript-api.yml
+++ b/.github/workflows/upgrade-typescript-api.yml
@@ -24,10 +24,10 @@ jobs:
           mkdir -p build
           docker cp dummy:/moonbeam/moonbeam build/moonbeam
           docker rm -f dummy
-      - name: Use Node.js 20.10
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.9.0
+          node-version: 20.10.0
       - name: Use pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.10.0
       - name: Generate version bump issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "editor.rulers": [100],
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscod"
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2097,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
@@ -2316,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2356,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.29",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "async-trait",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3818,7 +3818,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "evm",
  "frame-support",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -3939,7 +3939,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.0",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4023,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "indicatif",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "aquamarine",
  "bitflags 1.3.2",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4172,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -4191,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "log",
@@ -6387,7 +6387,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -8180,7 +8180,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8195,7 +8195,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8286,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8302,7 +8302,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8316,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8340,7 +8340,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8362,7 +8362,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8377,7 +8377,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8397,7 +8397,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "binary-merkle-tree",
@@ -8422,7 +8422,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8440,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8459,7 +8459,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8476,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8515,7 +8515,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8533,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8556,7 +8556,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8612,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8668,7 +8668,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "environmental",
  "evm",
@@ -8694,7 +8694,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "fp-evm",
 ]
@@ -8796,7 +8796,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8952,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "fp-evm",
  "num",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9244,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#539225fca1ff104f4c8ff8f2041eab8b68e903ec"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.3.0#8c90bb75ed280318465dcbedebd534a40ad09aa5"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9402,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9494,7 +9494,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "7.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9549,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9601,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9617,7 +9617,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9636,7 +9636,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9656,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9667,7 +9667,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9684,7 +9684,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9747,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9804,7 +9804,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9837,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9889,7 +9889,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9946,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9969,7 +9969,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9980,7 +9980,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9989,7 +9989,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10070,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10086,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -10102,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -10114,7 +10114,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10133,7 +10133,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10164,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -10200,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10587,7 +10587,7 @@ checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "futures-timer",
@@ -10605,7 +10605,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "always-assert",
  "futures 0.3.29",
@@ -10621,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10644,7 +10644,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10666,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "1.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "derive_more",
  "fatality",
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10766,7 +10766,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "futures-timer",
@@ -10787,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10810,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "parity-scale-codec",
@@ -10828,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -10857,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "futures 0.3.29",
@@ -10879,7 +10879,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "polkadot-node-subsystem",
@@ -10913,7 +10913,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -10934,7 +10934,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "polkadot-node-metrics",
@@ -10949,7 +10949,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "futures-timer",
@@ -10966,7 +10966,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "fatality",
  "futures 0.3.29",
@@ -10985,7 +10985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -11002,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11019,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "always-assert",
  "cfg-if",
@@ -11065,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "polkadot-node-primitives",
@@ -11081,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -11105,7 +11105,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "polkadot-node-metrics",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "lazy_static",
  "log",
@@ -11138,7 +11138,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bs58 0.5.0",
  "futures 0.3.29",
@@ -11157,7 +11157,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11181,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bounded-vec",
  "futures 0.3.29",
@@ -11203,7 +11203,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -11213,7 +11213,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -11273,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -11295,7 +11295,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -11312,7 +11312,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "hex-literal 0.4.1",
@@ -11338,7 +11338,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -11370,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bs58 0.5.0",
  "frame-benchmarking",
@@ -11433,7 +11433,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -11480,7 +11480,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -11598,7 +11598,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -11622,7 +11622,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -12494,7 +12494,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -12589,7 +12589,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12862,7 +12862,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "log",
  "sp-core",
@@ -12873,7 +12873,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -12901,7 +12901,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "futures-timer",
@@ -12924,7 +12924,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -12939,7 +12939,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -12958,7 +12958,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -12969,7 +12969,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "chrono",
@@ -13012,7 +13012,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "fnv",
  "futures 0.3.29",
@@ -13039,7 +13039,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "hash-db 0.16.0",
  "kvdb",
@@ -13065,7 +13065,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -13090,7 +13090,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -13119,7 +13119,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -13154,7 +13154,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "jsonrpsee",
@@ -13176,7 +13176,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "async-channel 1.9.0",
@@ -13210,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "jsonrpsee",
@@ -13229,7 +13229,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -13242,7 +13242,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "ahash 0.8.6",
  "array-bytes 6.2.0",
@@ -13283,7 +13283,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.29",
@@ -13303,7 +13303,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13338,7 +13338,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -13361,7 +13361,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13384,7 +13384,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "sc-allocator",
@@ -13397,7 +13397,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13417,7 +13417,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "ansi_term",
  "futures 0.3.29",
@@ -13433,7 +13433,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "parking_lot 0.12.1",
@@ -13447,7 +13447,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -13475,7 +13475,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "async-channel 1.9.0",
@@ -13516,7 +13516,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-channel 1.9.0",
  "cid",
@@ -13536,7 +13536,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -13553,7 +13553,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "ahash 0.8.6",
  "futures 0.3.29",
@@ -13571,7 +13571,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "async-channel 1.9.0",
@@ -13592,7 +13592,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "async-channel 1.9.0",
@@ -13627,7 +13627,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "futures 0.3.29",
@@ -13645,7 +13645,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "bytes",
@@ -13679,7 +13679,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13688,7 +13688,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "jsonrpsee",
@@ -13720,7 +13720,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13740,7 +13740,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -13755,7 +13755,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "futures 0.3.29",
@@ -13783,7 +13783,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "directories",
@@ -13847,7 +13847,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13858,7 +13858,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "clap",
  "fs4",
@@ -13872,7 +13872,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13891,7 +13891,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "libc",
@@ -13910,7 +13910,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "chrono",
  "futures 0.3.29",
@@ -13929,7 +13929,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "ansi_term",
  "atty",
@@ -13958,7 +13958,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -13969,7 +13969,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -13995,7 +13995,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -14011,7 +14011,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.29",
@@ -14492,7 +14492,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14686,7 +14686,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -14707,7 +14707,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14721,7 +14721,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14734,7 +14734,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -14748,7 +14748,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14761,7 +14761,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14772,7 +14772,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "log",
@@ -14790,7 +14790,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "futures 0.3.29",
@@ -14805,7 +14805,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14822,7 +14822,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14841,7 +14841,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14860,7 +14860,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14878,7 +14878,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14890,7 +14890,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "bandersnatch_vrfs",
@@ -14937,7 +14937,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14950,7 +14950,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -14960,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -14969,7 +14969,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14979,7 +14979,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14990,7 +14990,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -15001,7 +15001,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -15015,7 +15015,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.1.0",
@@ -15039,7 +15039,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -15050,7 +15050,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -15062,7 +15062,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -15071,7 +15071,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -15082,7 +15082,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -15112,7 +15112,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15126,7 +15126,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -15136,7 +15136,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -15146,7 +15146,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -15156,7 +15156,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -15178,7 +15178,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -15196,7 +15196,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -15208,7 +15208,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15223,7 +15223,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15237,7 +15237,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -15258,7 +15258,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "aes-gcm 0.10.3",
  "curve25519-dalek 4.1.1",
@@ -15282,12 +15282,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15313,7 +15313,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -15325,7 +15325,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15334,7 +15334,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15349,7 +15349,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "ahash 0.8.6",
  "hash-db 0.16.0",
@@ -15373,7 +15373,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -15390,7 +15390,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -15401,7 +15401,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15414,7 +15414,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15617,7 +15617,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "bounded-collections",
  "derivative",
@@ -15634,7 +15634,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15656,7 +15656,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15802,7 +15802,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 
 [[package]]
 name = "substrate-fixed"
@@ -15817,7 +15817,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.29",
@@ -15836,7 +15836,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "hyper",
  "log",
@@ -15848,7 +15848,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -15861,7 +15861,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15878,7 +15878,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "async-trait",
@@ -15904,7 +15904,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "array-bytes 6.2.0",
  "frame-executive",
@@ -15947,7 +15947,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "futures 0.3.29",
  "sc-block-builder",
@@ -15975,7 +15975,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -16532,7 +16532,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "coarsetime",
  "polkadot-node-jaeger",
@@ -16544,7 +16544,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "expander 2.0.0",
  "proc-macro-crate",
@@ -16693,7 +16693,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "async-trait",
  "clap",
@@ -17651,7 +17651,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17756,7 +17756,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -18105,7 +18105,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -18116,7 +18116,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#542721dd4ab6b8119a8479a8830e57e101249594"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.3.0#771cd7512cf6c4efc9f01539acb797a6f1cbb623"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -27,7 +27,7 @@
 //! derived from the multilocation of a use in this chain (tipically, hashing the ML).
 //! Such distinction is important since we want to keep the integrity of the sovereign account
 //!
-//! This pallet provides three ways of sending Transact operations to anothe chain
+//! This pallet provides three ways of sending Transact operations to another chain
 //!
 //! - transact_through_derivative: Transact through an address derived from this chains sovereign
 //! 	account in the destination chain. For the transaction to successfully be dispatched in the

--- a/primitives/xcm/src/fee_handlers.rs
+++ b/primitives/xcm/src/fee_handlers.rs
@@ -164,7 +164,7 @@ pub struct XcmFeesToAccount<Assets, Matcher, AccountId, ReceiverAccount>(
 impl<
 		Assets: Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
-		AccountId: Clone,
+		AccountId: Clone + Eq,
 		ReceiverAccount: Get<AccountId>,
 	> TakeRevenue for XcmFeesToAccount<Assets, Matcher, AccountId, ReceiverAccount>
 {

--- a/runtime/common/src/impl_on_charge_evm_transaction.rs
+++ b/runtime/common/src/impl_on_charge_evm_transaction.rs
@@ -17,34 +17,28 @@
 #[macro_export]
 macro_rules! impl_on_charge_evm_transaction {
 	{} => {
-		type CurrencyAccountId<T> = <T as frame_system::Config>::AccountId;
+		type FungibleAccountId<T> = <T as frame_system::Config>::AccountId;
 
 		type BalanceFor<T> =
-			<<T as pallet_evm::Config>::Currency as CurrencyT<CurrencyAccountId<T>>>::Balance;
-
-		type PositiveImbalanceFor<T> =
-			<<T as pallet_evm::Config>::Currency as CurrencyT<CurrencyAccountId<T>>>::PositiveImbalance;
-
-		type NegativeImbalanceFor<T> =
-			<<T as pallet_evm::Config>::Currency as CurrencyT<CurrencyAccountId<T>>>::NegativeImbalance;
+			<<T as pallet_evm::Config>::Currency as Inspect<FungibleAccountId<T>>>::Balance;
 
 		pub struct OnChargeEVMTransaction<OU>(sp_std::marker::PhantomData<OU>);
+
 		impl<T, OU> OnChargeEVMTransactionT<T> for OnChargeEVMTransaction<OU>
 		where
 			T: pallet_evm::Config,
-			PositiveImbalanceFor<T>: Imbalance<BalanceFor<T>, Opposite = NegativeImbalanceFor<T>>,
-			NegativeImbalanceFor<T>: Imbalance<BalanceFor<T>, Opposite = PositiveImbalanceFor<T>>,
-			OU: OnUnbalanced<NegativeImbalanceFor<T>>,
+			T::Currency: Balanced<T::AccountId>,
+			OU: OnUnbalanced<Credit<T::AccountId, T::Currency>>,
 			U256: UniqueSaturatedInto<BalanceFor<T>>
 		{
-			type LiquidityInfo = Option<NegativeImbalanceFor<T>>;
+			type LiquidityInfo = Option<Credit<T::AccountId, T::Currency>>;
 
 			fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, pallet_evm::Error<T>> {
-				EVMCurrencyAdapter::<<T as pallet_evm::Config>::Currency, ()>::withdraw_fee(who, fee)
+				EVMFungibleAdapter::<<T as pallet_evm::Config>::Currency, ()>::withdraw_fee(who, fee)
 			}
 
 			fn can_withdraw(who: &H160, amount: U256) -> Result<(), pallet_evm::Error<T>> {
-				EVMCurrencyAdapter::<<T as pallet_evm::Config>::Currency, ()>::can_withdraw(who, amount)
+				EVMFungibleAdapter::<<T as pallet_evm::Config>::Currency, ()>::can_withdraw(who, amount)
 			}
 
 			fn correct_and_deposit_fee(
@@ -52,8 +46,8 @@ macro_rules! impl_on_charge_evm_transaction {
 				corrected_fee: U256,
 				base_fee: U256,
 				already_withdrawn: Self::LiquidityInfo,
-			) -> Self::LiquidityInfo {
-				<EVMCurrencyAdapter<<T as pallet_evm::Config>::Currency, OU> as OnChargeEVMTransactionT<
+			) -> Result<Self::LiquidityInfo, pallet_evm::Error<T>> {
+				<EVMFungibleAdapter<<T as pallet_evm::Config>::Currency, OU> as OnChargeEVMTransactionT<
 					T,
 				>>::correct_and_deposit_fee(who, corrected_fee, base_fee, already_withdrawn)
 			}

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -63,12 +63,12 @@ use frame_support::{
 	pallet_prelude::DispatchResult,
 	parameter_types,
 	traits::{
-		fungible::HoldConsideration,
+		fungible::{Balanced, Credit, HoldConsideration, Inspect},
+		tokens::imbalance::ResolveTo,
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
-		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains,
-		Currency as CurrencyT, EitherOfDiverse, EqualPrivilegeOnly, FindAuthor, Imbalance,
-		InstanceFilter, LinearStoragePrice, OffchainWorker, OnFinalize, OnIdle, OnInitialize,
-		OnRuntimeUpgrade, OnUnbalanced,
+		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
+		EqualPrivilegeOnly, FindAuthor, Imbalance, InstanceFilter, LinearStoragePrice,
+		OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade, OnUnbalanced,
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
@@ -83,15 +83,15 @@ use governance::councils::*;
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
 use moonbeam_runtime_common::weights as moonbeam_weights;
 use nimbus_primitives::CanAuthor;
-use pallet_balances::NegativeImbalance;
 use pallet_ethereum::Call::transact;
 use pallet_ethereum::{PostLogContent, Transaction as EthereumTransaction};
 use pallet_evm::{
-	Account as EVMAccount, EVMCurrencyAdapter, EnsureAddressNever, EnsureAddressRoot,
+	Account as EVMAccount, EVMFungibleAdapter, EnsureAddressNever, EnsureAddressRoot,
 	FeeCalculator, GasWeightMapping, IdentityAddressMapping,
 	OnChargeEVMTransaction as OnChargeEVMTransactionT, Runner,
 };
-use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
+use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
+use pallet_treasury::TreasuryAccountId;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
@@ -318,36 +318,41 @@ impl pallet_balances::Config for Runtime {
 }
 
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>> for DealWithFees<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
-	pallet_treasury::Pallet<R>: OnUnbalanced<NegativeImbalance<R>>,
 {
 	// this seems to be called for substrate-based transactions
-	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
+	fn on_unbalanceds<B>(
+		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
+	) {
 		if let Some(fees) = fees_then_tips.next() {
 			// for fees, 80% are burned, 20% to the treasury
 			let (_, to_treasury) = fees.ration(80, 20);
-			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
+			// Balances pallet automatically burns dropped Credits by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
+				to_treasury,
+			);
 
 			// handle tip if there is one
 			if let Some(tip) = fees_then_tips.next() {
 				// for now we use the same burn/treasury strategy used for regular fees
 				let (_, to_treasury) = tip.ration(80, 20);
-				<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+				ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
+					to_treasury,
+				);
 			}
 		}
 	}
 
 	// this is called from pallet_evm for Ethereum-based transactions
 	// (technically, it calls on_unbalanced, which calls this when non-zero)
-	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		// Balances pallet automatically burns dropped Negative Imbalances by decreasing
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// Balances pallet automatically burns dropped Credits by decreasing
 		// total_supply accordingly
 		let (_, to_treasury) = amount.ration(80, 20);
-		<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
 	}
 }
 
@@ -375,7 +380,7 @@ impl WeightToFeePolynomial for LengthToFee {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = CurrencyAdapter<Balances, DealWithFees<Runtime>>;
+	type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees<Runtime>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ currency::WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -19,7 +19,6 @@
 mod common;
 use common::*;
 
-use pallet_balances::NegativeImbalance;
 use precompile_utils::{
 	precompile_set::{is_precompile_or_fail, IsActivePrecompile},
 	prelude::*,
@@ -2711,30 +2710,39 @@ fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
 	use moonbase_runtime::{DealWithFees, Treasury};
 
-	ExtBuilder::default()
-		.with_balances(vec![(AccountId::from(ALICE), 10_000)])
-		.build()
-		.execute_with(|| {
-			// Alice has 10_000, which makes inital supply 10_000.
-			// drop()ing the NegativeImbalance below will cause the total_supply to be decreased
-			// incorrectly (since there was never a withdraw to begin with), which in this case has
-			// the desired effect of showing that currency was burned.
-			let total_supply_before = Balances::total_issuance();
-			assert_eq!(total_supply_before, 10_000);
+	ExtBuilder::default().build().execute_with(|| {
+		// This test checks the functionality of the `DealWithFees` trait implementation in the runtime.
+		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
+		// treasury receives the correct amount (20% of the total), and the rest is burned (80%).
+		//
+		// The test follows these steps:
+		// 1. It issues a fee of 100 and a tip of 1000.
+		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
+		// 3. It checks that the treasury's balance is initially 0.
+		// 4. It calls `DealWithFees::on_unbalanceds` with the fee and tip.
+		// 5. It checks that the treasury's balance is now 220 (20% of the fee and tip).
+		// 6. It checks that the total supply has decreased by 880 (80% of the fee and tip), indicating
+		//    that this amount was burned.
+		let fee = <pallet_balances::Pallet<Runtime> as frame_support::traits::fungible::Balanced<
+			AccountId,
+		>>::issue(100);
+		let tip = <pallet_balances::Pallet<Runtime> as frame_support::traits::fungible::Balanced<
+			AccountId,
+		>>::issue(1000);
 
-			let fees_then_tips = vec![
-				NegativeImbalance::<moonbase_runtime::Runtime>::new(100),
-				NegativeImbalance::<moonbase_runtime::Runtime>::new(1_000),
-			];
-			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
+		let total_supply_before = Balances::total_issuance();
+		assert_eq!(total_supply_before, 1_100);
+		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
-			// treasury should have received 20%
-			assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+		DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
 
-			// verify 80% burned
-			let total_supply_after = Balances::total_issuance();
-			assert_eq!(total_supply_before - total_supply_after, 880);
-		});
+		// treasury should have received 20%
+		assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+
+		// verify 80% burned
+		let total_supply_after = Balances::total_issuance();
+		assert_eq!(total_supply_before - total_supply_after, 880);
+	});
 }
 
 #[test]

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -45,12 +45,12 @@ use frame_support::{
 	pallet_prelude::DispatchResult,
 	parameter_types,
 	traits::{
-		fungible::HoldConsideration,
+		fungible::{Balanced, Credit, HoldConsideration, Inspect},
+		tokens::imbalance::ResolveTo,
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
-		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains,
-		Currency as CurrencyT, EitherOfDiverse, EqualPrivilegeOnly, Imbalance, InstanceFilter,
-		LinearStoragePrice, OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade,
-		OnUnbalanced,
+		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
+		EqualPrivilegeOnly, Imbalance, InstanceFilter, LinearStoragePrice, OffchainWorker,
+		OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade, OnUnbalanced,
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
@@ -66,16 +66,16 @@ pub use moonbeam_core_primitives::{
 };
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
 use moonbeam_runtime_common::weights as moonbeam_weights;
-use pallet_balances::NegativeImbalance;
 use pallet_ethereum::Call::transact;
 use pallet_ethereum::{PostLogContent, Transaction as EthereumTransaction};
 use pallet_evm::{
-	Account as EVMAccount, EVMCurrencyAdapter, EnsureAddressNever, EnsureAddressRoot,
+	Account as EVMAccount, EVMFungibleAdapter, EnsureAddressNever, EnsureAddressRoot,
 	FeeCalculator, GasWeightMapping, IdentityAddressMapping,
 	OnChargeEVMTransaction as OnChargeEVMTransactionT, Runner,
 };
 pub use pallet_parachain_staking::{weights::WeightInfo, InflationInfo, Range};
-use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
+use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
+use pallet_treasury::TreasuryAccountId;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
@@ -308,36 +308,41 @@ impl pallet_balances::Config for Runtime {
 }
 
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>> for DealWithFees<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
-	pallet_treasury::Pallet<R>: OnUnbalanced<NegativeImbalance<R>>,
 {
 	// this seems to be called for substrate-based transactions
-	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
+	fn on_unbalanceds<B>(
+		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
+	) {
 		if let Some(fees) = fees_then_tips.next() {
 			// for fees, 80% are burned, 20% to the treasury
 			let (_, to_treasury) = fees.ration(80, 20);
-			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
+			// Balances pallet automatically burns dropped Credits by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
+				to_treasury,
+			);
 
 			// handle tip if there is one
 			if let Some(tip) = fees_then_tips.next() {
 				// for now we use the same burn/treasury strategy used for regular fees
 				let (_, to_treasury) = tip.ration(80, 20);
-				<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+				ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
+					to_treasury,
+				);
 			}
 		}
 	}
 
 	// this is called from pallet_evm for Ethereum-based transactions
 	// (technically, it calls on_unbalanced, which calls this when non-zero)
-	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		// Balances pallet automatically burns dropped Negative Imbalances by decreasing
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// Balances pallet automatically burns dropped Credits by decreasing
 		// total_supply accordingly
 		let (_, to_treasury) = amount.ration(80, 20);
-		<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
 	}
 }
 
@@ -365,7 +370,7 @@ impl WeightToFeePolynomial for LengthToFee {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = CurrencyAdapter<Balances, DealWithFees<Runtime>>;
+	type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees<Runtime>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ currency::WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2618,32 +2618,40 @@ fn removed_precompiles() {
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
 	use moonbeam_runtime::{DealWithFees, Treasury};
-	use pallet_balances::NegativeImbalance;
 
-	ExtBuilder::default()
-		.with_balances(vec![(AccountId::from(ALICE), 10_000)])
-		.build()
-		.execute_with(|| {
-			// Alice has 10_000, which makes inital supply 10_000.
-			// drop()ing the NegativeImbalance below will cause the total_supply to be decreased
-			// incorrectly (since there was never a withdraw to begin with), which in this case has
-			// the desired effect of showing that currency was burned.
-			let total_supply_before = Balances::total_issuance();
-			assert_eq!(total_supply_before, 10_000);
+	ExtBuilder::default().build().execute_with(|| {
+		// This test checks the functionality of the `DealWithFees` trait implementation in the runtime.
+		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
+		// treasury receives the correct amount (20% of the total), and the rest is burned (80%).
+		//
+		// The test follows these steps:
+		// 1. It issues a fee of 100 and a tip of 1000.
+		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
+		// 3. It checks that the treasury's balance is initially 0.
+		// 4. It calls `DealWithFees::on_unbalanceds` with the fee and tip.
+		// 5. It checks that the treasury's balance is now 220 (20% of the fee and tip).
+		// 6. It checks that the total supply has decreased by 880 (80% of the fee and tip), indicating
+		//    that this amount was burned.
+		let fee = <pallet_balances::Pallet<Runtime> as frame_support::traits::fungible::Balanced<
+			AccountId,
+		>>::issue(100);
+		let tip = <pallet_balances::Pallet<Runtime> as frame_support::traits::fungible::Balanced<
+			AccountId,
+		>>::issue(1000);
 
-			let fees_then_tips = vec![
-				NegativeImbalance::<moonbeam_runtime::Runtime>::new(100),
-				NegativeImbalance::<moonbeam_runtime::Runtime>::new(1_000),
-			];
-			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
+		let total_supply_before = Balances::total_issuance();
+		assert_eq!(total_supply_before, 1_100);
+		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
-			// treasury should have received 20%
-			assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+		DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
 
-			// verify 80% burned
-			let total_supply_after = Balances::total_issuance();
-			assert_eq!(total_supply_before - total_supply_after, 880);
-		});
+		// treasury should have received 20%
+		assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+
+		// verify 80% burned
+		let total_supply_after = Balances::total_issuance();
+		assert_eq!(total_supply_before - total_supply_after, 880);
+	});
 }
 
 #[test]

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -44,12 +44,12 @@ use frame_support::{
 	pallet_prelude::DispatchResult,
 	parameter_types,
 	traits::{
-		fungible::HoldConsideration,
+		fungible::{Balanced, Credit, HoldConsideration, Inspect},
+		tokens::imbalance::ResolveTo,
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
-		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains,
-		Currency as CurrencyT, EitherOfDiverse, EqualPrivilegeOnly, Imbalance, InstanceFilter,
-		LinearStoragePrice, OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade,
-		OnUnbalanced,
+		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
+		EqualPrivilegeOnly, Imbalance, InstanceFilter, LinearStoragePrice, OffchainWorker,
+		OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade, OnUnbalanced,
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
@@ -65,16 +65,16 @@ pub use moonbeam_core_primitives::{
 };
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
 use moonbeam_runtime_common::weights as moonbeam_weights;
-use pallet_balances::NegativeImbalance;
 use pallet_ethereum::Call::transact;
 use pallet_ethereum::{PostLogContent, Transaction as EthereumTransaction};
 use pallet_evm::{
-	Account as EVMAccount, EVMCurrencyAdapter, EnsureAddressNever, EnsureAddressRoot,
+	Account as EVMAccount, EVMFungibleAdapter, EnsureAddressNever, EnsureAddressRoot,
 	FeeCalculator, GasWeightMapping, IdentityAddressMapping,
 	OnChargeEVMTransaction as OnChargeEVMTransactionT, Runner,
 };
 pub use pallet_parachain_staking::{weights::WeightInfo, InflationInfo, Range};
-use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
+use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
+use pallet_treasury::TreasuryAccountId;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
@@ -309,36 +309,41 @@ impl pallet_balances::Config for Runtime {
 }
 
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>> for DealWithFees<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
-	pallet_treasury::Pallet<R>: OnUnbalanced<NegativeImbalance<R>>,
 {
 	// this seems to be called for substrate-based transactions
-	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
+	fn on_unbalanceds<B>(
+		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
+	) {
 		if let Some(fees) = fees_then_tips.next() {
 			// for fees, 80% are burned, 20% to the treasury
 			let (_, to_treasury) = fees.ration(80, 20);
-			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
+			// Balances pallet automatically burns dropped Credits by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
+				to_treasury,
+			);
 
 			// handle tip if there is one
 			if let Some(tip) = fees_then_tips.next() {
 				// for now we use the same burn/treasury strategy used for regular fees
 				let (_, to_treasury) = tip.ration(80, 20);
-				<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+				ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
+					to_treasury,
+				);
 			}
 		}
 	}
 
 	// this is called from pallet_evm for Ethereum-based transactions
 	// (technically, it calls on_unbalanced, which calls this when non-zero)
-	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		// Balances pallet automatically burns dropped Negative Imbalances by decreasing
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// Balances pallet automatically burns dropped Credits by decreasing
 		// total_supply accordingly
 		let (_, to_treasury) = amount.ration(80, 20);
-		<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
 	}
 }
 
@@ -366,7 +371,7 @@ impl WeightToFeePolynomial for LengthToFee {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = CurrencyAdapter<Balances, DealWithFees<Runtime>>;
+	type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees<Runtime>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ currency::WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;

--- a/test/.npmrc
+++ b/test/.npmrc
@@ -2,3 +2,4 @@ ignore-workspace-root-check = true
 strict-peer-dependencies = false
 registry = https://registry.npmjs.org/
 auto-install-peers = true
+engine-strict=true

--- a/test/configs/zombieAlphanet.json
+++ b/test/configs/zombieAlphanet.json
@@ -5,8 +5,7 @@
   },
   "relaychain": {
     "chain": "rococo-local",
-    "chain_spec_path": "tmp/rococo-modified-spec.json",
-    "default_command": "tmp/polkadot",
+    "default_command": "tmp/polkadot-forked-1.3",
     "default_args": [
       "--no-hardware-benchmarks",
       "-lparachain=debug",

--- a/test/configs/zombieAlphanet.json
+++ b/test/configs/zombieAlphanet.json
@@ -5,7 +5,7 @@
   },
   "relaychain": {
     "chain": "rococo-local",
-    "default_command": "tmp/polkadot-forked-1.3",
+    "default_command": "tmp/polkadot",
     "default_args": [
       "--no-hardware-benchmarks",
       "-lparachain=debug",

--- a/test/configs/zombieAlphanetRpc.json
+++ b/test/configs/zombieAlphanetRpc.json
@@ -5,8 +5,7 @@
   },
   "relaychain": {
     "chain": "rococo-local",
-    "default_command": "tmp/polkadot",
-    "chain_spec_path": "tmp/rococo-raw-spec.json",
+    "default_command": "tmp/polkadot-forked-1.3",
     "default_args": [
       "--no-hardware-benchmarks",
       "-lparachain=debug",

--- a/test/configs/zombieAlphanetRpc.json
+++ b/test/configs/zombieAlphanetRpc.json
@@ -5,7 +5,7 @@
   },
   "relaychain": {
     "chain": "rococo-local",
-    "default_command": "tmp/polkadot-forked-1.3",
+    "default_command": "tmp/polkadot",
     "default_args": [
       "--no-hardware-benchmarks",
       "-lparachain=debug",

--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -271,33 +271,6 @@ export const verifyBlockFees = async (
             }
           }
         }
-        // Then search for Deposit event from treasury
-        // This is for bug detection when the fees are not matching the expected value
-        // TODO: sudo should not have treasury event
-        const allDeposits = events
-          .filter(
-            (event) =>
-              event.section == "treasury" &&
-              event.method == "Deposit" &&
-              extrinsic.method.section !== "sudo"
-          )
-          .map((event) => (event.data[0] as any).toBigInt())
-          .reduce((p, v) => p + v, 0n);
-
-        expect(
-          txFees - txBurnt,
-          `Desposit Amount Discrepancy!\n` +
-            `    Block: #${blockDetails.block.header.number.toString()}\n` +
-            `Extrinsic: ${extrinsic.method.section}.${extrinsic.method.method}\n` +
-            `     Args: \n` +
-            extrinsic.args.map((arg) => `          - ${arg.toString()}\n`).join("") +
-            `   Events: \n` +
-            events
-              .map(({ data, method, section }) => `          - ${section}.${method}:: ${data}\n`)
-              .join("") +
-            `     fees not burnt : ${(txFees - txBurnt).toString().padStart(30, " ")}\n` +
-            `       all deposits : ${allDeposits.toString().padStart(30, " ")}`
-        ).to.eq(allDeposits);
       }
       // sumBlockFees += blockFees;
       sumBlockBurnt += blockBurnt;

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -79,6 +79,7 @@
       "testFileDir": ["suites/para"],
       "include": ["**/*moonbase*", "**/*common*"],
       "runScripts": ["download-polkadot.sh"],
+      "timeout": 300000,
       "foundation": {
         "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
         "type": "zombie",
@@ -89,6 +90,7 @@
     },
     {
       "name": "zombie_moonbase_rpc",
+      "timeout": 300000,
       "testFileDir": ["suites/para-rpc"],
       "include": ["**/*moonbase*", "**/*common*"],
       "runScripts": ["download-polkadot.sh"],

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -78,7 +78,6 @@
       "name": "zombie_moonbase",
       "testFileDir": ["suites/para"],
       "include": ["**/*moonbase*", "**/*common*"],
-      "runScripts": ["download-polkadot.sh"],
       "timeout": 300000,
       "foundation": {
         "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
@@ -93,7 +92,6 @@
       "timeout": 300000,
       "testFileDir": ["suites/para-rpc"],
       "include": ["**/*moonbase*", "**/*common*"],
-      "runScripts": ["download-polkadot.sh"],
       "foundation": {
         "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
         "type": "zombie",

--- a/test/package.json
+++ b/test/package.json
@@ -66,5 +66,9 @@
     "prettier": "2.8.8",
     "typescript": "5.3.3",
     "yargs": "17.7.2"
+  },
+  "engines": {
+    "pnpm": ">=8.6",
+    "node": ">=20.10.0"
   }
 }

--- a/test/suites/dev/test-author/test-author-failed-association.ts
+++ b/test/suites/dev/test-author/test-author-failed-association.ts
@@ -44,7 +44,6 @@ describeSuite({
         expect(result?.events.length === 6);
         expect(api.events.system.NewAccount.is(result?.events[2].event)).to.be.true;
         expect(api.events.balances.Endowed.is(result?.events[3].event)).to.be.true;
-        expect(api.events.treasury.Deposit.is(result?.events[4].event)).to.be.true;
         expect(api.events.system.ExtrinsicFailed.is(result?.events[6].event)).to.be.true;
 
         //check state

--- a/test/suites/dev/test-author/test-author-missing-deposit-fail.ts
+++ b/test/suites/dev/test-author/test-author-missing-deposit-fail.ts
@@ -69,7 +69,6 @@ describeSuite({
               expect(events.length === 6);
               expect(api.events.system.NewAccount.is(events[2].event)).to.be.true;
               expect(api.events.balances.Endowed.is(events[3].event)).to.be.true;
-              expect(api.events.treasury.Deposit.is(events[4].event)).to.be.true;
               expect(api.events.system.ExtrinsicFailed.is(events[5].event)).to.be.true;
               break;
             default:

--- a/test/suites/dev/test-author/test-author-non-author-clearing.ts
+++ b/test/suites/dev/test-author/test-author-non-author-clearing.ts
@@ -24,7 +24,6 @@ describeSuite({
         );
 
         expect(result?.events.length === 4);
-        expect(api.events.treasury.Deposit.is(result?.events[2].event)).to.be.true;
         expect(api.events.system.ExtrinsicFailed.is(result?.events[4].event)).to.be.true;
       },
     });

--- a/test/suites/dev/test-author/test-author-registered-clear.ts
+++ b/test/suites/dev/test-author/test-author-registered-clear.ts
@@ -27,7 +27,6 @@ describeSuite({
         expect(result?.events.length === 6);
         expect(api.events.balances.Unreserved.is(result?.events[1].event)).to.be.true;
         expect(api.events.authorMapping.KeysRemoved.is(result?.events[2].event)).to.be.true;
-        expect(api.events.treasury.Deposit.is(result?.events[4].event)).to.be.true;
         expect(api.events.system.ExtrinsicSuccess.is(result?.events[6].event)).to.be.true;
 
         // check mapping

--- a/test/suites/dev/test-author/test-author-simple-association.ts
+++ b/test/suites/dev/test-author/test-author-simple-association.ts
@@ -51,7 +51,6 @@ describeSuite({
         expect(api.events.authorMapping.KeysRegistered.is(result?.events[2].event)).to.be.true;
         expect(api.events.system.NewAccount.is(result?.events[4].event)).to.be.true;
         expect(api.events.balances.Endowed.is(result?.events[5].event)).to.be.true;
-        expect(api.events.treasury.Deposit.is(result?.events[6].event)).to.be.true;
         expect(api.events.system.ExtrinsicSuccess.is(result?.events[8].event)).to.be.true;
 
         // check association

--- a/test/suites/dev/test-author/test-author-unregistered-clear.ts
+++ b/test/suites/dev/test-author/test-author-unregistered-clear.ts
@@ -21,7 +21,6 @@ describeSuite({
         expect(result?.events.length === 6);
         expect(api.events.system.NewAccount.is(result?.events[2].event)).to.be.true;
         expect(api.events.balances.Endowed.is(result?.events[3].event)).to.be.true;
-        expect(api.events.treasury.Deposit.is(result?.events[4].event)).to.be.true;
         expect(api.events.system.ExtrinsicFailed.is(result?.events[6].event)).to.be.true;
       },
     });

--- a/test/suites/dev/test-balance/test-balance-extrinsics.ts
+++ b/test/suites/dev/test-balance/test-balance-extrinsics.ts
@@ -48,15 +48,14 @@ describeSuite({
           )!;
 
           context.polkadotJs().events.parachainStaking.candidate;
-          expect(ethTx.events.length).to.eq(9);
+          expect(ethTx.events.length).to.eq(8);
           expect(context.polkadotJs().events.system.NewAccount.is(ethTx.events[1])).to.be.true;
           expect(context.polkadotJs().events.balances.Endowed.is(ethTx.events[2])).to.be.true;
           expect(context.polkadotJs().events.balances.Transfer.is(ethTx.events[3])).to.be.true;
           expect(ethTx.events[3].data[0].toString()).to.eq(ALITH_ADDRESS);
           expect(ethTx.events[3].data[1].toString()).to.eq(randomAccount.address);
-          expect(context.polkadotJs().events.treasury.Deposit.is(ethTx.events[6])).to.be.true;
-          expect(context.polkadotJs().events.ethereum.Executed.is(ethTx.events[7])).to.be.true;
-          expect(context.polkadotJs().events.system.ExtrinsicSuccess.is(ethTx.events[8])).to.be
+          expect(context.polkadotJs().events.ethereum.Executed.is(ethTx.events[6])).to.be.true;
+          expect(context.polkadotJs().events.system.ExtrinsicSuccess.is(ethTx.events[7])).to.be
             .true;
         },
       });

--- a/test/suites/dev/test-balance/test-balance-transferable.ts
+++ b/test/suites/dev/test-balance/test-balance-transferable.ts
@@ -73,27 +73,13 @@ describeSuite({
           expect(await checkBalance(context, randomAddress)).toBeGreaterThan(4n * GLMR);
 
           // Do a second transfer of 2 GLMR to Balthazar
-          // const { result: res2 } = await context.createBlock(
-          //   context
-          //     .polkadotJs()
-          //     .tx.balances.transferAllowDeath(baltathar.address, 2n * GLMR)
-          //     .signAsync(randomAccount)
-          // );
-          // expect(res2!.successful).to.be.true;
-
-          // TODO Change this check once the transferable balance is fixed
-          // Check Ticket MOON-2598: https://opslayer.atlassian.net/browse/MOON-2598
-          expect(
-            async () =>
-              await context.createBlock(
-                context
-                  .polkadotJs()
-                  .tx.balances.transferAllowDeath(baltathar.address, 2n * GLMR)
-                  .signAsync(randomAccount)
-              )
-          ).rejects.toThrowError(
-            "1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low"
+          const { result: res2 } = await context.createBlock(
+            context
+              .polkadotJs()
+              .tx.balances.transferAllowDeath(baltathar.address, 2n * GLMR)
+              .signAsync(randomAccount)
           );
+          expect(res2!.successful).to.be.true;
         }
       },
     });

--- a/test/suites/dev/test-proxy/test-proxy-governance.ts
+++ b/test/suites/dev/test-proxy/test-proxy-governance.ts
@@ -51,7 +51,6 @@ describeSuite({
         const expectEvents = [
           context.polkadotJs().events.proxy.ProxyExecuted,
           context.polkadotJs().events.democracy.Voted,
-          context.polkadotJs().events.treasury.Deposit,
         ];
 
         const { result } = await context.createBlock(

--- a/test/suites/dev/test-sudo/test-sudo.ts
+++ b/test/suites/dev/test-sudo/test-sudo.ts
@@ -96,7 +96,6 @@ describeSuite({
         expect(context.polkadotJs().events.system.NewAccount.is(result!.events[2].event)).to.be
           .true;
         expect(context.polkadotJs().events.balances.Endowed.is(result!.events[3].event)).to.be.true;
-        expect(context.polkadotJs().events.treasury.Deposit.is(result!.events[4].event)).to.be.true;
         expect(context.polkadotJs().events.system.ExtrinsicFailed.is(result!.events[6].event)).to.be
           .true;
 

--- a/test/suites/para-rpc/test_moonbase.ts
+++ b/test/suites/para-rpc/test_moonbase.ts
@@ -49,9 +49,6 @@ describeSuite({
       title: "Chain can be upgraded",
       timeout: 1200000,
       test: async () => {
-        const blockNumberBefore = (
-          await paraApi.rpc.chain.getBlock()
-        ).block.header.number.toNumber();
         const currentCode = (await paraApi.rpc.state.getStorage(":code")) as any;
         const codeString = currentCode.toString();
         const upgradePath = (await MoonwallContext.getContext()).rtUpgradePath;
@@ -71,6 +68,9 @@ describeSuite({
         log(`New runtime hash: ${codeString.slice(0, 10)}...${codeString.slice(-10)}`);
 
         await context.upgradeRuntime({ logger: log });
+        const blockNumberBefore = (
+          await paraApi.rpc.chain.getBlock()
+        ).block.header.number.toNumber();
         await context.waitBlock(2);
         const blockNumberAfter = (
           await paraApi.rpc.chain.getBlock()

--- a/test/suites/para-rpc/test_moonbase.ts
+++ b/test/suites/para-rpc/test_moonbase.ts
@@ -71,7 +71,7 @@ describeSuite({
         const blockNumberBefore = (
           await paraApi.rpc.chain.getBlock()
         ).block.header.number.toNumber();
-        await context.waitBlock(2);
+        await context.waitBlock(2, "parachain");
         const blockNumberAfter = (
           await paraApi.rpc.chain.getBlock()
         ).block.header.number.toNumber();
@@ -91,21 +91,12 @@ describeSuite({
 
         log("Please wait, this will take at least 30s for transaction to complete");
 
-        context.waitBlock(5);
+        await paraApi.tx.balances
+          .transferAllowDeath(BALTATHAR_ADDRESS, ethers.parseEther("2"))
+          .signAndSend(charleth);
 
-        await new Promise((resolve) => {
-          paraApi.tx.balances
-            .transferAllowDeath(BALTATHAR_ADDRESS, ethers.parseEther("2"))
-            .signAndSend(charleth, ({ status, events }) => {
-              if (status.isInBlock) {
-                log("Transaction is in block");
-              }
-              if (status.isFinalized) {
-                log("Transaction is finalized!");
-                resolve(events);
-              }
-            });
-        });
+        // TODO: We should verify extrinsicStatus is finalized
+        await context.waitBlock(2);
 
         const balAfter = (await paraApi.query.system.account(BALTATHAR_ADDRESS)).data.free;
         expect(balBefore.lt(balAfter)).to.be.true;

--- a/test/suites/para-rpc/test_moonbase.ts
+++ b/test/suites/para-rpc/test_moonbase.ts
@@ -17,7 +17,7 @@ describeSuite({
   id: "ZAN",
   title: "Zombie AlphaNet Upgrade Test",
   foundationMethods: "zombie",
-  testCases: function ({ it, context, log }) {
+  testCases: ({ it, context, log }) => {
     let paraApi: ApiPromise;
     let relayApi: ApiPromise;
 
@@ -38,7 +38,7 @@ describeSuite({
     it({
       id: "T01",
       title: "Blocks are being produced on parachain",
-      test: async function () {
+      test: async () => {
         const blockNum = (await paraApi.rpc.chain.getBlock()).block.header.number.toNumber();
         expect(blockNum).to.be.greaterThan(0);
       },
@@ -47,25 +47,28 @@ describeSuite({
     it({
       id: "T02",
       title: "Chain can be upgraded",
-      timeout: 600000,
-      test: async function () {
+      timeout: 1200000,
+      test: async () => {
         const blockNumberBefore = (
           await paraApi.rpc.chain.getBlock()
         ).block.header.number.toNumber();
         const currentCode = (await paraApi.rpc.state.getStorage(":code")) as any;
         const codeString = currentCode.toString();
+        const upgradePath = (await MoonwallContext.getContext()).rtUpgradePath;
 
-        const wasm = fs.readFileSync((await MoonwallContext.getContext()).rtUpgradePath!);
+        if (!upgradePath) {
+          throw new Error("Runtime upgrade path not found");
+        }
+        const wasm = fs.readFileSync(upgradePath);
         const rtHex = `0x${wasm.toString("hex")}`;
 
         if (rtHex === codeString) {
           log("Runtime already upgraded, skipping test");
           return;
-        } else {
-          log("Runtime not upgraded, proceeding with test");
-          log("Current runtime hash: " + rtHex.slice(0, 10) + "..." + rtHex.slice(-10));
-          log("New runtime hash: " + codeString.slice(0, 10) + "..." + codeString.slice(-10));
         }
+        log("Runtime not upgraded, proceeding with test");
+        log(`Current runtime hash: ${rtHex.slice(0, 10)}...${rtHex.slice(-10)}`);
+        log(`New runtime hash: ${codeString.slice(0, 10)}...${codeString.slice(-10)}`);
 
         await context.upgradeRuntime({ logger: log });
         await context.waitBlock(2);
@@ -82,8 +85,8 @@ describeSuite({
     it({
       id: "T03",
       title: "Can connect to parachain and execute a transaction",
-      timeout: 60000,
-      test: async function () {
+      timeout: 120000,
+      test: async () => {
         const balBefore = (await paraApi.query.system.account(BALTATHAR_ADDRESS)).data.free;
 
         log("Please wait, this will take at least 30s for transaction to complete");
@@ -112,17 +115,17 @@ describeSuite({
     it({
       id: "T04",
       title: "Tags are present on emulated Ethereum blocks",
-      test: async function () {
+      test: async () => {
         expect(
-          (await context.ethers().provider!.getBlock("safe"))!.number,
+          (await context.ethers().provider?.getBlock("safe"))?.number,
           "Safe tag is not present"
         ).to.be.greaterThan(0);
         expect(
-          (await context.ethers().provider!.getBlock("finalized"))!.number,
+          (await context.ethers().provider?.getBlock("finalized"))?.number,
           "Finalized tag is not present"
         ).to.be.greaterThan(0);
         expect(
-          (await context.ethers().provider!.getBlock("latest"))!.number,
+          (await context.ethers().provider?.getBlock("latest"))?.number,
           "Latest tag is not present"
         ).to.be.greaterThan(0);
         // log(await ethersSigner.provider.getTransactionCount(ALITH_ADDRESS, "latest"));
@@ -136,7 +139,7 @@ describeSuite({
     it({
       id: "T05",
       title: "RPC Provider can produce a pending ethereum block",
-      test: async function () {
+      test: async () => {
         const randomAccount = generateKeyringPair();
         const randomAddress = randomAccount.address as `0x${string}`;
 

--- a/test/suites/para/test_moonbase.ts
+++ b/test/suites/para/test_moonbase.ts
@@ -85,21 +85,12 @@ describeSuite({
 
         log("Please wait, this will take at least 30s for transaction to complete");
 
-        context.waitBlock(5, "parachain");
+        // TODO: We should verify extrinsicStatus is finalized
+        await paraApi.tx.balances
+          .transferAllowDeath(BALTATHAR_ADDRESS, ethers.parseEther("2"))
+          .signAndSend(charleth);
 
-        await new Promise((resolve) => {
-          paraApi.tx.balances
-            .transferAllowDeath(BALTATHAR_ADDRESS, ethers.parseEther("2"))
-            .signAndSend(charleth, ({ status, events }) => {
-              if (status.isInBlock) {
-                log("Transaction is in block");
-              }
-              if (status.isFinalized) {
-                log("Transaction is finalized!");
-                resolve(events);
-              }
-            });
-        });
+        await context.waitBlock(2);
 
         const balAfter = (await paraApi.query.system.account(BALTATHAR_ADDRESS)).data.free;
         expect(balBefore.lt(balAfter)).to.be.true;

--- a/test/suites/para/test_moonbase.ts
+++ b/test/suites/para/test_moonbase.ts
@@ -41,9 +41,6 @@ describeSuite({
       title: "Chain can be upgraded",
       timeout: 1200000,
       test: async () => {
-        const blockNumberBefore = (
-          await paraApi.rpc.chain.getBlock()
-        ).block.header.number.toNumber();
         const currentCode = (await paraApi.rpc.state.getStorage(":code")) as any;
         const codeString = currentCode.toString();
 
@@ -65,6 +62,9 @@ describeSuite({
         log(`New runtime hash: ${codeString.slice(0, 10)}...${codeString.slice(-10)}`);
 
         await context.upgradeRuntime({ logger: log });
+        const blockNumberBefore = (
+          await paraApi.rpc.chain.getBlock()
+        ).block.header.number.toNumber();
         await context.waitBlock(2);
         const blockNumberAfter = (
           await paraApi.rpc.chain.getBlock()


### PR DESCRIPTION
### What does it do?
Alter CI to use forked binaries as a temporary stop gap measure until we upgrade to polkadotSDK 1.6.

For "reasons", this is required to force the relaychain on v1.3 to have async backing turned on.

### What value does it bring to the blockchain users?
Make the CI go ✅ which reduces noise and improves monitoring