### PR TITLE
Fix tracing for multiple xcm transactions in the same block

### DIFF
--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -96,7 +96,7 @@ macro_rules! impl_moonbeam_xcm_call_tracing {
 										}
 										dispatch_call()
 									},
-									EthereumXcmTracingStatus::TransactionExited => Ok(PostDispatchInfo {
+									EthereumXcmTracingStatus::TransactionExited => Ok(crate::PostDispatchInfo {
 		actual_weight: None,
 		pays_fee: frame_support::pallet_prelude::Pays::No,
 		}),

--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -96,7 +96,10 @@ macro_rules! impl_moonbeam_xcm_call_tracing {
 										}
 										dispatch_call()
 									},
-									EthereumXcmTracingStatus::TransactionExited => Ok(()),
+									EthereumXcmTracingStatus::TransactionExited => Ok(PostDispatchInfo {
+		actual_weight: None,
+		pays_fee: Pays::No,
+		}),
 								},
 								// This runtime instance is importing a block.
 								None => dispatch_call()

--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -96,7 +96,7 @@ macro_rules! impl_moonbeam_xcm_call_tracing {
 										}
 										dispatch_call()
 									},
-									_ => unreachable!()
+									EthereumXcmTracingStatus::TransactionExited => Ok(()),
 								},
 								// This runtime instance is importing a block.
 								None => dispatch_call()

--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -62,7 +62,7 @@ macro_rules! impl_moonbeam_xcm_call_tracing {
 								ETHEREUM_XCM_TRACING_STORAGE_KEY
 							) {
 								// This runtime instance is used for tracing.
-								Some(transaction) => match transaction {
+								Some(tracing_status) => match tracing_status {
 									// Tracing a block, all calls are done using environmental.
 									EthereumXcmTracingStatus::Block => {
 										// Each known extrinsic is a new call stack.
@@ -96,10 +96,13 @@ macro_rules! impl_moonbeam_xcm_call_tracing {
 										}
 										dispatch_call()
 									},
+									// Tracing a transaction that has already been found and
+									// executed. There's no need to dispatch the rest of the
+									// calls.
 									EthereumXcmTracingStatus::TransactionExited => Ok(crate::PostDispatchInfo {
-		actual_weight: None,
-		pays_fee: frame_support::pallet_prelude::Pays::No,
-		}),
+										actual_weight: None,
+										pays_fee: frame_support::pallet_prelude::Pays::No,
+									}),
 								},
 								// This runtime instance is importing a block.
 								None => dispatch_call()

