### PR TITLE
chore: fixes clippy redundant_closure_call error inside macros

### DIFF
--- a/precompiles/utils/src/testing/account.rs
+++ b/precompiles/utils/src/testing/account.rs
@@ -118,6 +118,7 @@ macro_rules! mock_account {
 	(# $name:ident, $convert:expr) => {
 		impl From<$name> for MockAccount {
 			fn from(value: $name) -> MockAccount {
+				#[allow(clippy::redundant_closure_call)]
 				$convert(value)
 			}
 		}


### PR DESCRIPTION
Fixes pipeline.

Clippy reports `redundant_closure_call` in mock_account macro. It could be implemented differently as we can see in the macro expansions bellow, but is easier and readable as it currently is.

![image](https://github.com/moonbeam-foundation/moonbeam/assets/22591718/3408e373-997c-489b-931e-6279f119e9fe)
![image](https://github.com/moonbeam-foundation/moonbeam/assets/22591718/7889ee72-1b79-4290-b883-4615c2543a74)


The error can be ignored: https://github.com/rust-lang/rust-clippy/issues/1553

### What does it do?

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
