### PR TITLE
Set async backing velocity to 1

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -703,7 +703,7 @@ parameter_types! {
 const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the
 /// number of blocks authored per slot.
-const BLOCK_PROCESSING_VELOCITY: u32 = 2;
+const BLOCK_PROCESSING_VELOCITY: u32 = 1;
 
 type ConsensusHook = pallet_async_backing::consensus_hook::FixedVelocityConsensusHook<
 	Runtime,


### PR DESCRIPTION
### What does it do?

Set async backing velocity to 1.
For historical reasons, we had set the velocity to 2 because that's what was recommended by parity at the time we developed async backing, and there was no live network with async backing activated at the time.
Now that several live networks (including Asset Hubs) have async backing activated with a velocity of 1, we know that we can reduce this value to 1.

What's more, velocity 2 poses staking reward distribution problems for collators, as each collator can produce two blocks in a row, preventing the next collator from producing its block.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

Fair rewards distribution for collators.
