### PR TITLE
Rename tests using moonwall

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -68,6 +68,12 @@ Running a particular smoke test:
 pnpm moonwall test smoke_moonbeam S100
 ```
 
+Rename all prefixes for a suite (to keep them consistent)
+
+```bash
+pnpm moonwall derive <suite_root_dir> 
+```
+
 > [!NOTE]\
 > For a full list of test environments and suites available, inspect the `moonwall.config.json` file.
 Alternatively, use the CLI to browse networks and tests available.

--- a/test/package.json
+++ b/test/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@acala-network/chopsticks": "0.9.8",
     "@moonbeam-network/api-augment": "0.2700.0",
-    "@moonwall/cli": "4.7.7",
-    "@moonwall/util": "4.7.7",
+    "@moonwall/cli": "4.7.8",
+    "@moonwall/util": "4.7.8",
     "@openzeppelin/contracts": "4.9.3",
     "@polkadot/api": "10.11.2",
     "@polkadot/api-augment": "10.11.2",

--- a/test/pnpm-lock.yaml
+++ b/test/pnpm-lock.yaml
@@ -12,11 +12,11 @@ dependencies:
     specifier: 0.2700.0
     version: 0.2700.0
   '@moonwall/cli':
-    specifier: 4.7.7
-    version: 4.7.7(@acala-network/chopsticks@0.9.8)(@polkadot/api@10.11.2)(@types/node@20.11.16)(@vitest/ui@1.2.2)(typescript@5.3.3)(vitest@1.2.2)
+    specifier: 4.7.8
+    version: 4.7.8(@acala-network/chopsticks@0.9.8)(@polkadot/api@10.11.2)(@types/node@20.11.16)(@vitest/ui@1.2.2)(typescript@5.3.3)(vitest@1.2.2)
   '@moonwall/util':
-    specifier: 4.7.7
-    version: 4.7.7(@polkadot/api@10.11.2)(typescript@5.3.3)(vitest@1.2.2)
+    specifier: 4.7.8
+    version: 4.7.8(@polkadot/api@10.11.2)(typescript@5.3.3)(vitest@1.2.2)
   '@openzeppelin/contracts':
     specifier: 4.9.3
     version: 4.9.3
@@ -1158,8 +1158,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@moonwall/cli@4.7.7(@acala-network/chopsticks@0.9.8)(@polkadot/api@10.11.2)(@types/node@20.11.16)(@vitest/ui@1.2.2)(typescript@5.3.3)(vitest@1.2.2):
-    resolution: {integrity: sha512-64NrcKIJ4Hj5G5bOK/7kq5M1/XeL6KL7IeRck2EglWErllju66p/A0OjSUlcQw4oFzN4TOv2E9XSfYvaGVmL/w==}
+  /@moonwall/cli@4.7.8(@acala-network/chopsticks@0.9.8)(@polkadot/api@10.11.2)(@types/node@20.11.16)(@vitest/ui@1.2.2)(typescript@5.3.3)(vitest@1.2.2):
+    resolution: {integrity: sha512-9d46374h8l22z+7MIBF0dyQG6TUJZhrUzxlACp2FUmuasQdJ11qwcVE7sCQqTEhrD4NWkaGcPaGKbQ5NqR0qCw==}
     engines: {node: '>=20.0.0', pnpm: '>=7'}
     hasBin: true
     peerDependencies:
@@ -1170,8 +1170,8 @@ packages:
     dependencies:
       '@acala-network/chopsticks': 0.9.8(debug@4.3.4)
       '@moonbeam-network/api-augment': 0.2700.0
-      '@moonwall/types': 4.7.7(@polkadot/api@10.11.2)(typescript@5.3.3)
-      '@moonwall/util': 4.7.7(@polkadot/api@10.11.2)(typescript@5.3.3)(vitest@1.2.2)
+      '@moonwall/types': 4.7.8(@polkadot/api@10.11.2)(typescript@5.3.3)
+      '@moonwall/util': 4.7.8(@polkadot/api@10.11.2)(typescript@5.3.3)(vitest@1.2.2)
       '@polkadot/api': 10.11.2
       '@polkadot/api-derive': 10.11.2
       '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2)
@@ -1218,8 +1218,8 @@ packages:
       - zod
     dev: false
 
-  /@moonwall/types@4.7.7(@polkadot/api@10.11.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-P2gcPbUeHkxNMnXKKkiyBT9gNXnEUOYUX6YZf/2zXk0EL0OmIlCOtMKgPmI7RGze/w1Pmnqov3+0S/9fQ3sGuA==}
+  /@moonwall/types@4.7.8(@polkadot/api@10.11.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-JLMTtdxcb2AX/kdBZdd8jOAjnVjW62Q50yu0gz91NZDwpWLhohemBs+HWL8JEiF2YPrtyBlNICGNfXXfqk/o3A==}
     engines: {node: '>=14.16.0', pnpm: '>=7'}
     peerDependencies:
       '@polkadot/api': 10.11.2
@@ -1249,15 +1249,15 @@ packages:
       - zod
     dev: false
 
-  /@moonwall/util@4.7.7(@polkadot/api@10.11.2)(typescript@5.3.3)(vitest@1.2.2):
-    resolution: {integrity: sha512-rCz3tPUqpY17uOVYAP2soNwNjWg19KuFOTnPIJJolE1tq5EffvuzijLzN5DWeRi6cQaZIcOYq9isgKyRVdMnYA==}
+  /@moonwall/util@4.7.8(@polkadot/api@10.11.2)(typescript@5.3.3)(vitest@1.2.2):
+    resolution: {integrity: sha512-/19Fs0Uo2WwQ0vfMlpA5lem7NOZPIyLuejMCC1pNeXrOHXGTa5SaqzKQr+ZVJ6DXbeZREhXstakIBGpZLmg1Og==}
     engines: {node: '>=14.16.0', pnpm: '>=7'}
     peerDependencies:
       '@polkadot/api': 10.11.2
       vitest: 1.2.2
     dependencies:
       '@moonbeam-network/api-augment': 0.2700.0
-      '@moonwall/types': 4.7.7(@polkadot/api@10.11.2)(typescript@5.3.3)
+      '@moonwall/types': 4.7.8(@polkadot/api@10.11.2)(typescript@5.3.3)
       '@polkadot/api': 10.11.2
       '@polkadot/api-derive': 10.11.2
       '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2)

--- a/test/suites/chopsticks/sample/test-basic-actions.ts
+++ b/test/suites/chopsticks/sample/test-basic-actions.ts
@@ -5,7 +5,7 @@ import { parseEther, ethers, Transaction, Wallet, parseUnits } from "ethers";
 import "@moonbeam-network/api-augment";
 
 describeSuite({
-  id: "CMB01",
+  id: "C0101",
   title: "Chopsticks test suite",
   foundationMethods: "chopsticks",
   testCases: ({ it, context, log }) => {

--- a/test/suites/dev/moonbase/sample/sample_basic.ts
+++ b/test/suites/dev/moonbase/sample/sample_basic.ts
@@ -5,7 +5,7 @@ import { BN } from "@polkadot/util";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "D01",
+  id: "D014001",
   title: "Dev test suite",
   foundationMethods: "dev",
   testCases: ({ it, context, log }) => {

--- a/test/suites/dev/moonbase/test-assets/test-assets-destroy.ts
+++ b/test/suites/dev/moonbase/test-assets/test-assets-destroy.ts
@@ -9,7 +9,7 @@ import { expectOk, mockAssetBalance } from "../../../../helpers";
 const ARBITRARY_ASSET_ID = 42259045809535163221576417993425387648n;
 
 describeSuite({
-  id: "D0101",
+  id: "D010101",
   title: "Pallet Assets - Destruction",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-assets/test-assets-drain-asset.ts
+++ b/test/suites/dev/moonbase/test-assets/test-assets-drain-asset.ts
@@ -11,7 +11,7 @@ const ARBITRARY_ASSET_ID = 42259045809535163221576417993425387648n;
 const ARBITRARY_TRANSFER_AMOUNT = 10000000000000n;
 
 describeSuite({
-  id: "D0102",
+  id: "D010102",
   title: "Pallet Assets - Sufficient tests: is_sufficient to true",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-assets/test-assets-drain-both.ts
+++ b/test/suites/dev/moonbase/test-assets/test-assets-drain-both.ts
@@ -11,7 +11,7 @@ const ARBITRARY_ASSET_ID = 42259045809535163221576417993425387648n;
 const ARBITRARY_TRANSFER_AMOUNT = 10000000000000n;
 
 describeSuite({
-  id: "D0103",
+  id: "D010103",
   title: "Pallet Assets - Sufficient tests: is_sufficient to true",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-assets/test-assets-insufficients.ts
+++ b/test/suites/dev/moonbase/test-assets/test-assets-insufficients.ts
@@ -11,7 +11,7 @@ const ARBITRARY_ASSET_ID = 42259045809535163221576417993425387648n;
 const ARBITRARY_TRANSFER_AMOUNT = 10000000000000n;
 
 describeSuite({
-  id: "D0104",
+  id: "D010104",
   title: "Pallet Assets - Sufficient tests: is_sufficient to false",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-assets/test-assets-transfer.ts
+++ b/test/suites/dev/moonbase/test-assets/test-assets-transfer.ts
@@ -10,7 +10,7 @@ import { mockAssetBalance } from "../../../../helpers";
 const ARBITRARY_ASSET_ID = 42259045809535163221576417993425387648n;
 
 describeSuite({
-  id: "D0105",
+  id: "D010105",
   title: "Pallet Assets - Transfer",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-assets/test-change-existing-asset.ts
+++ b/test/suites/dev/moonbase/test-assets/test-change-existing-asset.ts
@@ -12,7 +12,7 @@ import {
 
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 describeSuite({
-  id: "D0106",
+  id: "D010106",
   title: "XCM - asset manager - Change existing asset",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-assets/test-destroy-foreign-asset.ts
+++ b/test/suites/dev/moonbase/test-assets/test-destroy-foreign-asset.ts
@@ -12,7 +12,7 @@ import {
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D0107",
+  id: "D010107",
   title: "XCM - asset manager - destroy foreign asset",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-assets/test-foreign-asset.ts
+++ b/test/suites/dev/moonbase/test-assets/test-foreign-asset.ts
@@ -10,7 +10,7 @@ import {
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D0109",
+  id: "D010108",
   title: "XCM - asset manager - foreign asset",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-assets/test-remove-asset.ts
+++ b/test/suites/dev/moonbase/test-assets/test-remove-asset.ts
@@ -7,7 +7,7 @@ import { ApiPromise } from "@polkadot/api";
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D0111",
+  id: "D010109",
   title: "XCM - asset manager - Remove asset from supported",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-double-registration.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-double-registration.ts
@@ -12,7 +12,7 @@ import { ApiPromise } from "@polkadot/api";
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0201",
+  id: "D010201",
   title: "Author Mapping - double registration",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-failed-association.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-failed-association.ts
@@ -11,7 +11,7 @@ import { ApiPromise } from "@polkadot/api";
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0202",
+  id: "D010202",
   title: "Author Mapping - Fail to reassociate alice",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-first-time-keys.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-first-time-keys.ts
@@ -12,7 +12,7 @@ const originalKeys = [
 const concatOriginalKeys = `0x${originalKeys.map((key) => key.slice(2)).join("")}`;
 
 describeSuite({
-  id: "D0203",
+  id: "D010203",
   title: "Author Mapping - Set Charlie first time keys",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-missing-deposit-fail.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-missing-deposit-fail.ts
@@ -5,7 +5,7 @@ import { ApiPromise } from "@polkadot/api";
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0204",
+  id: "D010204",
   title: "Author Mapping - Fail without deposit",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-non-author-clearing.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-non-author-clearing.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, baltathar, BALTATHAR_SESSION_ADDRESS } from "@moonwall/u
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0205",
+  id: "D010205",
   title: "Author Mapping - non author clearing",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-non-author-rotate.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-non-author-rotate.ts
@@ -10,7 +10,7 @@ import { ApiPromise } from "@polkadot/api";
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0206",
+  id: "D010206",
   title: "Author Mapping - non-author cannot rotate",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-registered-clear.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-registered-clear.ts
@@ -4,7 +4,7 @@ import { expect, describeSuite } from "@moonwall/cli";
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0207",
+  id: "D010207",
   title: "Author Mapping - registered author can clear (de register)",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-registered-rotation.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-registered-rotation.ts
@@ -4,7 +4,7 @@ import { getMappingInfo } from "../../../../helpers";
 import { expect, describeSuite } from "@moonwall/cli";
 
 describeSuite({
-  id: "D0208",
+  id: "D010208",
   title: "Author Mapping - registered can rotate",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-removing-author.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-removing-author.ts
@@ -12,7 +12,7 @@ const originalKeys = [
 const concatOriginalKeys = `0x${originalKeys.map((key) => key.slice(2)).join("")}`;
 
 describeSuite({
-  id: "D0209",
+  id: "D010209",
   title: "Author Mapping - Removing non-existing author",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-removing-keys.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-removing-keys.ts
@@ -12,7 +12,7 @@ const originalKeys = [
 const concatOriginalKeys = `0x${originalKeys.map((key) => key.slice(2)).join("")}`;
 
 describeSuite({
-  id: "D0210",
+  id: "D010210",
   title: "Author Mapping - Remove Charlie keys",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-same-key-rotation.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-same-key-rotation.ts
@@ -12,7 +12,7 @@ const originalKeys = [
 const concatOriginalKeys = `0x${originalKeys.map((key) => key.slice(2)).join("")}`;
 
 describeSuite({
-  id: "D0211",
+  id: "D010211",
   title: "Author Mapping - Update Charlie mapping to the same keys",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-simple-association.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-simple-association.ts
@@ -12,7 +12,7 @@ import { ApiPromise } from "@polkadot/api";
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0212",
+  id: "D010212",
   title: "Author Mapping - simple association",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-unregistered-clear.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-unregistered-clear.ts
@@ -4,7 +4,7 @@ import { expect, describeSuite } from "@moonwall/cli";
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0213",
+  id: "D010213",
   title: "Author Mapping - unregistered author cannot clear association",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-unregistered-rotation.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-unregistered-rotation.ts
@@ -4,7 +4,7 @@ import { BALTATHAR_SESSION_ADDRESS, CHARLETH_SESSION_ADDRESS, alith } from "@moo
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D0214",
+  id: "D010214",
   title: "Author Mapping - unregistered cannot rotate",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-update-diff-keys.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-update-diff-keys.ts
@@ -12,7 +12,7 @@ const originalKeys = [
 const concatOriginalKeys = `0x${originalKeys.map((key) => key.slice(2)).join("")}`;
 
 describeSuite({
-  id: "D0215",
+  id: "D010215",
   title: "Author Mapping - Update different keys",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-author/test-author-update-nimbus-key.ts
+++ b/test/suites/dev/moonbase/test-author/test-author-update-nimbus-key.ts
@@ -18,7 +18,7 @@ const originalKeys = [
 const concatOriginalKeys = `0x${originalKeys.map((key) => key.slice(2)).join("")}`;
 
 describeSuite({
-  id: "D0216",
+  id: "D010216",
   title: "Author Mapping - Update someone else nimbus key",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-balance/test-balance-existential.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-existential.ts
@@ -5,7 +5,7 @@ import { createRawTransfer } from "@moonwall/util";
 import { Wallet } from "ethers";
 
 describeSuite({
-  id: "D0301",
+  id: "D010301",
   title: "Existential Deposit disabled",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-balance/test-balance-extrinsics.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-extrinsics.ts
@@ -11,7 +11,7 @@ import { PrivateKeyAccount } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 describeSuite({
-  id: "D0302",
+  id: "D010302",
   title: "Balance - Extrinsic",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-balance/test-balance-genesis.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-genesis.ts
@@ -8,7 +8,7 @@ import {
 import { ALITH_GENESIS_TRANSFERABLE_BALANCE } from "../../../../helpers";
 
 describeSuite({
-  id: "D0303",
+  id: "D010303",
   title: "Balance genesis",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-balance/test-balance-reducible.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-reducible.ts
@@ -12,7 +12,7 @@ import {
 import { blake2AsHex } from "@polkadot/util-crypto";
 
 describeSuite({
-  id: "D0304",
+  id: "D010304",
   title: "Reducible Balance",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-balance/test-balance-transfer-txwrapper-substrate.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-transfer-txwrapper-substrate.ts
@@ -11,7 +11,7 @@ import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { verifyLatestBlockFees, signWith } from "../../../../helpers";
 
 describeSuite({
-  id: "D0305",
+  id: "D010305",
   title: "Balance transfer - TxWrapper",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
@@ -19,7 +19,7 @@ import { ALITH_GENESIS_TRANSFERABLE_BALANCE, verifyLatestBlockFees } from "../..
 import { parseGwei } from "viem";
 
 describeSuite({
-  id: "D0306",
+  id: "D010306",
   title: "Balance Transfers",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-balance/test-balance-transferable.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-transferable.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, GLMR, baltathar, checkBalance, generateKeyringPair } fro
 import { createProposal } from "../../../../helpers/voting.ts";
 
 describeSuite({
-  id: "D4005",
+  id: "D010307",
   title: "Balance - Transferable",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-block/test-block-1.ts
+++ b/test/suites/dev/moonbase/test-block/test-block-1.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS } from "@moonwall/util";
 
 describeSuite({
-  id: "D0401",
+  id: "D010401",
   title: "Block 1",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-block/test-block-2.ts
+++ b/test/suites/dev/moonbase/test-block/test-block-2.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D0402",
+  id: "D010402",
   title: "Block creation - suite 2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-block/test-block-gas.ts
+++ b/test/suites/dev/moonbase/test-block/test-block-gas.ts
@@ -8,7 +8,7 @@ import {
 import { EXTRINSIC_GAS_LIMIT } from "@moonwall/util";
 
 describeSuite({
-  id: "D0403",
+  id: "D010403",
   title: "Block creation - suite 2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-block/test-block-genesis.ts
+++ b/test/suites/dev/moonbase/test-block/test-block-genesis.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D0404",
+  id: "D010404",
   title: "Block genesis",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-block/test-block-mocked-relay.ts
+++ b/test/suites/dev/moonbase/test-block/test-block-mocked-relay.ts
@@ -3,7 +3,7 @@ import { expect, describeSuite, beforeAll } from "@moonwall/cli";
 import { CumulusPrimitivesParachainInherentParachainInherentData } from "@polkadot/types/lookup";
 
 describeSuite({
-  id: "D0405",
+  id: "D010405",
   title: "Block - Mocked relaychain block",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-chain/test-fork-chain.ts
+++ b/test/suites/dev/moonbase/test-chain/test-fork-chain.ts
@@ -4,7 +4,7 @@ import { createRawTransfer } from "@moonwall/util";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 describeSuite({
-  id: "D0501",
+  id: "D010501",
   title: "Chain - Fork",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-creation.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-creation.ts
@@ -13,7 +13,7 @@ import { verifyLatestBlockFees } from "../../../../helpers";
 
 // TODO: expand these tests to do multiple txn types when added to viem
 describeSuite({
-  id: "D0601",
+  id: "D010601",
   title: "Contract creation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-delegate-call.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-delegate-call.ts
@@ -26,7 +26,7 @@ const DELEGATECALL_FORDIDDEN_MESSAGE =
   "0000000000000000000000000000000000000000000000000000000000000000"; // padding;
 
 describeSuite({
-  id: "D0602",
+  id: "D010602",
   title: "Delegate Call",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-error.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-error.ts
@@ -12,7 +12,7 @@ import { verifyLatestBlockFees } from "../../../../helpers";
 
 // TODO: expand these tests to do multiple txn types when added to viem
 describeSuite({
-  id: "D0603",
+  id: "D010603",
   title: "Contract loop error",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-event.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-event.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, createEthersTransaction } from "@moonwall/util";
 import { encodeDeployData } from "viem";
 
 describeSuite({
-  id: "D0604",
+  id: "D010604",
   title: "Contract event",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-evm-limits.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-evm-limits.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS, createEthersTransaction } from "@moonwall/util";
 
 describeSuite({
-  id: "D0605",
+  id: "D010605",
   title: "Contract - Excessive memory allocation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-fibonacci.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-fibonacci.ts
@@ -3,7 +3,7 @@ import { TransactionTypes, describeSuite, expect, fetchCompiledContract } from "
 import { encodeDeployData } from "viem";
 
 describeSuite({
-  id: "D0606",
+  id: "D010606",
   title: "Fibonacci",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-incr-loop.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-incr-loop.ts
@@ -4,7 +4,7 @@ import { encodeFunctionData } from "viem";
 import { verifyLatestBlockFees } from "../../../../helpers";
 
 describeSuite({
-  id: "D0607",
+  id: "D010607",
   title: "Contract loop",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-loop-cost.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-loop-cost.ts
@@ -4,7 +4,7 @@ import { encodeFunctionData } from "viem";
 import { createEthersTransaction } from "@moonwall/util";
 
 describeSuite({
-  id: "D0608",
+  id: "D010608",
   title: "Contract loop",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-methods.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-methods.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS } from "@moonwall/util";
 import { encodeFunctionData, Abi } from "viem";
 
 describeSuite({
-  id: "D0609",
+  id: "D010609",
   title: "Contract creation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-contract/test-contract-variables.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-variables.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D0610",
+  id: "D010610",
   title: "Block Contract - Block variables",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-conviction-voting/test-conviction-batch-delegate-undelegate.ts
+++ b/test/suites/dev/moonbase/test-conviction-voting/test-conviction-batch-delegate-undelegate.ts
@@ -4,7 +4,7 @@ import { KeyringPair, alith } from "@moonwall/util";
 import { createAccounts, expectSubstrateEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2622",
+  id: "D010701",
   title: "Conviction Voting - Batch Delegate and Undelegate",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-conviction-voting/test-conviction-delegate-weight-fit.ts
+++ b/test/suites/dev/moonbase/test-conviction-voting/test-conviction-delegate-weight-fit.ts
@@ -4,7 +4,7 @@ import { KeyringPair, alith } from "@moonwall/util";
 import { createAccounts, expectSubstrateEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2620",
+  id: "D010702",
   title: "Conviction Voting - Delegate Weight Fit",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-conviction-voting/test-conviction-delegation-batch.ts
+++ b/test/suites/dev/moonbase/test-conviction-voting/test-conviction-delegation-batch.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect, proposeReferendaAndDeposit } from "@m
 import { ALITH_ADDRESS, GLMR, alith, baltathar } from "@moonwall/util";
 
 describeSuite({
-  id: "D4005",
+  id: "D010703",
   title: "Conviction Voting - Batch Delegation",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-conviction-voting/test-conviction-delegation.ts
+++ b/test/suites/dev/moonbase/test-conviction-voting/test-conviction-delegation.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, GLMR, alith, baltathar, faith } from "@moonwall/util";
 import { expectSubstrateEvent } from "../../../../helpers";
 
 describeSuite({
-  id: "D2600",
+  id: "D010704",
   title: "Conviction Voting - Delegation",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-conviction-voting/test-conviction-undelegate-weight-fit.ts
+++ b/test/suites/dev/moonbase/test-conviction-voting/test-conviction-undelegate-weight-fit.ts
@@ -4,7 +4,7 @@ import { KeyringPair, alith } from "@moonwall/util";
 import { createAccounts, chunk, expectSubstrateEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2621",
+  id: "D010705",
   title: "Conviction Voting - Undelegate Weight Fit",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-conviction-voting/test-delegate.ts
+++ b/test/suites/dev/moonbase/test-conviction-voting/test-delegate.ts
@@ -10,7 +10,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D0601-01",
+  id: "D010706",
   title: "Conviction Voting - delegate",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-conviction-voting/test-delegate2.ts
+++ b/test/suites/dev/moonbase/test-conviction-voting/test-delegate2.ts
@@ -11,7 +11,7 @@ import {
 import { chunk } from "../../../../helpers";
 
 describeSuite({
-  id: "D0601-02",
+  id: "D010707",
   title: "Conviction Voting - undelegate",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan--proxy-transfer.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan--proxy-transfer.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0701",
+  id: "D010801",
   title: "Crowdloan - Proxy transfer",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-claim-bal.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-claim-bal.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0702",
+  id: "D010802",
   title: "Crowdloan - claim updates balances",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-claim.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-claim.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0703",
+  id: "D010803",
   title: "Crowdloan - make claim",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-claim5blocks.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-claim5blocks.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0704",
+  id: "D010804",
   title: "Crowdloan - claim after 5 blocks",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-democracy.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-democracy.ts
@@ -9,7 +9,7 @@ import {
 import { getAccountPayable } from "../../../../helpers";
 
 describeSuite({
-  id: "D0705",
+  id: "D010805",
   title: "Crowdloan - Democracy",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-dust.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-dust.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers/constants.js";
 
 describeSuite({
-  id: "D0706",
+  id: "D010806",
   title: "Crowdloan",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-identity.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-identity.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0707",
+  id: "D010807",
   title: "Crowdloan",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-init.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-init.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0708",
+  id: "D010808",
   title: "Crowdloan - Init",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-proxy-claim.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-proxy-claim.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0709",
+  id: "D010809",
   title: "Crowdloan - Proxy claim",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-register-accs.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-register-accs.ts
@@ -5,7 +5,7 @@ import { PrivateKeyAccount, generatePrivateKey, privateKeyToAccount } from "viem
 import { VESTING_PERIOD, getAccountPayable } from "../../../../helpers";
 
 describeSuite({
-  id: "D0710",
+  id: "D010810",
   title: "Crowdloan - many accounts",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-register-batch.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-register-batch.ts
@@ -5,7 +5,7 @@ import { PrivateKeyAccount, generatePrivateKey, privateKeyToAccount } from "viem
 import { VESTING_PERIOD, getAccountPayable } from "../../../../helpers";
 
 describeSuite({
-  id: "D0711",
+  id: "D010811",
   title: "Crowdloan - Many Accounts batch",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-small-amt.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-small-amt.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0712",
+  id: "D010812",
   title: "Crowdloan - small amount",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-update-address-relay.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-update-address-relay.ts
@@ -5,7 +5,7 @@ import { stringToU8a } from "@polkadot/util";
 import { VESTING_PERIOD, getAccountPayable } from "../../../../helpers";
 
 describeSuite({
-  id: "D0713",
+  id: "D010813",
   title: "Crowdloan - Update Address Relay",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-update-address.ts
+++ b/test/suites/dev/moonbase/test-crowdloan/test-crowdloan-update-address.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D0714",
+  id: "D010814",
   title: "Crowdloan - Update Address",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-democracy/test-democracy-instant-fastrack.ts
+++ b/test/suites/dev/moonbase/test-democracy/test-democracy-instant-fastrack.ts
@@ -15,7 +15,7 @@ import { SpRuntimeDispatchError } from "@polkadot/types/lookup";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 describeSuite({
-  id: "D0803",
+  id: "D010901",
   title: "Democracy - Instant FastTracking",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-democracy/test-democracy-preimage.ts
+++ b/test/suites/dev/moonbase/test-democracy/test-democracy-preimage.ts
@@ -5,7 +5,7 @@ import { blake2AsHex } from "@polkadot/util-crypto";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 describeSuite({
-  id: "D0804",
+  id: "D010902",
   title: "Democracy - Preimage",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-democracy/test-democracy-proposal.ts
+++ b/test/suites/dev/moonbase/test-democracy/test-democracy-proposal.ts
@@ -10,7 +10,7 @@ import { alith } from "@moonwall/util";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 describeSuite({
-  id: "D0806",
+  id: "D010903",
   title: "Democracy - proposing a vote",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-democracy/test-democracy-referendum.ts
+++ b/test/suites/dev/moonbase/test-democracy/test-democracy-referendum.ts
@@ -3,7 +3,7 @@ import { beforeEach, describeSuite, expect, instantFastTrack } from "@moonwall/c
 import { ALITH_ADDRESS, GLMR, KeyringPair, VOTE_AMOUNT, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D0807",
+  id: "D010904",
   title: "Democracy - Referendum",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-democracy/test-referenda-general-admin.ts
+++ b/test/suites/dev/moonbase/test-democracy/test-referenda-general-admin.ts
@@ -4,7 +4,7 @@ import { alith } from "@moonwall/util";
 import "@polkadot/api-augment";
 
 describeSuite({
-  id: "D0808",
+  id: "D010905",
   title: "Referenda - GeneralAdmin",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-eth-call/test-eth-call-state-override.ts
+++ b/test/suites/dev/moonbase/test-eth-call/test-eth-call-state-override.ts
@@ -13,7 +13,7 @@ import { encodeFunctionData, encodePacked, keccak256, pad, parseEther, Abi } fro
 import { expectOk } from "../../../../helpers";
 
 describeSuite({
-  id: "D0901",
+  id: "D011001",
   title: "Call - State Override",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
+++ b/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
@@ -7,7 +7,7 @@ import { parseGwei } from "viem";
 // We use ethers library in this test as apparently web3js's types are not fully EIP-1559
 // compliant yet.
 describeSuite({
-  id: "D1001",
+  id: "D011101",
   title: "Fee History",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-fee/test-eth-paysFee.ts
+++ b/test/suites/dev/moonbase/test-eth-fee/test-eth-paysFee.ts
@@ -5,7 +5,7 @@ import { BALTATHAR_ADDRESS, GLMR, createRawTransfer } from "@moonwall/util";
 // We use ethers library in this test as apparently web3js's types are not fully EIP-1559
 // compliant yet.
 describeSuite({
-  id: "D1002",
+  id: "D011102",
   title: "Ethereum - PaysFee",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-fee/test-eth-txn-weights.ts
+++ b/test/suites/dev/moonbase/test-eth-fee/test-eth-txn-weights.ts
@@ -19,7 +19,7 @@ import {
 // GasToWeight by gas_price, but does not adjust this afterwards. This leads to accounting for too
 // much weight in a block.
 describeSuite({
-  id: "D1003",
+  id: "D011103",
   title: "Ethereum Weight Accounting",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-discard.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-discard.ts
@@ -1,7 +1,7 @@
 import { describeSuite, expect, customDevRpcRequest } from "@moonwall/cli";
 
 describeSuite({
-  id: "D1101",
+  id: "D011201",
   title: "Transaction Cost discards",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
@@ -16,7 +16,7 @@ import { parseGwei } from "viem";
 import { ALITH_GENESIS_TRANSFERABLE_BALANCE } from "../../../../helpers";
 
 describeSuite({
-  id: "D1102",
+  id: "D011202",
   title: "Ethereum Rpc pool errors",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-multiple.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-multiple.ts
@@ -14,7 +14,7 @@ import { encodeDeployData } from "viem";
   */
 
 describeSuite({
-  id: "D1103",
+  id: "D011203",
   title: "EthPool - Multiple pending transactions",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-nonce-future.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-nonce-future.ts
@@ -11,7 +11,7 @@ import {
 import { encodeDeployData } from "viem";
 
 describeSuite({
-  id: "D1104",
+  id: "D011204",
   title: "EthPool - Future Ethereum transaction",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
@@ -4,7 +4,7 @@ import { parseGwei } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 describeSuite({
-  id: "D1105",
+  id: "D011205",
   title: "Resubmit transations",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-constants.ts
+++ b/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-constants.ts
@@ -1,7 +1,7 @@
 import { describeSuite, expect, customDevRpcRequest } from "@moonwall/cli";
 
 describeSuite({
-  id: "D1201",
+  id: "D011301",
   title: "RPC Constants",
   foundationMethods: "dev",
   testCases: ({ it, context }) => {

--- a/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-deprecated.ts
+++ b/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-deprecated.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { describeSuite, expect, customDevRpcRequest } from "@moonwall/cli";
 
 describeSuite({
-  id: "D1202",
+  id: "D011302",
   title: "Deprecated RPC",
   foundationMethods: "dev",
   testCases: ({ it }) => {

--- a/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-log-filtering.ts
+++ b/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-log-filtering.ts
@@ -9,7 +9,7 @@ import {
 import { TransactionReceipt } from "viem";
 
 describeSuite({
-  id: "D1203",
+  id: "D011303",
   title: "Ethereum RPC - Filtering non-matching logs",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
+++ b/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-transaction-receipt.ts
@@ -3,7 +3,7 @@ import { ApiPromise } from "@polkadot/api";
 import { BALTATHAR_ADDRESS, createViemTransaction, extractFee } from "@moonwall/util";
 
 describeSuite({
-  id: "D1206",
+  id: "D011304",
   title: "Ethereum RPC - eth_getTransactionReceipt",
   foundationMethods: "dev",
   testCases: ({ it, context, log }) => {

--- a/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-tx-index.ts
+++ b/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-tx-index.ts
@@ -2,7 +2,7 @@ import { describeSuite, beforeAll, expect } from "@moonwall/cli";
 import { BALTATHAR_ADDRESS, createRawTransfer } from "@moonwall/util";
 
 describeSuite({
-  id: "D1204",
+  id: "D011305",
   title: "Transaction Index",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-version.ts
+++ b/test/suites/dev/moonbase/test-eth-rpc/test-eth-rpc-version.ts
@@ -1,7 +1,7 @@
 import { describeSuite, expect, customDevRpcRequest } from "@moonwall/cli";
 
 describeSuite({
-  id: "D1205",
+  id: "D011306",
   title: "Version RPC",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-eth-tx/test-eth-tx-size.ts
+++ b/test/suites/dev/moonbase/test-eth-tx/test-eth-tx-size.ts
@@ -3,7 +3,7 @@ import { customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 import { EXTRINSIC_GAS_LIMIT, createEthersTransaction } from "@moonwall/util";
 
 describeSuite({
-  id: "D1301",
+  id: "D011401",
   title: "Ethereum Transaction - Large Transaction",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-tx/test-eth-tx-types.ts
+++ b/test/suites/dev/moonbase/test-eth-tx/test-eth-tx-types.ts
@@ -5,7 +5,7 @@ import { EthereumTransactionTransactionV2 } from "@polkadot/types/lookup";
 import { DEFAULT_TXN_MAX_BASE_FEE } from "../../../../helpers";
 
 describeSuite({
-  id: "D1302",
+  id: "D011402",
   title: "Ethereum Transaction - Legacy",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-eth-tx/test-test-tx-nonce.ts
+++ b/test/suites/dev/moonbase/test-eth-tx/test-test-tx-nonce.ts
@@ -8,7 +8,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D1303",
+  id: "D011403",
   title: "Ethereum Transaction - Nonce",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-ethers/test-ethers.ts
+++ b/test/suites/dev/moonbase/test-ethers/test-ethers.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect, fetchCompiledContract } from "@moonwall/cli";
 import { ethers } from "ethers";
 
 describeSuite({
-  id: "D1401",
+  id: "D011501",
   title: "Ethers.js",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-evm/test-pallet-evm-overflow.ts
+++ b/test/suites/dev/moonbase/test-evm/test-pallet-evm-overflow.ts
@@ -6,7 +6,7 @@ import { ALITH_ADDRESS, GLMR, generateKeyringPair } from "@moonwall/util";
 // A signed call cannot make a transfer directly in pallet_evm
 
 describeSuite({
-  id: "D1501",
+  id: "D011601",
   title: "Pallet EVM - Transfering",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-evm/test-pallet-evm-transfer.ts
+++ b/test/suites/dev/moonbase/test-evm/test-pallet-evm-transfer.ts
@@ -11,7 +11,7 @@ import {
 // A signed call cannot make a transfer directly in pallet_evm
 
 describeSuite({
-  id: "D1502",
+  id: "D011602",
   title: "Pallet EVM - call",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment/moonbase";
 import { describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D1601",
+  id: "D011701",
   title: "Genesis Fee Multiplier",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
@@ -12,7 +12,7 @@ import { encodeFunctionData } from "viem";
 // number used internally by transaction-payment for fee calculations.
 
 describeSuite({
-  id: "D1602",
+  id: "D011702",
   title: "Max Fee Multiplier",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-min.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-min.ts
@@ -10,7 +10,7 @@ import { nToHex } from "@polkadot/util";
 // To make sense of them, basically remove 18 zeroes (divide by 10^18). This will give you the
 // number used internally by transaction-payment for fee calculations.
 describeSuite({
-  id: "D1603",
+  id: "D011703",
   title: "Min Fee Multiplier",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-xcm.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-xcm.ts
@@ -23,7 +23,7 @@ const TARGET_FILL_AMOUNT = 186_934_032;
 // To make sense of them, basically remove 18 zeroes (divide by 10^18). This will give you the
 // number used internally by transaction-payment for fee calculations.
 describeSuite({
-  id: "D1604",
+  id: "D011704",
   title: "Fee Multiplier - XCM Executions",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-fees/test-fees-repartition.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fees-repartition.ts
@@ -3,7 +3,7 @@ import { TransactionTypes, describeSuite, expect } from "@moonwall/cli";
 import { BALTATHAR_ADDRESS, TREASURY_ACCOUNT, createRawTransfer, extractFee } from "@moonwall/util";
 
 describeSuite({
-  id: "D1605",
+  id: "D011705",
   title: "Fees - Transaction",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-fees/test-length-fees.ts
+++ b/test/suites/dev/moonbase/test-fees/test-length-fees.ts
@@ -4,7 +4,7 @@ import { BALTATHAR_ADDRESS, baltathar } from "@moonwall/util";
 
 //TODO: Change these to be less literal
 describeSuite({
-  id: "D1606",
+  id: "D011706",
   title: "Substrate Length Fees",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-fees/test-length-fees2.ts
+++ b/test/suites/dev/moonbase/test-fees/test-length-fees2.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { EXTRINSIC_GAS_LIMIT, createViemTransaction } from "@moonwall/util";
 
 describeSuite({
-  id: "D1607",
+  id: "D011707",
   title: "Substrate Length Fees - Ethereum txn Interaction",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-filter/test-filter-api-creation.ts
+++ b/test/suites/dev/moonbase/test-filter/test-filter-api-creation.ts
@@ -8,7 +8,7 @@ import {
 import { fromHex, toHex } from "viem";
 
 describeSuite({
-  id: "D1701",
+  id: "D011801",
   title: "Filter API",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-filter/test-filter-api-pending.ts
+++ b/test/suites/dev/moonbase/test-filter/test-filter-api-pending.ts
@@ -3,7 +3,7 @@ import { customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 import { fromHex } from "viem";
 
 describeSuite({
-  id: "D1702",
+  id: "D011802",
   title: "Filter Pending Transaction API",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-filter/test-filter-api-polling.ts
+++ b/test/suites/dev/moonbase/test-filter/test-filter-api-polling.ts
@@ -7,7 +7,7 @@ import {
 } from "@moonwall/cli";
 
 describeSuite({
-  id: "D1703",
+  id: "D011803",
   title: "Filter Block API",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-gas/test-gas-contract-creation.ts
+++ b/test/suites/dev/moonbase/test-gas/test-gas-contract-creation.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect, fetchCompiledContract } from "@moonwall/cli";
 import { ALITH_ADDRESS } from "@moonwall/util";
 
 describeSuite({
-  id: "D1801",
+  id: "D011901",
   title: "Estimate Gas - Contract creation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-gas/test-gas-estimation-allcontracts.ts
+++ b/test/suites/dev/moonbase/test-gas/test-gas-estimation-allcontracts.ts
@@ -19,7 +19,7 @@ import { encodeDeployData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D1802",
+  id: "D011902",
   title: "Estimate Gas - Multiply",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-gas/test-gas-estimation-contracts.ts
+++ b/test/suites/dev/moonbase/test-gas/test-gas-estimation-contracts.ts
@@ -10,7 +10,7 @@ import { ALITH_ADDRESS, PRECOMPILE_BATCH_ADDRESS } from "@moonwall/util";
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D1803",
+  id: "D011903",
   title: "Estimate Gas - Contract estimation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-gas/test-gas-estimation-multiply.ts
+++ b/test/suites/dev/moonbase/test-gas/test-gas-estimation-multiply.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS } from "@moonwall/util";
 import { Abi } from "viem";
 
 describeSuite({
-  id: "D1804",
+  id: "D011904",
   title: "Estimate Gas - Multiply",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-locks/test-locks-multiple-locks.ts
+++ b/test/suites/dev/moonbase/test-locks/test-locks-multiple-locks.ts
@@ -10,7 +10,7 @@ import {
 import { createProposal } from "../../../../helpers";
 
 describeSuite({
-  id: "D2580",
+  id: "D012001",
   title: "Locks - Voting and staking locks are not mutually exclusive",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-maintenance/test-maintenance-filter.ts
+++ b/test/suites/dev/moonbase/test-maintenance/test-maintenance-filter.ts
@@ -20,7 +20,7 @@ const RELAYCHAIN_ARBITRARY_ADDRESS_1: string =
 const ARBITRARY_VESTING_PERIOD = 201600n;
 
 describeSuite({
-  id: "D1901",
+  id: "D012101",
   title: "Maintenance Mode - Filter",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-maintenance/test-maintenance-filter2.ts
+++ b/test/suites/dev/moonbase/test-maintenance/test-maintenance-filter2.ts
@@ -14,7 +14,7 @@ import { RELAY_SOURCE_LOCATION, mockAssetBalance } from "../../../../helpers";
 const ARBITRARY_ASSET_ID = 42259045809535163221576417993425387648n;
 
 describeSuite({
-  id: "D1902",
+  id: "D012102",
   title: "Maintenance Mode - Filter2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-maintenance/test-maintenance-filter3.ts
+++ b/test/suites/dev/moonbase/test-maintenance/test-maintenance-filter3.ts
@@ -12,7 +12,7 @@ import { u128 } from "@polkadot/types-codec";
 import { BN } from "@polkadot/util";
 
 describeSuite({
-  id: "D1903",
+  id: "D012103",
   title: "Maintenance Mode - Filter2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-maintenance/test-maintenance-mode.ts
+++ b/test/suites/dev/moonbase/test-maintenance/test-maintenance-mode.ts
@@ -5,7 +5,7 @@ import { Result } from "@polkadot/types";
 import { SpRuntimeDispatchError } from "@polkadot/types/lookup";
 
 describeSuite({
-  id: "D1904",
+  id: "D012104",
   title: "Maintenance Mode - General",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-moon/test-moon-rpc.ts
+++ b/test/suites/dev/moonbase/test-moon/test-moon-rpc.ts
@@ -4,7 +4,7 @@ import { BALTATHAR_ADDRESS, createViemTransaction } from "@moonwall/util";
 import { DEFAULT_TXN_MAX_BASE_FEE } from "../../../../helpers";
 
 describeSuite({
-  id: "D2001",
+  id: "D012201",
   title: "Moon RPC Methods - moon_isBlockFinalized ",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-multisigs/test-multisigs.ts
+++ b/test/suites/dev/moonbase/test-multisigs/test-multisigs.ts
@@ -15,7 +15,7 @@ import {
 // TODO: Make the test cases atomic
 
 describeSuite({
-  id: "D2101",
+  id: "D012301",
   title: "Multisigs - perform multisigs operations",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-node-rpc/test-node-rpc-peer.ts
+++ b/test/suites/dev/moonbase/test-node-rpc/test-node-rpc-peer.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D2201",
+  id: "D012401",
   title: "Node - RPC",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-polkadot-js/test-polkadot-api.ts
+++ b/test/suites/dev/moonbase/test-polkadot-js/test-polkadot-api.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS, GLMR, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D2301",
+  id: "D012501",
   title: "Polkadot API",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-polkadot-js/test-polkadot-chain-info.ts
+++ b/test/suites/dev/moonbase/test-polkadot-js/test-polkadot-chain-info.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D2302",
+  id: "D012502",
   title: "Web3Api Information",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-pov/test-evm-over-pov.ts
+++ b/test/suites/dev/moonbase/test-pov/test-evm-over-pov.ts
@@ -5,7 +5,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { expectEVMResult, HeavyContract, deployHeavyContracts } from "../../../../helpers";
 
 describeSuite({
-  id: "D2401",
+  id: "D012601",
   title: "PoV controlled by gasLimit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-pov/test-evm-over-pov2.ts
+++ b/test/suites/dev/moonbase/test-pov/test-evm-over-pov2.ts
@@ -5,7 +5,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { HeavyContract, deployHeavyContracts } from "../../../../helpers";
 
 describeSuite({
-  id: "D2402",
+  id: "D012602",
   title: "PoV Limit (3.5Mb in Dev)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-pov/test-lazy-migrations-storage-removal.ts
+++ b/test/suites/dev/moonbase/test-pov/test-lazy-migrations-storage-removal.ts
@@ -5,7 +5,7 @@ import { ApiPromise } from "@polkadot/api";
 import { u128 } from "@polkadot/types";
 
 describeSuite({
-  id: "D2406",
+  id: "D012603",
   title: "Remove LocalAssets storage - PoV Size validation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-pov/test-precompile-over-pov.ts
+++ b/test/suites/dev/moonbase/test-pov/test-precompile-over-pov.ts
@@ -12,7 +12,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { ALITH_ADDRESS, PRECOMPILE_BATCH_ADDRESS, createEthersTransaction } from "@moonwall/util";
 
 describeSuite({
-  id: "D2403",
+  id: "D012604",
   title: "PoV precompile test - gasLimit",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-pov/test-precompile-over-pov2.ts
+++ b/test/suites/dev/moonbase/test-pov/test-precompile-over-pov2.ts
@@ -15,7 +15,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { HeavyContract, deployHeavyContracts } from "../../../../helpers";
 
 describeSuite({
-  id: "D2404",
+  id: "D012605",
   title: "PoV precompile test - PoV Limit (3.5Mb in Dev)",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-pov/test-xcm-to-evm-pov.ts
+++ b/test/suites/dev/moonbase/test-pov/test-xcm-to-evm-pov.ts
@@ -12,7 +12,7 @@ import {
 import { GAS_LIMIT_POV_RATIO } from "@moonwall/util";
 
 describeSuite({
-  id: "D2405",
+  id: "D012606",
   title: "XCM to EVM - PoV tests",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20-local-assets-removal.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20-local-assets-removal.ts
@@ -5,7 +5,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { extractRevertReason } from "../../../../helpers";
 
 describeSuite({
-  id: "D2584",
+  id: "D012701",
   title: "Precompiles - Assets-ERC20 (LocalAssets Removal)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20-low-level.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20-low-level.ts
@@ -20,7 +20,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { mockAssetBalance } from "../../../../helpers";
 
 describeSuite({
-  id: "D2501",
+  id: "D012702",
   title: "Precompiles - Low Level Transactions",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20.ts
@@ -7,7 +7,7 @@ import { Abi, decodeAbiParameters, encodeFunctionData } from "viem";
 import { mockAssetBalance } from "../../../../helpers";
 
 describeSuite({
-  id: "D2502",
+  id: "D012703",
   title: "Precompiles - Assets-ERC20 Wasm",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20a.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20a.ts
@@ -8,7 +8,7 @@ import { mockAssetBalance } from "../../../../helpers";
 import { Abi, encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D2503",
+  id: "D012704",
   title: "",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20b.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20b.ts
@@ -16,7 +16,7 @@ import { mockAssetBalance } from "../../../../helpers";
 import { Abi, encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D2504",
+  id: "D012705",
   title: "Precompiles - Assets-ERC20 Wasm",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20c.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20c.ts
@@ -7,7 +7,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { mockAssetBalance } from "../../../../helpers";
 
 describeSuite({
-  id: "D2505",
+  id: "D012706",
   title: "Precompiles - Assets-ERC20 Wasm",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20d.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20d.ts
@@ -13,7 +13,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { mockAssetBalance } from "../../../../helpers";
 
 describeSuite({
-  id: "D2506",
+  id: "D012707",
   title: "Precompiles - Assets-ERC20 Wasm",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20e.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20e.ts
@@ -13,7 +13,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { mockAssetBalance } from "../../../../helpers";
 
 describeSuite({
-  id: "D2507",
+  id: "D012708",
   title: "Precompiles - Assets-ERC20 Wasm",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20f.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-assets-erc20f.ts
@@ -7,7 +7,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { mockAssetBalance } from "../../../../helpers";
 
 describeSuite({
-  id: "D2508",
+  id: "D012709",
   title: "Precompiles - Assets-ERC20 Wasm",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers/precompiles.js";
 
 describeSuite({
-  id: "D2509",
+  id: "D012710",
   title: "Precompile Author Mapping - Set Faith first time keys",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys2.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers/precompiles.js";
 
 describeSuite({
-  id: "D2510",
+  id: "D012711",
   title: "Precompile Author Mapping - Update Faith mapping to the same keys",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys3.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../helpers/precompiles.js";
 
 describeSuite({
-  id: "D2511",
+  id: "D012712",
   title: "Precompile Author Mapping - Update different keys",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys4.ts
@@ -19,7 +19,7 @@ const SELECTORS = {
 };
 
 describeSuite({
-  id: "D2512",
+  id: "D012713",
   title: "Precompile Author Mapping - Remove Faith keys",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys5.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys5.ts
@@ -9,7 +9,7 @@ import {
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D2513",
+  id: "D012714",
   title: "Precompile Author Mapping - Removing non-existing author",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys6.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys6.ts
@@ -13,7 +13,7 @@ import { encodeFunctionData } from "viem";
 import { originalKeys, setAuthorMappingKeysViaPrecompile } from "../../../../helpers";
 
 describeSuite({
-  id: "D2514",
+  id: "D012715",
   title: "Precompile Author Mapping - Update someone else nimbus key",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys7.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys7.ts
@@ -4,7 +4,7 @@ import { FAITH_ADDRESS, FAITH_PRIVATE_KEY, getBlockExtrinsic } from "@moonwall/u
 import { originalKeys, setAuthorMappingKeysViaPrecompile } from "../../../../helpers";
 
 describeSuite({
-  id: "D2515",
+  id: "D012716",
   title: "Precompile Author Mapping - Set Faith only 1 key",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys8.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping-keys8.ts
@@ -4,7 +4,7 @@ import { FAITH_ADDRESS, FAITH_PRIVATE_KEY, getBlockExtrinsic } from "@moonwall/u
 import { setAuthorMappingKeysViaPrecompile } from "../../../../helpers";
 
 describeSuite({
-  id: "D2516",
+  id: "D012717",
   title: "Precompile Author Mapping - Set Faith mapping with 0 keys",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping.ts
@@ -11,7 +11,7 @@ import { u8aToHex } from "@polkadot/util";
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D2517",
+  id: "D012718",
   title: "Precompiles - author mapping",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping2.ts
@@ -12,7 +12,7 @@ import { u8aToHex } from "@polkadot/util";
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D2518",
+  id: "D012719",
   title: "Precompiles - author mapping",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-author-mapping3.ts
@@ -12,7 +12,7 @@ import { u8aToHex } from "@polkadot/util";
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D2519",
+  id: "D012720",
   title: "Precompiles - author mapping",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-batch-gas-limit.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-batch-gas-limit.ts
@@ -7,7 +7,7 @@ import { extractRevertReason } from "../../../../helpers";
 // Casting of type in solidity is performing truncation:
 // https://docs.soliditylang.org/en/latest/types.html#conversions-between-elementary-types
 describeSuite({
-  id: "D2520-1",
+  id: "D012721",
   title: "Precompile Batch - Overflowing gasLimit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-batch.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-batch.ts
@@ -14,7 +14,7 @@ import { encodeFunctionData, fromHex } from "viem";
 import { expectEVMResult, getSignatureParameters } from "../../../../helpers";
 
 describeSuite({
-  id: "D2520",
+  id: "D012722",
   title: "Batch",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-blake2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-blake2.ts
@@ -7,7 +7,7 @@ import { createViemTransaction } from "@moonwall/util";
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D2521",
+  id: "D012723",
   title: "Precompiles - blake2",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-bn128-bounds.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-bn128-bounds.ts
@@ -11,7 +11,7 @@ import { createViemTransaction, sendRawTransaction } from "@moonwall/util";
  */
 
 describeSuite({
-  id: "D2522",
+  id: "D012724",
   title: "Precompiles - bn128",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-bn128add.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-bn128add.ts
@@ -5,7 +5,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2523",
+  id: "D012725",
   title: "Precompiles - bn128add",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-bn128mul.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-bn128mul.ts
@@ -5,7 +5,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2524",
+  id: "D012726",
   title: "Precompiles - bn128mul",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-bn128pairing.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-bn128pairing.ts
@@ -5,7 +5,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2525",
+  id: "D012727",
   title: "Precompiles - bn128pairing",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-call-permit-demo.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-call-permit-demo.ts
@@ -17,7 +17,7 @@ import { Abi, encodeFunctionData, fromHex } from "viem";
 import { expectEVMResult, getSignatureParameters } from "../../../../helpers";
 
 describeSuite({
-  id: "D2526",
+  id: "D012728",
   title: "Precompile - Call Permit - foo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-collective.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-collective.ts
@@ -41,7 +41,7 @@ const successfulCouncilCall = async (
 };
 
 describeSuite({
-  id: "D2527",
+  id: "D012729",
   title: "Treasury council precompile #1",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-collective2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-collective2.ts
@@ -36,7 +36,7 @@ const successfulTreasuryCouncilCall = async (
   expect(result?.successful).to.equal(true);
 };
 describeSuite({
-  id: "D2528",
+  id: "D012730",
   title: "Treasury council precompile #2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2529",
+  id: "D012731",
   title: "Precompiles - Conviction Voting precompile",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting2.ts
@@ -5,7 +5,7 @@ import { expectEVMResult, createProposal, ConvictionVoting } from "../../../../h
 const CONVICTION_VALUES = [0n, 1n, 2n, 3n, 4n, 5n, 6n];
 
 describeSuite({
-  id: "D2529-1",
+  id: "D012732",
   title: "Precompiles - Conviction",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting3.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2529-2",
+  id: "D012733",
   title: "Precompiles - Conviction on Root Track",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting4.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2529-3",
+  id: "D012734",
   title: "Precompiles - Conviction on General Admin Track",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting5.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting5.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2529-4",
+  id: "D012735",
   title: "Precompiles - Ended proposal",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting6.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-conviction-voting6.ts
@@ -6,7 +6,7 @@ import { expectEVMResult, createProposal, ConvictionVoting } from "../../../../h
 // Each test is instantiating a new proposal (Not ideal for isolation but easier to write)
 // Be careful to not reach the maximum number of proposals.
 describeSuite({
-  id: "D2529-5",
+  id: "D012736",
   title: "Precompiles - ClassLocksFor & VotingFor",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-democracy.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-democracy.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, ZERO_ADDRESS } from "@moonwall/util";
 import { notePreimagePrecompile } from "../../../../helpers";
 
 describeSuite({
-  id: "D2530",
+  id: "D012737",
   title: "Democracy - genesis and preimage",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-democracy2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-democracy2.ts
@@ -11,7 +11,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { notePreimagePrecompile } from "../../../../helpers";
 
 describeSuite({
-  id: "D2531",
+  id: "D012738",
   title: "Democracy - propose",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-dummy-bytecode.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-dummy-bytecode.ts
@@ -20,7 +20,7 @@ import { keccak256 } from "viem";
 const INIT_CODE = "0x600580600B6000396000F360006000fd";
 
 describeSuite({
-  id: "D2534",
+  id: "D012739",
   title: "Precompiles - precompiles dummy bytecode",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-ecpairing.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-ecpairing.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect, beforeEach } from "@moonwall/cli";
 import { u8aToHex } from "@polkadot/util";
 
 describeSuite({
-  id: "D2535",
+  id: "D012740",
   title: "Precompiles - ecPairing",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-ecrecover.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-ecrecover.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS, ALITH_PRIVATE_KEY } from "@moonwall/util";
 
 describeSuite({
-  id: "D2536",
+  id: "D012741",
   title: "Precompiles - ecrecover",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-erc20-overflow.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-erc20-overflow.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D2537-1",
+  id: "D012742",
   title: "Precompile ERC20 - Transfering through precompile",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-erc20.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-erc20.ts
@@ -28,7 +28,7 @@ import { ALITH_GENESIS_TRANSFERABLE_BALANCE } from "../../../../helpers";
 const ABI_REVERT_SELECTOR = "0x08c379a0";
 
 describeSuite({
-  id: "D2537",
+  id: "D012743",
   title: "Precompiles - ERC20 Native",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity.ts
@@ -5,7 +5,7 @@ import { toHex } from "viem";
 import { PRECOMPILE_IDENTITY_ADDRESS } from "../../../../helpers";
 
 describeSuite({
-  id: "D3400",
+  id: "D012744",
   title: "Precompiles - Identity precompile",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity10.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity10.ts
@@ -4,7 +4,7 @@ import { alith, charleth } from "@moonwall/util";
 import { expectEVMResult, PRECOMPILE_IDENTITY_ADDRESS } from "../../../../helpers";
 
 describeSuite({
-  id: "D3409",
+  id: "D012745",
   title: "Precompiles - Identity precompile - set account id",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity11.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity11.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3410",
+  id: "D012746",
   title: "Precompiles - Identity precompile - add sub",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity12.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity12.ts
@@ -5,7 +5,7 @@ import { toHex } from "viem";
 import { PRECOMPILE_IDENTITY_ADDRESS, expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D3411",
+  id: "D012747",
   title: "Precompiles - Identity precompile - rename sub",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity13.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity13.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3412",
+  id: "D012748",
   title: "Precompiles - Identity precompile - remove sub",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity14.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity14.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3413",
+  id: "D012749",
   title: "Precompiles - Identity precompile - quit sub",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity2.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3401",
+  id: "D012750",
   title: "Precompiles - Identity precompile - set identity",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity3.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3402",
+  id: "D012751",
   title: "Precompiles - Identity precompile - clear identity",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity4.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3403",
+  id: "D012752",
   title: "Precompiles - Identity precompile - request judgement",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity5.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity5.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3404",
+  id: "D012753",
   title: "Precompiles - Identity precompile - cancel requested judgement",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity6.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity6.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D3405",
+  id: "D012754",
   title: "Precompiles - Identity precompile - provide judgement",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity7.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity7.ts
@@ -5,7 +5,7 @@ import { toHex } from "viem";
 import { PRECOMPILE_IDENTITY_ADDRESS, expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D3406",
+  id: "D012755",
   title: "Precompiles - Identity precompile - set subs",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity8.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity8.ts
@@ -4,7 +4,7 @@ import { alith } from "@moonwall/util";
 import { expectEVMResult, PRECOMPILE_IDENTITY_ADDRESS } from "../../../../helpers";
 
 describeSuite({
-  id: "D3407",
+  id: "D012756",
   title: "Precompiles - Identity precompile - set fee",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-identity9.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-identity9.ts
@@ -4,7 +4,7 @@ import { alith } from "@moonwall/util";
 import { expectEVMResult, PRECOMPILE_IDENTITY_ADDRESS } from "../../../../helpers";
 
 describeSuite({
-  id: "D3408",
+  id: "D012757",
   title: "Precompiles - Identity precompile - set fields",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-modexp.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-modexp.ts
@@ -7,7 +7,7 @@ import { expectEVMResult, testVectors } from "../../../../helpers";
 const MODEXP_PRECOMPILE_ADDRESS = "0x0000000000000000000000000000000000000005";
 
 describeSuite({
-  id: "D2539",
+  id: "D012758",
   title: "Precompiles - modexp",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-preimage.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-preimage.ts
@@ -6,7 +6,7 @@ import { Preimage, expectEVMResult, expectSubstrateEvent } from "../../../../hel
 // Each test is instantiating a new proposal (Not ideal for isolation but easier to write)
 // Be careful to not reach the maximum number of proposals.
 describeSuite({
-  id: "D2580",
+  id: "D012759",
   title: "Precompiles - Preimage precompile",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-author-mapping.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-author-mapping.ts
@@ -12,7 +12,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult, getAuthorMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D2540",
+  id: "D012760",
   title: "Proxy : Author Mapping - simple association",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-governance.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-governance.ts
@@ -23,7 +23,7 @@ import { expectEVMResult } from "../../../../helpers";
 const proposalHash = "0xf3d039875302d49d52fb1af6877a2c46bc55b004afb8130f94dd9d0489ca3185";
 
 describeSuite({
-  id: "D2541",
+  id: "D012761",
   title: "Proxing governance (through proxy precompile)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-leader-demo.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-leader-demo.ts
@@ -4,7 +4,7 @@ import { BALTATHAR_ADDRESS, CHARLETH_ADDRESS, DOROTHY_ADDRESS, GLMR } from "@moo
 import { setupPoolWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2542",
+  id: "D012762",
   title: "Proxy Leader Demo - Preparing Participation Pool",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-leader-demo2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-leader-demo2.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { expectEVMResult, setupPoolWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2543",
+  id: "D012763",
   title: "Proxy Leader Demo - Start Voting",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-leader-demo3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-leader-demo3.ts
@@ -10,7 +10,7 @@ import {
 import { setupPoolWithParticipants, expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2544",
+  id: "D012764",
   title: "Proxy Leader Demo - Vote",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-non-transfer.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-non-transfer.ts
@@ -18,7 +18,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult, getAuthorMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D2545",
+  id: "D012765",
   title: "Proxy : Non transfer - Evm transfer",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo.ts
@@ -13,7 +13,7 @@ import { nToHex } from "@polkadot/util";
 import { setupWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2546",
+  id: "D012766",
   title: "Proxy Call Staking Demo - Register Candidate",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo2.ts
@@ -16,7 +16,7 @@ import { nToHex } from "@polkadot/util";
 import { setupWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2547",
+  id: "D012767",
   title: "Proxy Call Staking Demo - New Participant",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo3.ts
@@ -14,7 +14,7 @@ import { nToHex } from "@polkadot/util";
 import { setupWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2548",
+  id: "D012768",
   title: "Proxy Call Staking Demo - Leave Participant",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy-staking-demo4.ts
@@ -13,7 +13,7 @@ import { nToHex } from "@polkadot/util";
 import { setupWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2549",
+  id: "D012769",
   title: "Proxy Call Staking Demo - Unregister Candidate",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-proxy.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-proxy.ts
@@ -23,7 +23,7 @@ import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2550",
+  id: "D012770",
   title: "Precompile - Proxy",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-referenda-demo.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-referenda-demo.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2551",
+  id: "D012771",
   title: "Precompiles - Referenda Auto Upgrade Demo",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-referenda.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-referenda.ts
@@ -11,7 +11,7 @@ import {
 
 // Each test is instantiating a new proposal (Not ideal for isolation but easier to write)
 describeSuite({
-  id: "D2552",
+  id: "D012772",
   title: "Precompiles - Referenda precompile",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-relay-encoder.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-relay-encoder.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { ALITH_SESSION_ADDRESS, BALTATHAR_SESSION_ADDRESS } from "@moonwall/util";
 
 describeSuite({
-  id: "D2553",
+  id: "D012773",
   title: "Precompiles - relay-encoder",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-revert-attack.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-revert-attack.ts
@@ -10,7 +10,7 @@ import { ALITH_ADDRESS, MIN_GLMR_STAKING } from "@moonwall/util";
 // We have to make sure that's not possible
 
 describeSuite({
-  id: "D2554",
+  id: "D012774",
   title: "Precompiles - Reverting Staking precompile",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-ripemd160.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-ripemd160.ts
@@ -4,7 +4,7 @@ import { toHex } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2555",
+  id: "D012775",
   title: "Precompiles - ripemd160 ",
   foundationMethods: "dev",
   testCases: ({ context, log, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-sha3fips.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-sha3fips.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D2556",
+  id: "D012776",
   title: "Precompiles - sha3fips",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call.ts
@@ -12,7 +12,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2557",
+  id: "D012777",
   title: "Smart Contract Precompile Call - AddProxy Staking",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call2.ts
@@ -12,7 +12,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2558",
+  id: "D012778",
   title: "Smart Contract Precompile Call - Proxy - Any Proxy Type",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call3.ts
@@ -11,7 +11,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2559",
+  id: "D012779",
   title: "Smart Contract Precompile Call - Proxy - Any Proxy Type",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call4.ts
@@ -5,7 +5,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2560",
+  id: "D012780",
   title: "Smart Contract Precompile Call - Proxy - Real Account",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call5.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call5.ts
@@ -4,7 +4,7 @@ import { encodeFunctionData } from "viem";
 import { expectEVMResult } from "../../../../helpers";
 
 describeSuite({
-  id: "D2561",
+  id: "D012781",
   title: "Smart Contract Precompile Call - Proxy - Real Account",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-staking.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-staking.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS } from "@moonwall/util";
 
 describeSuite({
-  id: "D2562",
+  id: "D012782",
   title: "Precompiles - Staking - Genesis",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-staking2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-staking2.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, ETHAN_ADDRESS, ETHAN_PRIVATE_KEY, MIN_GLMR_STAKING } fro
 import { verifyLatestBlockFees } from "../../../../helpers";
 
 describeSuite({
-  id: "D2563",
+  id: "D012783",
   title: "Precompiles - Staking - Join Candidates",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-staking3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-staking3.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { ETHAN_ADDRESS, ETHAN_PRIVATE_KEY, MIN_GLMR_STAKING } from "@moonwall/util";
 
 describeSuite({
-  id: "D2564",
+  id: "D012784",
   title: "Precompiles - Staking - Collator Leaving",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-staking4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-staking4.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS, ETHAN_ADDRESS, ETHAN_PRIVATE_KEY, MIN_GLMR_STAKING } from "@moonwall/util";
 
 describeSuite({
-  id: "D2565",
+  id: "D012785",
   title: "Precompiles - Staking - Join Delegators",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-staking5.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-staking5.ts
@@ -9,7 +9,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D2566",
+  id: "D012786",
   title: "Precompiles - Staking - Join Delegators",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-staking6.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-staking6.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS, ETHAN_ADDRESS } from "@moonwall/util";
 
 describeSuite({
-  id: "D2567",
+  id: "D012787",
   title: "Precompiles - Staking - AwardedPoints",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-wormhole.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-wormhole.ts
@@ -50,7 +50,7 @@ const WH_IMPLICIT_DECIMALS = 18n;
 const WH_IMPLICIT_MULTIPLIER = 10n ** WH_IMPLICIT_DECIMALS;
 
 describeSuite({
-  id: "D2568",
+  id: "D012788",
   title: "Test local Wormhole",
   foundationMethods: "dev",
 

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-wormhole2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-wormhole2.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { expectEVMResult, extractRevertReason } from "../../../../helpers";
 
 describeSuite({
-  id: "D2569",
+  id: "D012789",
   title: "Test GMP Killswitch",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2570",
+  id: "D012790",
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
@@ -15,7 +15,7 @@ import {
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
 
 describeSuite({
-  id: "D2579",
+  id: "D012791",
   title: "Precompiles - xcm transactor V3",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor11.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor11.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2580",
+  id: "D012792",
   title: "Precompiles - xcm transactor V3",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor12.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor12.ts
@@ -14,7 +14,7 @@ import {
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
 
 describeSuite({
-  id: "D2581",
+  id: "D012793",
   title: "Precompiles - xcm transactor V3",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor2.ts
@@ -13,7 +13,7 @@ import {
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
 
 describeSuite({
-  id: "D2571",
+  id: "D012794",
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor3.ts
@@ -13,7 +13,7 @@ import {
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
 
 describeSuite({
-  id: "D2572",
+  id: "D012795",
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor4.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2573",
+  id: "D012796",
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor5.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor5.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2574",
+  id: "D012797",
   title: "Precompiles - xcm transactor V2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor6.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor6.ts
@@ -13,7 +13,7 @@ import {
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
 
 describeSuite({
-  id: "D2575",
+  id: "D012798",
   title: "Precompiles - xcm transactor V2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor7.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor7.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2576",
+  id: "D012799",
   title: "Precompiles - xcm transactor V2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor8.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor8.ts
@@ -13,7 +13,7 @@ import {
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
 
 describeSuite({
-  id: "D2577",
+  id: "D012700",
   title: "Precompiles - xcm transactor V2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor9.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor9.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2578",
+  id: "D012701",
   title: "Precompiles - xcm transactor V3",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
@@ -8,7 +8,7 @@ import { expectEVMResult, descendOriginFromAddress20 } from "../../../../helpers
 export const CLEAR_ORIGIN_WEIGHT = 5_194_000n;
 
 describeSuite({
-  id: "D2582",
+  id: "D012702",
   title: "Precompiles - xcm utils",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xtokens.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xtokens.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2583",
+  id: "D012703",
   title: "Precompiles - xtokens",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-proxy/test-proxy-author-mapping.ts
+++ b/test/suites/dev/moonbase/test-proxy/test-proxy-author-mapping.ts
@@ -9,7 +9,7 @@ import {
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D2601",
+  id: "D012801",
   title: "Proxy : Author Mapping - simple association",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-proxy/test-proxy-balance.ts
+++ b/test/suites/dev/moonbase/test-proxy/test-proxy-balance.ts
@@ -9,7 +9,7 @@ import {
 import { getMappingInfo } from "../../../../helpers";
 
 describeSuite({
-  id: "D2602",
+  id: "D012802",
   title: "Proxy: Balances",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-proxy/test-proxy-for-contracts.ts
+++ b/test/suites/dev/moonbase/test-proxy/test-proxy-for-contracts.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, GLMR } from "@moonwall/util";
 import { alith } from "@moonwall/util";
 
 describeSuite({
-  id: "D4007",
+  id: "D012803",
   title: "Proxy Call for Contract",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-proxy/test-proxy-governance.ts
+++ b/test/suites/dev/moonbase/test-proxy/test-proxy-governance.ts
@@ -11,7 +11,7 @@ import { GLMR, VOTE_AMOUNT, dorothy, ethan } from "@moonwall/util";
 const proposalHash = "0xf3d039875302d49d52fb1af6877a2c46bc55b004afb8130f94dd9d0489ca3185";
 
 describeSuite({
-  id: "D2603",
+  id: "D012804",
   title: "Proxing governance",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-proxy/test-proxy-identity.ts
+++ b/test/suites/dev/moonbase/test-proxy/test-proxy-identity.ts
@@ -3,7 +3,7 @@ import { beforeEach, describeSuite, expect } from "@moonwall/cli";
 import { GLMR, KeyringPair, alith, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D2604",
+  id: "D012805",
   title: "Proxy : IdentityJudgement",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-proxy/test-proxy.ts
+++ b/test/suites/dev/moonbase/test-proxy/test-proxy.ts
@@ -12,7 +12,7 @@ import {
 // Charleth is used as a target account when making transfers.
 
 describeSuite({
-  id: "D2605",
+  id: "D012806",
   title: "Proxy - proxy",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-babe-lottery.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-babe-lottery.ts
@@ -4,7 +4,7 @@ import { GLMR } from "@moonwall/util";
 import { expectEVMResult, setupLotteryWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2701",
+  id: "D012901",
   title: "Randomness Babe - Preparing Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-babe-lottery2.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-babe-lottery2.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../helpers/randomness.js";
 
 describeSuite({
-  id: "D2702",
+  id: "D012902",
   title: "Randomness Babe - Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-babe-lottery3.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-babe-lottery3.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../../helpers/randomness.js";
 
 describeSuite({
-  id: "D2703",
+  id: "D012903",
   title: "Randomness Babe - Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-babe-request.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-babe-request.ts
@@ -4,7 +4,7 @@ import { CONTRACT_RANDOMNESS_STATUS_DOES_NOT_EXISTS, GLMR, alith } from "@moonwa
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2704",
+  id: "D012904",
   title: "Randomness Babe - Requesting a random number",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-babe-request2.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-babe-request2.ts
@@ -4,7 +4,7 @@ import { GLMR, alith } from "@moonwall/util";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2705",
+  id: "D012905",
   title: "Randomness Babe - Requesting a random number",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-babe-request3.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-babe-request3.ts
@@ -4,7 +4,7 @@ import { GLMR, alith } from "@moonwall/util";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2706",
+  id: "D012906",
   title: "Randomness Babe - Requesting a random number",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-result.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-result.ts
@@ -13,7 +13,7 @@ import { PalletRandomnessRandomnessResult } from "@polkadot/types/lookup";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2707",
+  id: "D012907",
   title: "Randomness Result - Requesting 4 random numbers for the same target block",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-result2.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-result2.ts
@@ -12,7 +12,7 @@ import { PalletRandomnessRandomnessResult } from "@polkadot/types/lookup";
 import { jumpBlocks, SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2708",
+  id: "D012908",
   title: "Randomness Result - Fulfilling one of multiple random numbers",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-result3.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-result3.ts
@@ -10,7 +10,7 @@ import {
 import { jumpBlocks, SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2709",
+  id: "D012909",
   title: "Randomness Result - Fulfilling all of random numbers",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-result4.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-result4.ts
@@ -6,7 +6,7 @@ import { PalletRandomnessRandomnessResult } from "@polkadot/types/lookup";
 import { jumpBlocks, SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2710",
+  id: "D012910",
   title: "Randomness Result - Passing targetted block",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery.ts
@@ -4,7 +4,7 @@ import { GLMR } from "@moonwall/util";
 import { setupLotteryWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2711",
+  id: "D012911",
   title: "Randomness VRF - Preparing Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery2.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery2.ts
@@ -4,7 +4,7 @@ import { GLMR } from "@moonwall/util";
 import { expectEVMResult, setupLotteryWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2712",
+  id: "D012912",
   title: "Randomness VRF - Starting the Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery3.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery3.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../helpers";
 
 describeSuite({
-  id: "D2713",
+  id: "D012913",
   title: "Randomness VRF - Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery4.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery4.ts
@@ -4,7 +4,7 @@ import { GLMR } from "@moonwall/util";
 import { expectEVMResult, setupLotteryWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2714",
+  id: "D012914",
   title: "Randomness VRF - Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery5.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery5.ts
@@ -12,7 +12,7 @@ import { TransactionReceipt, decodeEventLog } from "viem";
 import { setupLotteryWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2715",
+  id: "D012915",
   title: "Randomness VRF - Fulfilling Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery6.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-lottery6.ts
@@ -5,7 +5,7 @@ import { TransactionReceipt } from "viem";
 import { setupLotteryWithParticipants } from "../../../../helpers";
 
 describeSuite({
-  id: "D2716",
+  id: "D012916",
   title: "Randomness VRF - Static fulfilling Lottery Demo",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request.ts
@@ -4,7 +4,7 @@ import { GLMR, alith } from "@moonwall/util";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2717",
+  id: "D012917",
   title: "Randomness VRF - Requesting a random number",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request2.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request2.ts
@@ -4,7 +4,7 @@ import { GLMR, alith } from "@moonwall/util";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2718",
+  id: "D012918",
   title: "Randomness VRF - Requesting a random number",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request3.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request3.ts
@@ -10,7 +10,7 @@ import {
 import { expectEVMResult, extractRevertReason, SIMPLE_SALT, jumpBlocks } from "../../../../helpers";
 
 describeSuite({
-  id: "D2719",
+  id: "D012919",
   title: "Randomness VRF - Requesting a random number",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request4.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request4.ts
@@ -4,7 +4,7 @@ import { GLMR, alith } from "@moonwall/util";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2720",
+  id: "D012920",
   title: "Randomness VRF - Fulfilling a random request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request5.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request5.ts
@@ -4,7 +4,7 @@ import { GLMR, alith } from "@moonwall/util";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2721",
+  id: "D012921",
   title: "Randomness VRF - Requesting 2 random requests at same block/delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request6.ts
+++ b/test/suites/dev/moonbase/test-randomness/test-randomness-vrf-request6.ts
@@ -4,7 +4,7 @@ import { GLMR, alith } from "@moonwall/util";
 import { SIMPLE_SALT } from "../../../../helpers";
 
 describeSuite({
-  id: "D2722",
+  id: "D012922",
   title: "Randomness VRF - Fulfilling one of the 2 random requests at same block/delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-receipt/test-receipt-revert.ts
+++ b/test/suites/dev/moonbase/test-receipt/test-receipt-revert.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { getAddress } from "viem";
 
 describeSuite({
-  id: "D2801",
+  id: "D013001",
   title: "Receipt - Revert",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-receipt/test-receipt-root.ts
+++ b/test/suites/dev/moonbase/test-receipt/test-receipt-root.ts
@@ -7,7 +7,7 @@ import * as RLP from "rlp";
 import { Log, encodeDeployData, toHex } from "viem";
 
 describeSuite({
-  id: "D2802",
+  id: "D013002",
   title: "Receipt root - With events",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-receipt/test-receipt.ts
+++ b/test/suites/dev/moonbase/test-receipt/test-receipt.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { BALTATHAR_ADDRESS, alith } from "@moonwall/util";
 
 describeSuite({
-  id: "D2803",
+  id: "D013003",
   title: "Receipt - Contract",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-force-join.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-force-join.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan, faith } from "@moonwall/util";
 
 describeSuite({
-  id: "D2992",
+  id: "D013101",
   title: "Staking - Candidate Force Join - bond less than min",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-join.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-join.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2901",
+  id: "D013102",
   title: "Staking - Candidate Join - bond less than min",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-join2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-join2.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { ALITH_ADDRESS, MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2902",
+  id: "D013103",
   title: "Staking - Candidate Join - already a delegator",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-join3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-join3.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2903",
+  id: "D013104",
   title: "Staking - Candidate Join - valid request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2904",
+  id: "D013105",
   title: "Staking - Candidate Leave Schedule - hint too low",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave2.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2905",
+  id: "D013106",
   title: "Staking - Candidate Leave Schedule - already scheduled",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave3.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2906",
+  id: "D013107",
   title: "Staking - Candidate Leave Schedule - valid request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave4.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2907",
+  id: "D013108",
   title: "Staking - Candidate Leave Execute - before round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave5.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2908",
+  id: "D013109",
   title: "Staking - Candidate Leave Execute - exact round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave6.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave6.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2909",
+  id: "D013110",
   title: "Staking - Candidate Leave Execute - after round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave7.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2910",
+  id: "D013111",
   title: "Staking - Candidate Leave Cancel - leave not scheduled",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-candidate-leave8.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-leave8.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2911",
+  id: "D013112",
   title: "Staking - Candidate Leave Cancel - leave scheduled",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan, goliath } from "@moonwall/util";
 
 describeSuite({
-  id: "D2912",
+  id: "D013113",
   title: "Staking - Delegate With Auto-Compound",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound2.ts
@@ -4,7 +4,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2913",
+  id: "D013114",
   title: "Staking - Delegate With Auto-Compound - already delegated",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound3.ts
@@ -11,7 +11,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D2914",
+  id: "D013115",
   title: "Staking - Delegate With Auto-Compound - wrong candidate delegation hint",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound4.ts
@@ -11,7 +11,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D2915",
+  id: "D013116",
   title: "Staking - Delegate With Auto-Compound - wrong candidate auto-compounding delegation hint",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound5.ts
@@ -11,7 +11,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D2916",
+  id: "D013117",
   title: "Staking - Delegate With Auto-Compound - wrong delegation hint",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound6.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound6.ts
@@ -4,7 +4,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2921",
+  id: "D013118",
   title: "Staking - Delegate With Auto-Compound - valid request",
   foundationMethods: "dev",
   testCases: ({ it, log, context }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests.ts
@@ -5,7 +5,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 const numberToHex = (n: bigint): string => `0x${n.toString(16).padStart(32, "0")}`;
 
 describeSuite({
-  id: "D2922",
+  id: "D013119",
   title: "Staking - Delegation Scheduled Requests - schedule revoke",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests10-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests10-bondless-collator.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers/block.js";
 
 describeSuite({
-  id: "D2999",
+  id: "D013120",
   title:
     "Staking - Delegation Scheduled Requests with bondless collator \
         - execute bond less exact round",

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests10.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests10.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2931",
+  id: "D013121",
   title: "Staking - Delegation Scheduled Requests -execute bond less exact round",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests11-bondless-collator.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers/block.js";
 
 describeSuite({
-  id: "D3000",
+  id: "D013122",
   title:
     "Staking - Delegation Scheduled Requests with bondless collator \
         - execute bond less after round delay",

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests11.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests11.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2932",
+  id: "D013123",
   title: "Staking - Delegation Scheduled Requests - execute bond less after round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests12-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests12-bondless-collator.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers/block.js";
 
 describeSuite({
-  id: "D3001",
+  id: "D013124",
   title: "Staking - Delegation Scheduled Requests with bondless collator - collator leave",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests12.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests12.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2933",
+  id: "D013125",
   title: "Staking - Delegation Scheduled Requests - collator leave",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests2.ts
@@ -5,7 +5,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 const numberToHex = (n: bigint): string => `0x${n.toString(16).padStart(32, "0")}`;
 
 describeSuite({
-  id: "D2923",
+  id: "D013126",
   title: "Staking - Delegation Scheduled Requests - cancel scheduled revoke",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests3.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2924",
+  id: "D013127",
   title: "Staking - Delegation Scheduled Requests - execute revoke early",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests4-bondless-collator.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers/block.js";
 
 describeSuite({
-  id: "D2993",
+  id: "D013128",
   title:
     "Staking - Delegation Scheduled Requests with bondless collator \
         - execute revoke exact round delay",

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests4.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2925",
+  id: "D013129",
   title: "Staking - Delegation Scheduled Requests - execute revoke exact round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests5-bondless-collator.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers/block.js";
 
 describeSuite({
-  id: "D2994",
+  id: "D013130",
   title:
     "Staking - Delegation Scheduled Requests with bondless collator \
         - execute revoke after round delay",

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests5.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2926",
+  id: "D013131",
   title: "Staking - Delegation Scheduled Requests - execute revoke after round delay",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests6-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests6-bondless-collator.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers/block.js";
 
 describeSuite({
-  id: "D2995",
+  id: "D013132",
   title:
     "Staking - Delegation Scheduled Requests with bondless collator \
         - execute revoke on last delegation",

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests6.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests6.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2927",
+  id: "D013133",
   title: "Staking - Delegation Scheduled Requests - execute revoke on last delegation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests7-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests7-bondless-collator.ts
@@ -3,7 +3,7 @@ import { describeSuite, beforeAll, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2996",
+  id: "D013134",
   title: "Staking - Delegation Scheduled Requests with bondless collator - schedule bond less",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests7.ts
@@ -3,7 +3,7 @@ import { describeSuite, beforeAll, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2928",
+  id: "D013135",
   title: "Staking - Delegation Scheduled Requests - schedule bond less",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests8-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests8-bondless-collator.ts
@@ -3,7 +3,7 @@ import { describeSuite, beforeAll, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2997",
+  id: "D013136",
   title:
     "Staking - Delegation Scheduled Requests with bondless collator - cancel scheduled bond less",
   foundationMethods: "dev",

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests8.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests8.ts
@@ -3,7 +3,7 @@ import { describeSuite, beforeAll, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2929",
+  id: "D013137",
   title: "Staking - Delegation Scheduled Requests - cancel scheduled bond less",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests9-bondless-collator.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests9-bondless-collator.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers/block.js";
 
 describeSuite({
-  id: "D2998",
+  id: "D013138",
   title: "Staking - Delegation Scheduled Requests with bondless collator - execute bond less early",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests9.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegation-scheduled-requests9.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpToRound } from "../../../../helpers";
 
 describeSuite({
-  id: "D2930",
+  id: "D013139",
   title: "Staking - Delegation Scheduled Requests - execute bond less early",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-bond-more.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-bond-more.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2935",
+  id: "D013140",
   title: "Staking - Bond More - no scheduled request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-bond-more2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-bond-more2.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2936",
+  id: "D013141",
   title: "Staking - Bond More - bond less scheduled",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-bond-more3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-bond-more3.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2937",
+  id: "D013142",
   title: "Staking - Bond More - revoke scheduled",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-join.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-join.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2938",
+  id: "D013143",
   title: "Staking - Delegator Join",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-join2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-join2.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2939",
+  id: "D013144",
   title: "Staking - Delegator Join - already delegated",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-join3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-join3.ts
@@ -10,7 +10,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D2940",
+  id: "D013145",
   title: "Staking - Delegator Join - wrong candidate delegation hint",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-join4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-join4.ts
@@ -10,7 +10,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D2941",
+  id: "D013146",
   title: "Staking - Delegator Join - wrong delegation hint",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-delegator-join5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegator-join5.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2942",
+  id: "D013147",
   title: "Staking - Delegator Join - valid request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-genesis.ts
+++ b/test/suites/dev/moonbase/test-staking/test-genesis.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { DEFAULT_GENESIS_STAKING, GLMR, alith } from "@moonwall/util";
 
 describeSuite({
-  id: "D2952",
+  id: "D013148",
   title: "Staking - Genesis",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-parachain-bond.ts
+++ b/test/suites/dev/moonbase/test-staking/test-parachain-bond.ts
@@ -5,7 +5,7 @@ import { ZERO_ADDRESS, alith } from "@moonwall/util";
 const TWENTY_PERCENT = 20;
 
 describeSuite({
-  id: "D2953",
+  id: "D013149",
   title: "Staking - Parachain Bond - set bond account",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound-pov.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound-pov.ts
@@ -11,7 +11,7 @@ import {
 import { chunk, jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D3542",
+  id: "D013150",
   title: "Staking - Rewards Auto-Compound - PoV Size",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2954",
+  id: "D013151",
   title: "Staking - Rewards Auto-Compound - no auto-compound config",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound10.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound10.ts
@@ -13,7 +13,7 @@ import {
 import { chunk } from "../../../../helpers";
 
 describeSuite({
-  id: "D2963",
+  id: "D013152",
   title: "Staking - Rewards Auto-Compound - bottom delegation kick",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound2.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2955",
+  id: "D013153",
   title: "Staking - Rewards Auto-Compound - 0% auto-compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound3.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, Percent, alith, ethan } from "@moonwall/util";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2956",
+  id: "D013154",
   title: "Staking - Rewards Auto-Compound - 1% auto-compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound4.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, Percent, alith, ethan } from "@moonwall/util";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2957",
+  id: "D013155",
   title: "Staking - Rewards Auto-Compound - 50% auto-compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound5.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2958",
+  id: "D013156",
   title: "Staking - Rewards Auto-Compound - 100% auto-compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound6.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound6.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2959",
+  id: "D013157",
   title: "Staking - Rewards Auto-Compound - no revoke requests",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound7.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
 
 describeSuite({
-  id: "D2960",
+  id: "D013158",
   title: "Staking - Rewards Auto-Compound - scheduled revoke request after round snapshot",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound8.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound8.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2961",
+  id: "D013159",
   title: "Staking - Rewards Auto-Compound - delegator revoke",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound9.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards-auto-compound9.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, MIN_GLMR_STAKING, alith, baltathar, ethan } from "@
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2962",
+  id: "D013160",
   title: "Staking - Rewards Auto-Compound - candidate leave",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2964",
+  id: "D013161",
   title: "Staking - Rewards - no scheduled requests",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards2.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2965",
+  id: "D013162",
   title: "Staking - Rewards - scheduled revoke request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards3.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, alith, ethan } from "@moonwall/util";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2966",
+  id: "D013163",
   title: "Staking - Rewards - scheduled revoke request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-rewards4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-rewards4.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, alith, baltathar, ethan } from "@moonwall/util";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2967",
+  id: "D013164",
   title: "Staking - Rewards - scheduled bond decrease request",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-set-auto-compound.ts
+++ b/test/suites/dev/moonbase/test-staking/test-set-auto-compound.ts
@@ -11,7 +11,7 @@ import {
 } from "@moonwall/util";
 
 describeSuite({
-  id: "D2968",
+  id: "D013165",
   title: "Staking - Set Auto-Compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-set-auto-compound2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-set-auto-compound2.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2969",
+  id: "D013166",
   title: "Staking - Set Auto-Compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-set-auto-compound3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-set-auto-compound3.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2970",
+  id: "D013167",
   title: "Staking - Set Auto-Compound - new config 101%",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-staking/test-set-auto-compound4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-set-auto-compound4.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2971",
+  id: "D013168",
   title: "Staking - Set Auto-Compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-set-auto-compound5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-set-auto-compound5.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2972",
+  id: "D013169",
   title: "Staking - Set Auto-Compound - update existing config",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-set-auto-compound6.ts
+++ b/test/suites/dev/moonbase/test-staking/test-set-auto-compound6.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { MIN_GLMR_DELEGATOR, alith, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D2973",
+  id: "D013170",
   title: "Staking - Set Auto-Compound - remove existing config if 0% auto-compound",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-consts.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-consts.ts
@@ -12,7 +12,7 @@ import {
 import { chunk } from "../../../../helpers";
 
 describeSuite({
-  id: "D2974",
+  id: "D013171",
   title: "Staking - Consts - MaxDelegationsPerDelegator",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks.ts
@@ -4,7 +4,7 @@ import { GLMR, MIN_GLMR_DELEGATOR, alith, generateKeyringPair } from "@moonwall/
 import { fromBytes } from "viem";
 
 describeSuite({
-  id: "D2975",
+  id: "D013172",
   title: "Staking - Locks - join delegators",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks10.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks10.ts
@@ -11,7 +11,7 @@ import {
 import { fromBytes } from "viem";
 
 describeSuite({
-  id: "D2984",
+  id: "D013173",
   title: "Staking - Locks - multiple delegations single lock",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks11.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks11.ts
@@ -4,7 +4,7 @@ import { GLMR, KeyringPair, MIN_GLMR_DELEGATOR, alith, generateKeyringPair } fro
 import { chunk } from "../../../../helpers";
 
 describeSuite({
-  id: "D2985",
+  id: "D013174",
   title: "Staking - Locks - bottom delegator removed",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks12.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks12.ts
@@ -12,7 +12,7 @@ import { fromBytes } from "viem";
 import { chunk } from "../../../../helpers";
 
 describeSuite({
-  id: "D2986",
+  id: "D013175",
   title: "Staking - Locks - bottom and top delegations",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks2.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_STAKING, baltathar } from "@moonwall/util";
 import { fromBytes } from "viem";
 
 describeSuite({
-  id: "D2976",
+  id: "D013176",
   title: "Staking - Locks - join candidates",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks3.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { GLMR, MIN_GLMR_DELEGATOR, alith, baltathar, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D2977",
+  id: "D013177",
   title: "Staking - Locks - delegator balance is locked",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks4.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { GLMR, MIN_GLMR_STAKING, alith, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D2978",
+  id: "D013178",
   title: "Staking - Locks - candidate balance is locked",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks5.ts
@@ -10,7 +10,7 @@ import {
 import { GLMR, MIN_GLMR_DELEGATOR, alith, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D2979",
+  id: "D013179",
   title: "Staking - Locks - democracy vote",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks6.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks6.ts
@@ -4,7 +4,7 @@ import { GLMR, MIN_GLMR_DELEGATOR, alith, generateKeyringPair } from "@moonwall/
 import { fromBytes } from "viem";
 
 describeSuite({
-  id: "D2980",
+  id: "D013180",
   title: "Staking - Locks - schedule revoke",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks7.ts
@@ -4,7 +4,7 @@ import { GLMR, MIN_GLMR_DELEGATOR, alith, generateKeyringPair } from "@moonwall/
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2981",
+  id: "D013181",
   title: "Staking - Locks - execute revoke",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks8.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks8.ts
@@ -11,7 +11,7 @@ import { fromBytes } from "viem";
 import { jumpRounds } from "../../../../helpers";
 
 describeSuite({
-  id: "D2982",
+  id: "D013182",
   title: "Staking - Locks - multiple delegations single revoke",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-staking-locks9.ts
+++ b/test/suites/dev/moonbase/test-staking/test-staking-locks9.ts
@@ -12,7 +12,7 @@ import { fromBytes } from "viem";
 import { chunk } from "../../../../helpers";
 
 describeSuite({
-  id: "D2983",
+  id: "D013183",
   title: "Staking - Locks - max delegations",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-weights.ts
+++ b/test/suites/dev/moonbase/test-staking/test-weights.ts
@@ -6,7 +6,7 @@ import { createAccounts, countExtrinsics } from "../../../../helpers";
 const INITIAL_AMOUNT = 12n * MIN_GLMR_STAKING + 50n * GLMR;
 
 describeSuite({
-  id: "D2987",
+  id: "D013184",
   title: "Staking - Max Transaction Fit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-weights2.ts
+++ b/test/suites/dev/moonbase/test-staking/test-weights2.ts
@@ -6,7 +6,7 @@ import { createAccounts, countExtrinsics } from "../../../../helpers";
 const INITIAL_AMOUNT = 12n * MIN_GLMR_STAKING + 50n * GLMR;
 
 describeSuite({
-  id: "D2988",
+  id: "D013185",
   title: "Staking - Max Transaction Fit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-weights3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-weights3.ts
@@ -4,7 +4,7 @@ import { MIN_GLMR_DELEGATOR, alith } from "@moonwall/util";
 import { chunk, createAccounts, countExtrinsics } from "../../../../helpers";
 
 describeSuite({
-  id: "D2989",
+  id: "D013186",
   title: "Staking - Max Transaction Fit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-weights4.ts
+++ b/test/suites/dev/moonbase/test-staking/test-weights4.ts
@@ -6,7 +6,7 @@ import { chunk, createAccounts, countExtrinsics } from "../../../../helpers";
 const INITIAL_AMOUNT = 12n * MIN_GLMR_STAKING + 50n * GLMR;
 
 describeSuite({
-  id: "D2990",
+  id: "D013187",
   title: "Staking - Max Transaction Fit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-staking/test-weights5.ts
+++ b/test/suites/dev/moonbase/test-staking/test-weights5.ts
@@ -6,7 +6,7 @@ import { chunk, createAccounts, countExtrinsics } from "../../../../helpers";
 const INITIAL_AMOUNT = 12n * MIN_GLMR_STAKING + 50n * GLMR;
 
 describeSuite({
-  id: "D2991",
+  id: "D013188",
   title: "Staking - Max Transaction Fit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-storage-growth/test-block-storage-growth.ts
+++ b/test/suites/dev/moonbase/test-storage-growth/test-block-storage-growth.ts
@@ -4,7 +4,7 @@ import { createEthersTransaction, sendRawTransaction } from "@moonwall/util";
 import { encodeDeployData } from "viem";
 
 describeSuite({
-  id: "D4003",
+  id: "D013201",
   title: "Storage Block (40Kb) - Storage Growth Limit",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-storage-growth/test-evm-create-storage-growth.ts
+++ b/test/suites/dev/moonbase/test-storage-growth/test-evm-create-storage-growth.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, createEthersTransaction } from "@moonwall/util";
 import { expectEVMResult } from "helpers/eth-transactions";
 
 describeSuite({
-  id: "D4001",
+  id: "D013202",
   title: "Storage growth limit - Contract Creation",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-storage-growth/test-evm-store-storage-growth.ts
+++ b/test/suites/dev/moonbase/test-storage-growth/test-evm-store-storage-growth.ts
@@ -11,7 +11,7 @@ import { expectOk } from "helpers/expect";
 import { Abi, encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D4002",
+  id: "D013203",
   title: "Storage growth limit - New Entries",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-storage-growth/test-precompile-storage-growth.ts
+++ b/test/suites/dev/moonbase/test-storage-growth/test-precompile-storage-growth.ts
@@ -12,7 +12,7 @@ import { expectEVMResult } from "helpers/eth-transactions";
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D4004",
+  id: "D013204",
   title: "Storage growth limit - Precompiles",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-subscription/test-subscription-logs.ts
+++ b/test/suites/dev/moonbase/test-subscription/test-subscription-logs.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D3001",
+  id: "D013301",
   title: "Subscription - Logs",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-subscription/test-subscription-logs2.ts
+++ b/test/suites/dev/moonbase/test-subscription/test-subscription-logs2.ts
@@ -4,7 +4,7 @@ import { ALITH_CONTRACT_ADDRESSES } from "@moonwall/util";
 import { Log } from "web3";
 
 describeSuite({
-  id: "D3002",
+  id: "D013302",
   title: "Subscription - Logs",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-subscription/test-subscription-past-events.ts
+++ b/test/suites/dev/moonbase/test-subscription/test-subscription-past-events.ts
@@ -5,7 +5,7 @@ import { encodeDeployData } from "viem";
 import { web3SubscribeHistoricalLogs } from "../../../../helpers";
 
 describeSuite({
-  id: "D3003",
+  id: "D013303",
   title: "Subscription - Past Events",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-subscription/test-subscription-pending.ts
+++ b/test/suites/dev/moonbase/test-subscription/test-subscription-pending.ts
@@ -4,7 +4,7 @@ import { BALTATHAR_ADDRESS, GLMR, createRawTransfer, sendRawTransaction } from "
 import { setTimeout } from "timers/promises";
 
 describeSuite({
-  id: "D3004",
+  id: "D013304",
   title: "Subscription -  Pending transactions",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-subscription/test-subscription.ts
+++ b/test/suites/dev/moonbase/test-subscription/test-subscription.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, BALTATHAR_ADDRESS, createRawTransfer } from "@moonwall/u
 import { PublicClient, createPublicClient, webSocket } from "viem";
 
 describeSuite({
-  id: "D3005",
+  id: "D013305",
   title: "Subscription - Block headers",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-sudo/test-sudo.ts
+++ b/test/suites/dev/moonbase/test-sudo/test-sudo.ts
@@ -11,7 +11,7 @@ import {
 import { ALITH_GENESIS_TRANSFERABLE_BALANCE, verifyLatestBlockFees } from "../../../../helpers";
 
 describeSuite({
-  id: "D3101",
+  id: "D013401",
   title: "Sudo - successful setParachainBondAccount",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3201",
+  id: "D013501",
   title: "Treasury proposal #1",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal10.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal10.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { baltathar, charleth, dorothy, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3210",
+  id: "D013502",
   title: "Treasury proposal #10",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal2.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal2.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3202",
+  id: "D013503",
   title: "Treasury proposal #2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal3.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal3.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { GLMR, baltathar, charleth, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3203",
+  id: "D013504",
   title: "Treasury proposal #3",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal4.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal4.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { baltathar, charleth, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3204",
+  id: "D013505",
   title: "Treasury proposal #4",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal5.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal5.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { alith, baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3205",
+  id: "D013506",
   title: "Treasury proposal #5",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal6.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal6.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { alith, baltathar, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3206",
+  id: "D013507",
   title: "Treasury proposal #6",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal7.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal7.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { GLMR, baltathar, charleth, dorothy, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3207",
+  id: "D013508",
   title: "Treasury proposal #7",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal8.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal8.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { baltathar, charleth, dorothy, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3208",
+  id: "D013509",
   title: "Treasury proposal #8",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-proposal9.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-proposal9.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { GLMR, baltathar, charleth, dorothy, ethan } from "@moonwall/util";
 
 describeSuite({
-  id: "D3209",
+  id: "D013510",
   title: "Treasury proposal #9",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-fairness.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-fairness.ts
@@ -24,7 +24,7 @@ import {
 const HIGH_MAX_FEE_PER_GAS = GLMR;
 
 describeSuite({
-  id: "D3301",
+  id: "D013601",
   title: "Tip should be respected",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-future.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-future.ts
@@ -4,7 +4,7 @@ import { alith, createEthersTransaction, sendRawTransaction } from "@moonwall/ut
 import { encodeDeployData, toHex } from "viem";
 
 describeSuite({
-  id: "D3302",
+  id: "D013602",
   title: "TxPool - Future Ethereum transaction",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-limits.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-limits.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { BALTATHAR_ADDRESS, createRawTransfer, sendRawTransaction } from "@moonwall/util";
 
 describeSuite({
-  id: "D3303",
+  id: "D013603",
   title: "TxPool - Limits",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-limits2.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-limits2.ts
@@ -4,7 +4,7 @@ import { createEthersTransaction } from "@moonwall/util";
 import { encodeDeployData } from "viem";
 
 describeSuite({
-  id: "D3304",
+  id: "D013604",
   title: "TxPool - Limits",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-limits3.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-limits3.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, createEthersTransaction } from "@moonwall/util";
 import { encodeDeployData } from "viem";
 
 describeSuite({
-  id: "D3305",
+  id: "D013605",
   title: "TxPool - Limits",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-limits4.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-limits4.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, createEthersTransaction } from "@moonwall/util";
 import { encodeDeployData } from "viem";
 
 describeSuite({
-  id: "D3306",
+  id: "D013606",
   title: "TxPool - Limits",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-pending.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-pending.ts
@@ -4,7 +4,7 @@ import { ALITH_ADDRESS, createEthersTransaction, sendRawTransaction } from "@moo
 import { encodeDeployData, toHex } from "viem";
 
 describeSuite({
-  id: "D3310",
+  id: "D013607",
   title: "TxPool - Pending Ethereum transaction",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-pending2.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-pending2.ts
@@ -9,7 +9,7 @@ import {
 import { encodeFunctionData, toHex } from "viem";
 
 describeSuite({
-  id: "D3311",
+  id: "D013608",
   title: "TxPool - Ethereum Contract Call",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-reset.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-reset.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { describeSuite, expect } from "@moonwall/cli";
 
 describeSuite({
-  id: "D3312",
+  id: "D013609",
   title: "TxPool - Genesis",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-reset2.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-reset2.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { describeSuite, expect, beforeAll } from "@moonwall/cli";
 
 describeSuite({
-  id: "D3313",
+  id: "D013610",
   title: "TxPool - New block",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-1.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3401",
+  id: "D013701",
   title: "Mock XCM V3 - downward transfer with non-triggered error handler",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-2.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3402",
+  id: "D013702",
   title: "Mock XCM V3 - downward transfer with triggered error handler",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-3.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3403",
+  id: "D013703",
   title: "Mock XCM V3 - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-4.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3404",
+  id: "D013704",
   title: "Mock XCM V3 - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-5.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3405",
+  id: "D013705",
   title: "Mock XCM V3 - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-error-and-appendix-6.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3406",
+  id: "D013706",
   title: "Mock XCM V3 - downward transfer claim trapped assets",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-queue.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-dmp-queue.ts
@@ -6,7 +6,7 @@ import { u8aToHex } from "@polkadot/util";
 import { XcmFragment, weightMessage } from "../../../../helpers";
 
 describeSuite({
-  id: "D3407",
+  id: "D013707",
   title: "Mock XCMP - test XCMP execution",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-1.ts
@@ -34,7 +34,7 @@ const STATEMINT_LOCATION = {
 };
 
 describeSuite({
-  id: "D3408",
+  id: "D013708",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-2.ts
@@ -36,7 +36,7 @@ const STATEMINT_LOCATION = {
 };
 
 describeSuite({
-  id: "D3409",
+  id: "D013709",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-3.ts
@@ -14,7 +14,7 @@ import {
 const foreign_para_id = 2000;
 
 describeSuite({
-  id: "D3410",
+  id: "D013710",
   title: "Mock XCM - receive horizontal transfer of DEV",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-4.ts
@@ -15,7 +15,7 @@ import {
 const foreign_para_id = 2000;
 
 describeSuite({
-  id: "D3411",
+  id: "D013711",
   title: "Mock XCM - receive horizontal transfer of DEV with new reanchor",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-5.ts
@@ -50,7 +50,7 @@ const STATEMINT_ASSET_ONE_LOCATION = {
 };
 
 describeSuite({
-  id: "D3413",
+  id: "D013712",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-asset-transfer-6.ts
@@ -34,7 +34,7 @@ const STATEMINT_LOCATION = {
 };
 
 describeSuite({
-  id: "D3415",
+  id: "D013713",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-1.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3416",
+  id: "D013714",
   title: "Mock XCM - receive horizontal transact",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-2.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3417",
+  id: "D013715",
   title: "Mock XCM - receive horizontal transact with two Descends",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-3.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3418",
+  id: "D013716",
   title: "Mock XCM - receive horizontal transact without withdraw",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-4.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3419",
+  id: "D013717",
   title: "Mock XCM - receive horizontal transact without buy execution",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-1.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3420",
+  id: "D013718",
   title: "Mock XCM - receive horizontal transact ETHEREUM (transfer)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-10.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-10.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3429",
+  id: "D013719",
   title: "Mock XCM - transact ETHEREUM input size check fails",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-2.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3421",
+  id: "D013720",
   title: "Mock XCM - receive horizontal transact ETHEREUM (call)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-3.ts
@@ -16,7 +16,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3422",
+  id: "D013721",
   title: "Mock XCM - receive horizontal transact ETHEREUM (asset fee)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-4.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3423",
+  id: "D013722",
   title: "Mock XCM - receive horizontal transact ETHEREUM (proxy)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-5.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3424",
+  id: "D013723",
   title: "Mock XCM - receive horizontal transact ETHEREUM (proxy)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-6.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3425",
+  id: "D013724",
   title: "Mock XCM - receive horizontal transact ETHEREUM (proxy)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-7.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-7.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3426",
+  id: "D013725",
   title: "Mock XCM - transact ETHEREUM (proxy) disabled switch",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-8.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-8.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3427",
+  id: "D013726",
   title: "Mock XCM - transact ETHEREUM (non-proxy) disabled switch",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-9.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-mock-hrmp-transact-ethereum-9.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { alith } from "@moonwall/util";
 
 describeSuite({
-  id: "D3428",
+  id: "D013727",
   title: "Mock XCM - EthereumXcm only disable by root",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-xcm-erc20-transfer-two-ERC20.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-xcm-erc20-transfer-two-ERC20.ts
@@ -13,7 +13,7 @@ import {
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 
 describeSuite({
-  id: "D3430",
+  id: "D013728",
   title: "Mock XCM - Send two local ERC20",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-xcm-erc20-transfer.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-xcm-erc20-transfer.ts
@@ -14,7 +14,7 @@ import {
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 
 describeSuite({
-  id: "D3431",
+  id: "D013729",
   title: "Mock XCM - Send local erc20",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-xcm-ver-conversion-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-xcm-ver-conversion-1.ts
@@ -15,7 +15,7 @@ import {
 const foreign_para_id = 2000;
 
 describeSuite({
-  id: "D3432",
+  id: "D013730",
   title: "XCM Moonbase: version compatibility",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v2/test-xcm-ver-conversion-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v2/test-xcm-ver-conversion-2.ts
@@ -15,7 +15,7 @@ import {
 const foreign_para_id = 2000;
 
 describeSuite({
-  id: "D3433",
+  id: "D013731",
   title: "XCM Moonriver: version compatibility",
   foundationMethods: "dev",
   chainType: "moonriver",

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-asset-transfer.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-asset-transfer.ts
@@ -13,7 +13,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3501",
+  id: "D013801",
   title: "Mock XCM - receive downward transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-1.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3502",
+  id: "D013802",
   title: "Mock XCM V3 - downward transfer with non-triggered error handler",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-2.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3503",
+  id: "D013803",
   title: "Mock XCM V3 - downward transfer with triggered error handler",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-3.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3504",
+  id: "D013804",
   title: "Mock XCM V3 - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-4.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3505",
+  id: "D013805",
   title: "Mock XCM V3 - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-5.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3506",
+  id: "D013806",
   title: "Mock XCM V3 - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-6.ts
@@ -15,7 +15,7 @@ const RELAY_TOKEN = 1_000_000_000_000n;
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
-  id: "D3507",
+  id: "D013807",
   title: "Mock XCM V3 - downward transfer claim trapped assets",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-queue.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-queue.ts
@@ -6,7 +6,7 @@ import { u8aToHex } from "@polkadot/util";
 import { XcmFragment, weightMessage } from "../../../../helpers";
 
 describeSuite({
-  id: "D3508",
+  id: "D013808",
   title: "Mock XCMP - test XCMP execution",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-1.ts
@@ -16,7 +16,7 @@ const assetMetadata = {
 };
 
 describeSuite({
-  id: "D3509",
+  id: "D013809",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-2.ts
@@ -34,7 +34,7 @@ const STATEMINT_LOCATION = {
 };
 
 describeSuite({
-  id: "D3510",
+  id: "D013810",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-3.ts
@@ -35,7 +35,7 @@ const STATEMINT_LOCATION = {
 };
 
 describeSuite({
-  id: "D3511",
+  id: "D013811",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-4.ts
@@ -13,7 +13,7 @@ import {
 const foreign_para_id = 2000;
 
 describeSuite({
-  id: "D3512",
+  id: "D013812",
   title: "Mock XCM - receive horizontal transfer of DEV",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-5.ts
@@ -14,7 +14,7 @@ import {
 const foreign_para_id = 2000;
 
 describeSuite({
-  id: "D3513",
+  id: "D013813",
   title: "Mock XCM - receive horizontal transfer of DEV with new reanchor",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-6.ts
@@ -48,7 +48,7 @@ const STATEMINT_ASSET_ONE_LOCATION = {
 };
 
 describeSuite({
-  id: "D3515",
+  id: "D013814",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-8.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-8.ts
@@ -33,7 +33,7 @@ const STATEMINT_LOCATION = {
 };
 
 describeSuite({
-  id: "D3517",
+  id: "D013815",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-1.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3518",
+  id: "D013816",
   title: "Mock XCM - receive horizontal transact",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-2.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3519",
+  id: "D013817",
   title: "Mock XCM - receive horizontal transact with two Descends",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-3.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3520",
+  id: "D013818",
   title: "Mock XCM - receive horizontal transact without withdraw",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-4.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3521",
+  id: "D013819",
   title: "Mock XCM - receive horizontal transact without buy execution",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-1.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3522",
+  id: "D013820",
   title: "Mock XCM - receive horizontal transact ETHEREUM (transfer)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-10.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-10.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3531",
+  id: "D013821",
   title: "Mock XCM - transact ETHEREUM input size check succeeds",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-11.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-11.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3532",
+  id: "D013822",
   title: "Mock XCM - transact ETHEREUM input size check fails",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3533",
+  id: "D013823",
   title: "Mock XCM - receive horizontal transact ETHEREUM (transfer)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-2.ts
@@ -12,7 +12,7 @@ import {
 import { GAS_LIMIT_POV_RATIO } from "@moonwall/util";
 
 describeSuite({
-  id: "D3523",
+  id: "D013824",
   title: "Mock XCM - receive horizontal transact ETHEREUM (call)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
@@ -16,7 +16,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3524",
+  id: "D013825",
   title: "Mock XCM - receive horizontal transact ETHEREUM (asset fee)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-4.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3525",
+  id: "D013826",
   title: "Mock XCM - receive horizontal transact ETHEREUM (proxy)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-5.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3526",
+  id: "D013827",
   title: "Mock XCM - receive horizontal transact ETHEREUM (proxy)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-6.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3527",
+  id: "D013828",
   title: "Mock XCM - receive horizontal transact ETHEREUM (proxy)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-7.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-7.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3528",
+  id: "D013829",
   title: "Mock XCM - transact ETHEREUM (proxy) disabled switch",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-8.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-8.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../helpers/xcm.js";
 
 describeSuite({
-  id: "D3529",
+  id: "D013830",
   title: "Mock XCM - transact ETHEREUM (non-proxy) disabled switch",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-9.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-9.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { alith } from "@moonwall/util";
 
 describeSuite({
-  id: "D3530",
+  id: "D013831",
   title: "Mock XCM - EthereumXcm only disable by root",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-data-field-size.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-data-field-size.ts
@@ -11,7 +11,7 @@ import { parseEther } from "ethers";
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 
 describeSuite({
-  id: "D3543",
+  id: "D013832",
   title: "Mock ERC20 <> XCM - Test wrong size of GeneralKey data field",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-excess-gas.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-excess-gas.ts
@@ -14,7 +14,7 @@ import {
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 
 describeSuite({
-  id: "D3534",
+  id: "D013833",
   title: "Mock XCM - Test bad contract with excess gas usage",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
@@ -15,7 +15,7 @@ import {
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 
 describeSuite({
-  id: "D3535",
+  id: "D013834",
   title: "Mock XCM - Fails trying to pay fees with ERC20",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3-filter.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3-filter.ts
@@ -13,7 +13,7 @@ import {
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 
 describeSuite({
-  id: "D3536",
+  id: "D013835",
   title: "Mock XCM V3 - XCM Weight Limit",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3.ts
@@ -13,7 +13,7 @@ import {
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 
 describeSuite({
-  id: "D3537",
+  id: "D013836",
   title: "Mock XCM V3 - Receive erc20 via XCM",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-transactor-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-transactor-1.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { alith } from "@moonwall/util";
 
 describeSuite({
-  id: "D3538",
+  id: "D013837",
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-transactor-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-transactor-2.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment";
 import { describeSuite, expect, dispatchAsGeneralAdmin } from "@moonwall/cli";
 
 describeSuite({
-  id: "D3539",
+  id: "D013838",
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcmv3-max-weight-instructions.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcmv3-max-weight-instructions.ts
@@ -12,7 +12,7 @@ import {
 import { parseEther } from "ethers";
 
 describeSuite({
-  id: "D3540",
+  id: "D013839",
   title: "XCM V3 - Max Weight Instructions",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcmv3-new-instructions.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcmv3-new-instructions.ts
@@ -15,7 +15,7 @@ import { parseEther } from "ethers";
 // the important thing (and what we are testing) is that they are
 // executed and are not blocked with 'WeightNotComputable' due to using max weight.
 describeSuite({
-  id: "D3541",
+  id: "D013840",
   title: "XCM V3 - Max Weight Instructions",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/dev/moonbeam/test-precompile/test-precompile-assets-erc20-local-assets-removal.ts
+++ b/test/suites/dev/moonbeam/test-precompile/test-precompile-assets-erc20-local-assets-removal.ts
@@ -3,7 +3,7 @@ import { ALITH_ADDRESS } from "@moonwall/util";
 import { Abi } from "viem";
 
 describeSuite({
-  id: "E0101",
+  id: "D020101",
   title: "Precompiles - Assets-ERC20 (LocalAssets Removal)",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {

--- a/test/suites/rt-upgrade/test-upgrade-chain.ts
+++ b/test/suites/rt-upgrade/test-upgrade-chain.ts
@@ -5,7 +5,7 @@ import { ApiPromise } from "@polkadot/api";
 import { parseEther } from "ethers";
 
 describeSuite({
-  id: "CIRT",
+  id: "R01",
   title: "Chopsticks Upgrade",
   foundationMethods: "chopsticks",
   testCases: ({ it, context, log }) => {

--- a/test/suites/smoke/test-author-filter-consistency.ts
+++ b/test/suites/smoke/test-author-filter-consistency.ts
@@ -4,7 +4,7 @@ import { ApiDecoration } from "@polkadot/api/types";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "S100",
+  id: "S01",
   title: `Verify author filter consistency`,
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-author-mapping-consistency.ts
+++ b/test/suites/smoke/test-author-mapping-consistency.ts
@@ -6,7 +6,7 @@ import { ApiDecoration } from "@polkadot/api/types";
 import chalk from "chalk";
 
 describeSuite({
-  id: "S200",
+  id: "S02",
   title: `Verifying deposit for associated nimbus ids`,
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-balances-consistency.ts
+++ b/test/suites/smoke/test-balances-consistency.ts
@@ -46,7 +46,7 @@ type LocksInfo = { total?: bigint; locks?: { [key: string]: bigint } };
 // is not exhausted.
 
 describeSuite({
-  id: "S300",
+  id: "S03",
   title: "Verifying balances consistency",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-block-finalized.ts
+++ b/test/suites/smoke/test-block-finalized.ts
@@ -17,7 +17,7 @@ const timePeriod = process.env.TIME_PERIOD ? Number(process.env.TIME_PERIOD) : T
 const timeout = Math.floor(timePeriod / 12); // 2 hour -> 10 minute timeout
 
 describeSuite({
-  id: "S400",
+  id: "S04",
   title: "Parachain blocks should be finalized",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-block-weights.ts
+++ b/test/suites/smoke/test-block-weights.ts
@@ -30,7 +30,7 @@ interface BlockLimits {
 }
 
 describeSuite({
-  id: "S500",
+  id: "S05",
   foundationMethods: "read_only",
   title:
     "Verifying weights of blocks in the past " +

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -52,7 +52,7 @@ enum Change {
 }
 
 describeSuite({
-  id: "S550",
+  id: "S06",
   title: `Dynamic fees in past ${hours} hours should be correct`,
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-eth-parent-hash-bad-block-fix.ts
+++ b/test/suites/smoke/test-eth-parent-hash-bad-block-fix.ts
@@ -4,7 +4,7 @@ import { THIRTY_MINS } from "@moonwall/util";
 import { ApiDecoration } from "@polkadot/api/types";
 
 describeSuite({
-  id: "S570",
+  id: "S07",
   title: `RPC Eth ParentHash`,
   foundationMethods: "dev",
   testCases: async function ({ context, it, log }) {

--- a/test/suites/smoke/test-ethereum-contract-code.ts
+++ b/test/suites/smoke/test-ethereum-contract-code.ts
@@ -7,7 +7,7 @@ import chalk from "chalk";
 import { processAllStorage } from "../../helpers/storageQueries.js";
 
 describeSuite({
-  id: "S600",
+  id: "S08",
   title: `Ethereum contract bytecode should not be large`,
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-ethereum-current-consistency.ts
+++ b/test/suites/smoke/test-ethereum-current-consistency.ts
@@ -31,7 +31,7 @@ function* range(from: number, to: number, step = 1) {
 }
 
 describeSuite({
-  id: "S700",
+  id: "S09",
   title: "Ethereum CurrentBlock and CurrentReceipts should never be 0x00",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-ethereum-db-mapping.ts
+++ b/test/suites/smoke/test-ethereum-db-mapping.ts
@@ -5,7 +5,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 // We want to compare both to verify recent db data consistency and rpc impl across client versions.
 
 describeSuite({
-  id: "S800",
+  id: "S10",
   title: "Ethereum secondary DB should contains valid data",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-ethereum-failures.ts
+++ b/test/suites/smoke/test-ethereum-failures.ts
@@ -26,7 +26,7 @@ type BlockFilteredRecord = {
 };
 
 describeSuite({
-  id: "S900",
+  id: "S11",
   title: `ETH Failures in past ${hours} hours should be reported correctly`,
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-foreign-asset-consistency.ts
+++ b/test/suites/smoke/test-foreign-asset-consistency.ts
@@ -4,7 +4,7 @@ import { describeSuite, expect, beforeAll } from "@moonwall/cli";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "S1000",
+  id: "S12",
   title: `Verifying foreign asset count, mapping, assetIds and deposits`,
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-foreign-xcm-failures.ts
+++ b/test/suites/smoke/test-foreign-xcm-failures.ts
@@ -22,7 +22,7 @@ type NetworkBlockEvents = {
 let skip = false;
 
 describeSuite({
-  id: "S1100",
+  id: "S13",
   title:
     `Foreign XCM Failures in past ${(timePeriod / (1000 * 60 * 60)).toFixed(2)} hours` +
     ` should not be serious`,

--- a/test/suites/smoke/test-historic-compatibility.ts
+++ b/test/suites/smoke/test-historic-compatibility.ts
@@ -9,7 +9,7 @@ import { ethers } from "ethers";
 const limiter = rateLimiter();
 
 describeSuite({
-  id: "S1200",
+  id: "S14",
   title: "Verifying historic compatibility",
   foundationMethods: "read_only",
   testCases: async ({ context, it, log }) => {

--- a/test/suites/smoke/test-orbiter-consistency.ts
+++ b/test/suites/smoke/test-orbiter-consistency.ts
@@ -12,7 +12,7 @@ import { StorageKey } from "@polkadot/types";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "S1400",
+  id: "S15",
   title: "Verify orbiters",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-polkadot-decoding.ts
+++ b/test/suites/smoke/test-polkadot-decoding.ts
@@ -8,7 +8,7 @@ const pageSize = (process.env.PAGE_SIZE && parseInt(process.env.PAGE_SIZE)) || 5
 
 // TODO: This test case really spams the logs, we should find a way to make it less verbose
 describeSuite({
-  id: "S1500",
+  id: "S16",
   title: "Polkadot API - Storage items",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-proxy-consistency.ts
+++ b/test/suites/smoke/test-proxy-consistency.ts
@@ -7,7 +7,7 @@ import { ApiPromise } from "@polkadot/api";
 import { rateLimiter } from "../../helpers/common.js";
 
 describeSuite({
-  id: "S1600",
+  id: "S17",
   title: "Verify account proxies created",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-randomness-consistency.ts
+++ b/test/suites/smoke/test-randomness-consistency.ts
@@ -10,7 +10,7 @@ import chalk from "chalk";
 const RANDOMNESS_ACCOUNT_ID = "0x6d6f646c6d6f6f6e72616e640000000000000000";
 
 describeSuite({
-  id: "S1700",
+  id: "S18",
   title: "Verify randomness consistency",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-relay-indices.ts
+++ b/test/suites/smoke/test-relay-indices.ts
@@ -7,7 +7,7 @@ import { hexToU8a } from "@polkadot/util";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "S1750",
+  id: "S19",
   title: "Relay chain Module:Method indices should match our encoding",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-relay-xcm-fees.ts
+++ b/test/suites/smoke/test-relay-xcm-fees.ts
@@ -5,7 +5,7 @@ import { extractWeight } from "@moonwall/util";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "S1800",
+  id: "S20",
   title: "Verify XCM weight fees for relay",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-staking-consistency.ts
+++ b/test/suites/smoke/test-staking-consistency.ts
@@ -13,7 +13,7 @@ import { describeSuite, expect, beforeAll } from "@moonwall/cli";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "S1900",
+  id: "S21",
   title: "Verify staking consistency",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-staking-rewards.ts
+++ b/test/suites/smoke/test-staking-rewards.ts
@@ -20,7 +20,7 @@ import { AccountId20 } from "@polkadot/types/interfaces";
 const limiter = rateLimiter();
 
 describeSuite({
-  id: "S2000",
+  id: "S22",
   title: "When verifying ParachainStaking rewards",
   foundationMethods: "read_only",
   testCases: function ({ context, it, log }) {

--- a/test/suites/smoke/test-staking-round-cleanup.ts
+++ b/test/suites/smoke/test-staking-round-cleanup.ts
@@ -45,7 +45,7 @@ async function getKeysBeforeRound<
 }
 
 describeSuite({
-  id: "S2100",
+  id: "S23",
   title: "Verify staking round cleanup",
   foundationMethods: "read_only",
   testCases: function ({ context, it, log }) {

--- a/test/suites/smoke/test-treasury-consistency.ts
+++ b/test/suites/smoke/test-treasury-consistency.ts
@@ -4,7 +4,7 @@ import { describeSuite, expect, beforeAll } from "@moonwall/cli";
 import { ApiPromise } from "@polkadot/api";
 
 describeSuite({
-  id: "S2200",
+  id: "S24",
   title: "Verify treasury consistency",
   foundationMethods: "read_only",
   testCases: ({ context, it, log }) => {

--- a/test/suites/smoke/test-xcm-failures.ts
+++ b/test/suites/smoke/test-xcm-failures.ts
@@ -22,7 +22,7 @@ type BlockEventsRecord = {
 };
 
 describeSuite({
-  id: "S2300",
+  id: "S25",
   title:
     `XCM Failures in past ${(timePeriod / (1000 * 60 * 60)).toFixed(2)} hours` +
     ` should not be serious`,

--- a/test/suites/tracing-tests/test-trace-1.ts
+++ b/test/suites/tracing-tests/test-trace-1.ts
@@ -5,7 +5,7 @@ import { nestedSingle } from "../../helpers";
 import BS_TRACER from "../../helpers/tracer/blockscout_tracer.min.json" assert { type: "json" };
 
 describeSuite({
-  id: "D3601",
+  id: "T01",
   title: "Trace",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-2.ts
+++ b/test/suites/tracing-tests/test-trace-2.ts
@@ -3,7 +3,7 @@ import BS_TRACER_V2 from "../../helpers/tracer/blockscout_tracer_v2.min.json" as
 import { nestedSingle } from "../../helpers";
 
 describeSuite({
-  id: "D3602",
+  id: "T02",
   title: "Trace blockscout v2 - AllEthTxTypes",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-3.ts
+++ b/test/suites/tracing-tests/test-trace-3.ts
@@ -8,7 +8,7 @@ import {
 import BS_TRACER_V2 from "../../helpers/tracer/blockscout_tracer_v2.min.json" assert { type: "json" }; // editorconfig-checker-disable-line
 
 describeSuite({
-  id: "D3603",
+  id: "T03",
   title: "Trace (Blockscout v2) - AllEthTxTypes",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-4.ts
+++ b/test/suites/tracing-tests/test-trace-4.ts
@@ -9,7 +9,7 @@ import {
 import BS_TRACER from "../../helpers/tracer/blockscout_tracer.min.json" assert { type: "json" };
 
 describeSuite({
-  id: "D3604",
+  id: "T04",
   title: "Trace (Blockscout)",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-5.ts
+++ b/test/suites/tracing-tests/test-trace-5.ts
@@ -8,7 +8,7 @@ import { alith } from "@moonwall/util";
 import { createContracts, nestedCall, nestedSingle } from "../../helpers";
 
 describeSuite({
-  id: "D3605",
+  id: "T05",
   title: "Trace (callTrace)",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-6.ts
+++ b/test/suites/tracing-tests/test-trace-6.ts
@@ -10,7 +10,7 @@ import {
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D3606",
+  id: "T06",
   title: "Trace (call list)",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-7.ts
+++ b/test/suites/tracing-tests/test-trace-7.ts
@@ -3,7 +3,7 @@ import { ALITH_PRIVATE_KEY, alith, createEthersTransaction } from "@moonwall/uti
 import { encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D3607",
+  id: "T07",
   title: "Raw trace limits",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-concurrency.ts
+++ b/test/suites/tracing-tests/test-trace-concurrency.ts
@@ -10,7 +10,7 @@ import { createEthersTransaction } from "@moonwall/util";
 import { Abi, encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D3608",
+  id: "T08",
   title: "Trace filter - Concurrency",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-erc20-xcm.ts
+++ b/test/suites/tracing-tests/test-trace-erc20-xcm.ts
@@ -11,7 +11,7 @@ import {
 } from "../../helpers";
 
 describeSuite({
-  id: "D3609",
+  id: "T09",
   title: "Trace ERC20 xcm",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-1.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-1.ts
@@ -8,7 +8,7 @@ import {
 import { hexToNumber, Abi, encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "D3610",
+  id: "T10",
   title: "Trace ethereum xcm #1",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-2.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-2.ts
@@ -9,7 +9,7 @@ import {
 } from "../../helpers";
 
 describeSuite({
-  id: "D3611",
+  id: "T11",
   title: "Trace ethereum xcm #2",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-filter-reorg.ts
+++ b/test/suites/tracing-tests/test-trace-filter-reorg.ts
@@ -3,7 +3,7 @@ import { describeSuite, customDevRpcRequest } from "@moonwall/cli";
 import { createEthersTransaction, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "D3612",
+  id: "T12",
   title: "Trace filter reorg",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-filter.ts
+++ b/test/suites/tracing-tests/test-trace-filter.ts
@@ -2,7 +2,7 @@ import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall
 import { ALITH_ADDRESS, ALITH_CONTRACT_ADDRESSES, alith } from "@moonwall/util";
 
 describeSuite({
-  id: "D3613",
+  id: "T13",
   title: "Trace filter - Contract creation ",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-gas.ts
+++ b/test/suites/tracing-tests/test-trace-gas.ts
@@ -5,7 +5,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { numberToHex } from "@polkadot/util";
 
 describeSuite({
-  id: "D3614",
+  id: "T14",
   title: "Trace filter - Gas Loop",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/zombie/test_para.ts
+++ b/test/suites/zombie/test_para.ts
@@ -6,7 +6,7 @@ import { ethers } from "ethers";
 import fs from "node:fs";
 
 describeSuite({
-  id: "ZAN",
+  id: "Z01",
   title: "Zombie AlphaNet Upgrade Test",
   foundationMethods: "zombie",
   testCases: ({ it, context, log }) => {


### PR DESCRIPTION
### What does it do?
Updates `moonwall` to `4.7.8` that incorporates a prefix renamer and runs it on all of our suites.