### PR TITLE
Disable 'clear_local_assets_storage' extrinsic for runtime 2801

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1205,6 +1205,10 @@ impl Contains<RuntimeCall> for NormalFilter {
 				| pallet_treasury::Call::check_status { .. }
 				| pallet_treasury::Call::void_spend { .. },
 			) => false,
+			// TODO(RT29000): Remove this filter for runtime upgrade 2900
+			RuntimeCall::MoonbeamLazyMigrations(
+				pallet_moonbeam_lazy_migrations::Call::clear_local_assets_storage { .. },
+			) => false,
 			_ => true,
 		}
 	}

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1185,6 +1185,10 @@ impl Contains<RuntimeCall> for NormalFilter {
 				| pallet_treasury::Call::check_status { .. }
 				| pallet_treasury::Call::void_spend { .. },
 			) => false,
+			// TODO(RT29000): Remove this filter for runtime upgrade 2900
+			RuntimeCall::MoonbeamLazyMigrations(
+				pallet_moonbeam_lazy_migrations::Call::clear_local_assets_storage { .. },
+			) => false,
 			_ => true,
 		}
 	}

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1187,6 +1187,10 @@ impl Contains<RuntimeCall> for NormalFilter {
 				| pallet_treasury::Call::check_status { .. }
 				| pallet_treasury::Call::void_spend { .. },
 			) => false,
+			// TODO(RT29000): Remove this filter for runtime upgrade 2900
+			RuntimeCall::MoonbeamLazyMigrations(
+				pallet_moonbeam_lazy_migrations::Call::clear_local_assets_storage { .. },
+			) => false,
 			_ => true,
 		}
 	}

--- a/test/suites/dev/moonbase/test-pov/test-lazy-migrations-storage-removal.ts
+++ b/test/suites/dev/moonbase/test-pov/test-lazy-migrations-storage-removal.ts
@@ -21,6 +21,8 @@ describeSuite({
       id: "T01",
       title: "Validate storage removal uses a reasonable proof size",
       test: async function () {
+        // TODO(RT2900) : re-enable test for runtime 2900
+        return;
         const total_entries = 9000;
         // sp_io::hashing::twox_128("LocalAssets".as_bytes());
         const pallet_name_hash = "0xbebaa96ee6c1d0e946832368c6396271";


### PR DESCRIPTION
### What does it do?

Any call to `clear_local_assets_storage` is now rejected.

For RT2900, `clear_local_assets_storage` extrinsic will be updated to also destroys any pending approvals and un-reserve any reserved balance from pallet LocalAssets.
