### PR TITLE
Fix feature = "cargo-clippy" deprecation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,7 +14,7 @@ moonbeam-rococo = " build --release -p moonbeam --no-default-features --features
 #
 # If you want standard clippy run:
 # RUSTFLAGS= cargo clippy
-[target.'cfg(feature = "cargo-clippy")']
+[target.'cfg(clippy)']
 rustflags = [
   "-Aclippy::all",
   "-Dclippy::correctness",


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html