### PR TITLE
Set protocolId for live networks

### DIFF
--- a/specs/alphanet/parachain-embedded-specs-v8.json
+++ b/specs/alphanet/parachain-embedded-specs-v8.json
@@ -15,7 +15,7 @@
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]
   ],
-  "protocolId": null,
+  "protocolId": "moonbase-alpha",
   "properties": {
     "tokenDecimals": 18,
     "tokenSymbol": "DEV",

--- a/specs/moonbeam/parachain-embedded-specs.json
+++ b/specs/moonbeam/parachain-embedded-specs.json
@@ -24,7 +24,7 @@
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]
   ],
-  "protocolId": null,
+  "protocolId": "moonbeam",
   "properties": {
     "SS58Prefix": 1284,
     "tokenDecimals": 18,

--- a/specs/moonriver/parachain-embedded-specs.json
+++ b/specs/moonriver/parachain-embedded-specs.json
@@ -19,7 +19,7 @@
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]
   ],
-  "protocolId": null,
+  "protocolId": "moonriver",
   "properties": {
     "tokenDecimals": 18,
     "tokenSymbol": "MOVR",


### PR DESCRIPTION
### What does it do?

Set the protocolId field on the chain spec for live networks (moonbase-alpha, moonriver and moonbeam).

The current implementation of polkadot-sdk create 2 networks protocols that work both in parallel, one based on the genesis hash and another one based on the protocolId name.

The problem is that when the protocolId is not set, polkadot-sdk use the default value "sub", that is used by thousand of nodes on internet, and then we try to join this big worldwide useless network.

The goal of this PR is to reduce log noises and useless connection traffic by setting the protocolId to a different value.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
