### PR TITLE
Fix `vec` import in common migrations

### DIFF
--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -36,7 +36,7 @@ use pallet_parachain_staking::{Round, RoundIndex, RoundInfo};
 use parity_scale_codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
 use sp_core::Get;
-use sp_std::{marker::PhantomData, prelude::*};
+use sp_std::{marker::PhantomData, prelude::*, vec};
 
 #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct OldRoundInfo<BlockNumber> {


### PR DESCRIPTION
### What does it do?

fix a compilation error while building the tracing runtimes:

```
Build moonbase-2800-substitute-tracing…
║ 🧰 Substrate Runtime Toolbox - srtool v0.13.0 🧰
║ - by Chevdor -
info: using existing install for '1.74.0-x86_64-unknown-linux-gnu'
info: override toolchain for '/build' set to '1.74.0-x86_64-unknown-linux-gnu'
║
║ 1.74.0-x86_64-unknown-linux-gnu unchanged - rustc 1.74.0 (79e9716c9 2023-11-13)
...
║ error: cannot find macro `vec` in this scope
║ --> /home/builder/cargo/git/checkouts/moonbeam-43ea08ca2e3f6df3/e2fae82/runtime/common/src/migrations.rs:326:3
║ |
║ 326 | vec![
║ | ^^^
║ |
║ help: consider importing one of these items
║ |
║ 26 + use frame_benchmarking::__private::vec;
║ |
║ 26 + use parity_scale_codec::alloc::vec;
║ |
║ 26 + use sp_api::vec;
║ |
║ 26 + use sp_std::vec;
║ |
║
║ error: could not compile `moonbeam-runtime-common` (lib) due to previous error

```
the errors exists only for moonbase

