### PR TITLE
Bump runtime and client versions and fix CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -6636,7 +6636,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli-opt"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "account",
  "bip32",
@@ -7126,7 +7126,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-service"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "ansi_term",
  "async-backing-primitives",

--- a/node/cli-opt/Cargo.toml
+++ b/node/cli-opt/Cargo.toml
@@ -4,7 +4,7 @@ authors = { workspace = true }
 edition = "2021"
 homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
-version = "0.36.0"
+version = "0.37.0"
 
 [dependencies]
 bip32 = { workspace = true, features = ["bip39"] }

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "moonbeam-cli"
 authors = { workspace = true }
 edition = "2021"
-version = "0.36.0"
+version = "0.37.0"
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -4,7 +4,7 @@ authors = { workspace = true }
 edition = "2021"
 homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
-version = "0.36.0"
+version = "0.37.0"
 
 [dependencies]
 ansi_term = { workspace = true }

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -189,7 +189,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 4,
-	spec_version: 2800,
+	spec_version: 2900,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -183,7 +183,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 2800,
+	spec_version: 2900,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -183,7 +183,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 2800,
+	spec_version: 2900,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/test/configs/alphanet.yml
+++ b/test/configs/alphanet.yml
@@ -9,9 +9,7 @@ import-storage:
         - providers: 1
           data:
             free: "100000000000000000000000"
-  TechCommitteeCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  CouncilCollective:
+  OpenTechCommitteeCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
   TreasuryCouncilCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]

--- a/test/configs/moonbeam.yml
+++ b/test/configs/moonbeam.yml
@@ -9,9 +9,7 @@ import-storage:
         - providers: 1
           data:
             free: "100000000000000000000000"
-  TechCommitteeCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  CouncilCollective:
+  OpenTechCommitteeCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
   TreasuryCouncilCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]

--- a/test/configs/moonriver.yml
+++ b/test/configs/moonriver.yml
@@ -9,9 +9,7 @@ import-storage:
         - providers: 1
           data:
             free: "100000000000000000000000"
-  TechCommitteeCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  CouncilCollective:
+  OpenTechCommitteeCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
   TreasuryCouncilCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -75,6 +75,8 @@
     {
       "name": "zombie_moonbase",
       "testFileDir": ["suites/zombie"],
+      "multiThreads": false,
+      "runScripts": ["download-polkadot.sh"],
       "foundation": {
         "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
         "type": "zombie",
@@ -86,6 +88,7 @@
     {
       "name": "zombie_moonbase_rpc",
       "testFileDir": ["suites/zombie"],
+      "runScripts": ["download-polkadot.sh"],
       "foundation": {
         "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
         "type": "zombie",

--- a/test/scripts/modify-plain-specs.ts
+++ b/test/scripts/modify-plain-specs.ts
@@ -41,7 +41,6 @@ yargs(hideBin(process.argv))
       plainSpec.genesis.runtime.authorMapping.mappings = [
         ["5HEL3iLyDyaqmfibHXAXVzyQq4fBqLCHGMEYxZXgRAuhEKXX", ALITH_ADDRESS],
       ];
-      plainSpec.genesis.runtime.councilCollective.members = [ALITH_ADDRESS];
       plainSpec.genesis.runtime.techCommitteeCollective.members = [ALITH_ADDRESS];
 
       process.stdout.write(`Writing to: ${argv.outputPath} ...`);

--- a/test/scripts/modify-plain-specs.ts
+++ b/test/scripts/modify-plain-specs.ts
@@ -41,7 +41,7 @@ yargs(hideBin(process.argv))
       plainSpec.genesis.runtime.authorMapping.mappings = [
         ["5HEL3iLyDyaqmfibHXAXVzyQq4fBqLCHGMEYxZXgRAuhEKXX", ALITH_ADDRESS],
       ];
-      plainSpec.genesis.runtime.techCommitteeCollective.members = [ALITH_ADDRESS];
+      plainSpec.genesis.runtime.openTechCommitteeCollective.members = [ALITH_ADDRESS];
 
       process.stdout.write(`Writing to: ${argv.outputPath} ...`);
       await fs.writeFile(

--- a/test/suites/zombie/test_para.ts
+++ b/test/suites/zombie/test_para.ts
@@ -63,7 +63,7 @@ describeSuite({
 
         await paraApi.tx.parachainSystem.enactAuthorizedUpgrade(rtHex).signAndSend(alith);
 
-        await context.waitBlock(10);
+        await context.waitBlock(15);
 
         const rtafter = paraApi.consts.system.version.specVersion.toNumber();
         expect(rtafter).to.be.greaterThan(rtBefore);

--- a/test/suites/zombie/test_para.ts
+++ b/test/suites/zombie/test_para.ts
@@ -65,10 +65,6 @@ describeSuite({
 
         await context.waitBlock(10);
 
-        const rtafter = paraApi.consts.system.version.specVersion.toNumber();
-        expect(rtafter).to.be.greaterThan(rtBefore);
-
-        log(`RT upgrade has increased specVersion from ${rtBefore} to ${rtafter}`);
 
         const blockNumberAfter = (
           await paraApi.rpc.chain.getBlock()
@@ -77,6 +73,11 @@ describeSuite({
         expect(blockNumberAfter, "Block number did not increase").to.be.greaterThan(
           blockNumberBefore
         );
+
+        const rtafter = paraApi.consts.system.version.specVersion.toNumber();
+        expect(rtafter).to.be.greaterThan(rtBefore);
+
+        log(`RT upgrade has increased specVersion from ${rtBefore} to ${rtafter}`);
       },
     });
 

--- a/test/suites/zombie/test_para.ts
+++ b/test/suites/zombie/test_para.ts
@@ -65,6 +65,10 @@ describeSuite({
 
         await context.waitBlock(10);
 
+        const rtafter = paraApi.consts.system.version.specVersion.toNumber();
+        expect(rtafter).to.be.greaterThan(rtBefore);
+
+        log(`RT upgrade has increased specVersion from ${rtBefore} to ${rtafter}`);
 
         const blockNumberAfter = (
           await paraApi.rpc.chain.getBlock()
@@ -73,11 +77,6 @@ describeSuite({
         expect(blockNumberAfter, "Block number did not increase").to.be.greaterThan(
           blockNumberBefore
         );
-
-        const rtafter = paraApi.consts.system.version.specVersion.toNumber();
-        expect(rtafter).to.be.greaterThan(rtBefore);
-
-        log(`RT upgrade has increased specVersion from ${rtBefore} to ${rtafter}`);
       },
     });
 


### PR DESCRIPTION
### What does it do?

- Bumps runtime version to 2900
- Bumps client version to 0.37.0
- Fixes the CI pipeline by removing `councilCollective` from script.