--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -98,7 +98,7 @@ macro_rules! impl_moonbeam_xcm_call_tracing {
 									},
 									EthereumXcmTracingStatus::TransactionExited => Ok(PostDispatchInfo {
 		actual_weight: None,
-		pays_fee: Pays::No,
+		pays_fee: frame_support::pallet_prelude::Pays::No,
 		}),
 								},
 								// This runtime instance is importing a block.

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
@@ -8,8 +8,8 @@ import {
 import { hexToNumber, Abi, encodeFunctionData } from "viem";
 
 describeSuite({
-  id: "T10",
-  title: "Trace ethereum xcm #2: Multiple xcms in a block",
+  id: "T12",
+  title: "Trace ethereum xcm #3: Multiple xcms in a block",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {
     let incremetorAddress: `0x${string}`;

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
@@ -84,9 +84,7 @@ describeSuite({
             },
           ],
           weight_limit: {
-            //refTime: 4000000000n,
             refTime: 4000000000n,
-            //proofSize: 80000n,
             proofSize: 60000n,
           } as any,
           descend_origin: sendingAddress,
@@ -98,9 +96,7 @@ describeSuite({
             Transact: {
               originKind: "SovereignAccount",
               requireWeightAtMost: {
-                //refTime: 3000000000n,
                 refTime: 3000000000n,
-                //proofSize: 50000n,
                 proofSize: 30000n,
               },
               call: {

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
@@ -115,6 +115,7 @@ describeSuite({
       await context.createBlock();
 
       const txHashes = (await context.viem().getBlock({ blockTag: "latest" })).transactions;
+      expect(txHashes.length).toBe(2);
       transactionHashes.push(...txHashes);
     });
 

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
@@ -1,7 +1,6 @@
 import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 import {
   XcmFragment,
-  injectHrmpMessageAndSeal,
   injectHrmpMessage,
   descendOriginFromAddress20,
   RawXcmMessage,
@@ -22,11 +21,12 @@ describeSuite({
       incremetorAddress = contractAddress;
       incremetorABI = abi;
 
-      const { originAddress: originAddress1, descendOriginAddress: descendOriginAddress1 } = descendOriginFromAddress20(context);
+      const { originAddress: originAddress1, descendOriginAddress: descendOriginAddress1 } =
+        descendOriginFromAddress20(context);
       const sendingAddress1 = originAddress1;
-      const { originAddress: originAddress2, descendOriginAddress: descendOriginAddress2 } = descendOriginFromAddress20(
-        context, "0x0101010101010101010101010101010101010101", 2);
-      const sendingAddress2 = originAddress1;
+      const { originAddress: originAddress2, descendOriginAddress: descendOriginAddress2 } =
+        descendOriginFromAddress20(context, "0x0101010101010101010101010101010101010101", 2);
+      const sendingAddress2 = originAddress2;
       const transferredBalance = 10_000_000_000_000_000_000n;
 
       // We first fund parachain 2000 sovreign account
@@ -49,28 +49,29 @@ describeSuite({
         .find(({ name }) => name.toString() == "Balances")!
         .index.toNumber();
 
-      const xcmTransactions = [
-        {
-          V2: {
-            gas_limit: 100000,
-            action: {
-              Call: incremetorAddress,
-            },
-            value: 0n,
-            input: encodeFunctionData({
-              abi: incremetorABI,
-              functionName: "incr",
-              args: [],
-            }),
-            access_list: null,
+      const xcmTransaction = {
+        V2: {
+          gas_limit: 100000,
+          action: {
+            Call: incremetorAddress,
           },
+          value: 0n,
+          input: encodeFunctionData({
+            abi: incremetorABI,
+            functionName: "incr",
+            args: [],
+          }),
+          access_list: null,
         },
-      ];
+      };
 
-      for (const xcmTransaction of xcmTransactions) {
-        const transferCall = context.polkadotJs().tx.ethereumXcm.transact(xcmTransaction);
-        const transferCallEncoded = transferCall?.method.toHex();
-        const xcmMessage1 = new XcmFragment({
+      const transferCall = context.polkadotJs().tx.ethereumXcm.transact(xcmTransaction);
+      const transferCallEncoded = transferCall?.method.toHex();
+      for (const [paraId, sendingAddress] of [
+        [1, sendingAddress1],
+        [2, sendingAddress2],
+      ]) {
+        const xcmMessage = new XcmFragment({
           assets: [
             {
               multilocation: {
@@ -79,7 +80,7 @@ describeSuite({
                   X1: { PalletInstance: balancesPalletIndex },
                 },
               },
-              fungible: transferredBalance / 2n,
+              fungible: transferredBalance,
             },
           ],
           weight_limit: {
@@ -88,45 +89,7 @@ describeSuite({
             //proofSize: 80000n,
             proofSize: 60000n,
           } as any,
-          descend_origin: sendingAddress1,
-        })
-          .descend_origin()
-          .withdraw_asset()
-          .buy_execution()
-          .push_any({
-            Transact: {
-              originKind: "SovereignAccount",
-              requireWeightAtMost: {
-                //refTime: 3000000000n,
-                refTime: 3000000000n,
-                //proofSize: 50000n,
-                proofSize: 30000n,
-              },
-              call: {
-                encoded: transferCallEncoded,
-              },
-            },
-          })
-          .as_v3();
-        const xcmMessage2 = new XcmFragment({
-          assets: [
-            {
-              multilocation: {
-                parents: 0,
-                interior: {
-                  X1: { PalletInstance: balancesPalletIndex },
-                },
-              },
-              fungible: transferredBalance / 2n,
-            },
-          ],
-          weight_limit: {
-            //refTime: 4000000000n,
-            refTime: 4000000000n,
-            //proofSize: 80000n,
-            proofSize: 60000n,
-          } as any,
-          descend_origin: sendingAddress2,
+          descend_origin: sendingAddress,
         })
           .descend_origin()
           .withdraw_asset()
@@ -148,31 +111,15 @@ describeSuite({
           .as_v3();
 
         // Send an XCM and create block to execute it
-        await injectHrmpMessage(context, 1, {
+        await injectHrmpMessage(context, paraId, {
           type: "XcmVersionedXcm",
-          payload: xcmMessage1,
+          payload: xcmMessage,
         } as RawXcmMessage);
-        await injectHrmpMessage(context, 2, {
-          type: "XcmVersionedXcm",
-          payload: xcmMessage2,
-        } as RawXcmMessage);
-        await context.createBlock();
-
-        const allRecords = await context.polkadotJs().query.system.events();
-        allRecords.forEach(({event}) => {
-          console.log(`${event.section}.${event.method}`);
-          if (context.polkadotJs().events.xcmpQueue.Fail.is(event)) {
-            
-            console.log("reason: ", event.data[2].toHuman());
-
-          }
-        })
-
-        // Retrieve the stored ethereum transaction hash
-
-        const txHashes = (await context.viem().getBlock({ blockTag: "latest" })).transactions;
-        transactionHashes.push(...txHashes);
       }
+      await context.createBlock();
+
+      const txHashes = (await context.viem().getBlock({ blockTag: "latest" })).transactions;
+      transactionHashes.push(...txHashes);
     });
 
     it({

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
@@ -29,7 +29,7 @@ describeSuite({
       const sendingAddress2 = originAddress2;
       const transferredBalance = 10_000_000_000_000_000_000n;
 
-      // We first fund parachain 2000 sovreign account
+      // We first fund parachain sovreign accounts
       await context.createBlock(
         context
           .polkadotJs()

--- a/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
+++ b/test/suites/tracing-tests/test-trace-ethereum-xcm-3.ts
@@ -1,0 +1,195 @@
+import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
+import {
+  XcmFragment,
+  injectHrmpMessageAndSeal,
+  injectHrmpMessage,
+  descendOriginFromAddress20,
+  RawXcmMessage,
+} from "../../helpers";
+import { hexToNumber, Abi, encodeFunctionData } from "viem";
+
+describeSuite({
+  id: "T10",
+  title: "Trace ethereum xcm #2: Multiple xcms in a block",
+  foundationMethods: "dev",
+  testCases: ({ context, it }) => {
+    let incremetorAddress: `0x${string}`;
+    let incremetorABI: Abi;
+    const transactionHashes: `0x${string}`[] = [];
+
+    beforeAll(async () => {
+      const { contractAddress, abi } = await context.deployContract!("Incrementor");
+      incremetorAddress = contractAddress;
+      incremetorABI = abi;
+
+      const { originAddress: originAddress1, descendOriginAddress: descendOriginAddress1 } = descendOriginFromAddress20(context);
+      const sendingAddress1 = originAddress1;
+      const { originAddress: originAddress2, descendOriginAddress: descendOriginAddress2 } = descendOriginFromAddress20(
+        context, "0x0101010101010101010101010101010101010101", 2);
+      const sendingAddress2 = originAddress1;
+      const transferredBalance = 10_000_000_000_000_000_000n;
+
+      // We first fund parachain 2000 sovreign account
+      await context.createBlock(
+        context
+          .polkadotJs()
+          .tx.balances.transferAllowDeath(descendOriginAddress1, transferredBalance),
+        { allowFailures: false }
+      );
+      await context.createBlock(
+        context
+          .polkadotJs()
+          .tx.balances.transferAllowDeath(descendOriginAddress2, transferredBalance),
+        { allowFailures: false }
+      );
+
+      // Get Pallet balances index
+      const metadata = await context.polkadotJs().rpc.state.getMetadata();
+      const balancesPalletIndex = metadata.asLatest.pallets
+        .find(({ name }) => name.toString() == "Balances")!
+        .index.toNumber();
+
+      const xcmTransactions = [
+        {
+          V2: {
+            gas_limit: 100000,
+            action: {
+              Call: incremetorAddress,
+            },
+            value: 0n,
+            input: encodeFunctionData({
+              abi: incremetorABI,
+              functionName: "incr",
+              args: [],
+            }),
+            access_list: null,
+          },
+        },
+      ];
+
+      for (const xcmTransaction of xcmTransactions) {
+        const transferCall = context.polkadotJs().tx.ethereumXcm.transact(xcmTransaction);
+        const transferCallEncoded = transferCall?.method.toHex();
+        const xcmMessage1 = new XcmFragment({
+          assets: [
+            {
+              multilocation: {
+                parents: 0,
+                interior: {
+                  X1: { PalletInstance: balancesPalletIndex },
+                },
+              },
+              fungible: transferredBalance / 2n,
+            },
+          ],
+          weight_limit: {
+            //refTime: 4000000000n,
+            refTime: 4000000000n,
+            //proofSize: 80000n,
+            proofSize: 60000n,
+          } as any,
+          descend_origin: sendingAddress1,
+        })
+          .descend_origin()
+          .withdraw_asset()
+          .buy_execution()
+          .push_any({
+            Transact: {
+              originKind: "SovereignAccount",
+              requireWeightAtMost: {
+                //refTime: 3000000000n,
+                refTime: 3000000000n,
+                //proofSize: 50000n,
+                proofSize: 30000n,
+              },
+              call: {
+                encoded: transferCallEncoded,
+              },
+            },
+          })
+          .as_v3();
+        const xcmMessage2 = new XcmFragment({
+          assets: [
+            {
+              multilocation: {
+                parents: 0,
+                interior: {
+                  X1: { PalletInstance: balancesPalletIndex },
+                },
+              },
+              fungible: transferredBalance / 2n,
+            },
+          ],
+          weight_limit: {
+            //refTime: 4000000000n,
+            refTime: 4000000000n,
+            //proofSize: 80000n,
+            proofSize: 60000n,
+          } as any,
+          descend_origin: sendingAddress2,
+        })
+          .descend_origin()
+          .withdraw_asset()
+          .buy_execution()
+          .push_any({
+            Transact: {
+              originKind: "SovereignAccount",
+              requireWeightAtMost: {
+                //refTime: 3000000000n,
+                refTime: 3000000000n,
+                //proofSize: 50000n,
+                proofSize: 30000n,
+              },
+              call: {
+                encoded: transferCallEncoded,
+              },
+            },
+          })
+          .as_v3();
+
+        // Send an XCM and create block to execute it
+        await injectHrmpMessage(context, 1, {
+          type: "XcmVersionedXcm",
+          payload: xcmMessage1,
+        } as RawXcmMessage);
+        await injectHrmpMessage(context, 2, {
+          type: "XcmVersionedXcm",
+          payload: xcmMessage2,
+        } as RawXcmMessage);
+        await context.createBlock();
+
+        const allRecords = await context.polkadotJs().query.system.events();
+        allRecords.forEach(({event}) => {
+          console.log(`${event.section}.${event.method}`);
+          if (context.polkadotJs().events.xcmpQueue.Fail.is(event)) {
+            
+            console.log("reason: ", event.data[2].toHuman());
+
+          }
+        })
+
+        // Retrieve the stored ethereum transaction hash
+
+        const txHashes = (await context.viem().getBlock({ blockTag: "latest" })).transactions;
+        transactionHashes.push(...txHashes);
+      }
+    });
+
+    it({
+      id: "T01",
+      title: "should trace ethereum xcm transactions with debug_traceTransaction",
+      test: async function () {
+        for (const hash of transactionHashes) {
+          const receipt = await context.viem().getTransactionReceipt({ hash });
+          const trace = await customDevRpcRequest("debug_traceTransaction", [
+            hash,
+            { tracer: "callTracer" },
+          ]);
+          // We traced the transaction, and the traced gas used matches the one recorded
+          // in the ethereum transaction receipt.
+          expect(hexToNumber(trace.gasUsed)).to.eq(Number(receipt.gasUsed));
+        }
+      },
+    });
+  },
+});

--- a/test/suites/tracing-tests/test-trace-filter-reorg.ts
+++ b/test/suites/tracing-tests/test-trace-filter-reorg.ts
@@ -3,7 +3,7 @@ import { describeSuite, customDevRpcRequest } from "@moonwall/cli";
 import { createEthersTransaction, generateKeyringPair } from "@moonwall/util";
 
 describeSuite({
-  id: "T12",
+  id: "T13",
   title: "Trace filter reorg",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-filter.ts
+++ b/test/suites/tracing-tests/test-trace-filter.ts
@@ -2,7 +2,7 @@ import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall
 import { ALITH_ADDRESS, ALITH_CONTRACT_ADDRESSES, alith } from "@moonwall/util";
 
 describeSuite({
-  id: "T13",
+  id: "T14",
   title: "Trace filter - Contract creation ",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {

--- a/test/suites/tracing-tests/test-trace-gas.ts
+++ b/test/suites/tracing-tests/test-trace-gas.ts
@@ -5,7 +5,7 @@ import { Abi, encodeFunctionData } from "viem";
 import { numberToHex } from "@polkadot/util";
 
 describeSuite({
-  id: "T14",
+  id: "T15",
   title: "Trace filter - Gas Loop",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {


### PR DESCRIPTION
### What does it do?
When multiple eth transactions were submitted on the same block via xcm, the tracing panicked when querying the tracing of a transaction that was not the last one of the xcm ethereum calls. This was due to an unexpected value for the tracing status stored for the xcm `CallDispatcher`.  Whenever the transaction the request wants to trace is found, it sets the tracing status to `EthereumXcmTracingStatus::TransactionExited` so that no more transactions are processed and it does not expect to process any more transactions afterwards (it was panicking if a msg was being dispatched and that flag was set). The approach works well on the normal extrinsics loop because it will stop applying extrinsics when it sees that flag, but xcms are all processed on the same extrinsic (`set_validation_data` as of polkadot v1.3.0) and execution won't halt until the last xcm message is executed. If the target tx was not the last one, the flag would be set and the next ethereum call would get the flag and panic.

The fix replaces a panic with a noop returning a `PostDispatchInfo` as we don't really care about the execution of ethereum transactions after the one requested by the user.

### Is there something left for follow-up PRs?
Maybe add a test involving dmp queues as they seem to not be executed during `set_validation_data` anymore (see [polkadot v1.4.0 changes](https://forum.polkadot.network/t/polkadot-release-analysis-v1-4-0/5152#high-impact-5))