### PR TITLE
evm-tracing should replay on_idle

### DIFF
--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -17,6 +17,31 @@
 #[macro_export]
 macro_rules! impl_runtime_apis_plus_common {
 	{$($custom:tt)*} => {
+
+		#[cfg(feature = "evm-tracing")]
+		// Helper function to replay the "on_idle" hook for all pallets, we need this for
+		// evm-tracing because some ethereum-xcm transactions might be executed at on_idle.
+		//
+		// We need to make sure that we replay on_idle exactly the same way as the
+		// original block execution, but unfortunatly frame executive diosn't provide a function
+		// to replay only on_idle, so we need to copy here some code inside frame executive.
+		fn replay_on_idle() {
+			use frame_system::pallet_prelude::BlockNumberFor;
+
+			let weight = <frame_system::Pallet<Runtime>>::block_weight();
+			let max_weight = <
+					<Runtime as frame_system::Config>::BlockWeights as
+					frame_support::traits::Get<_>
+				>::get().max_block;
+			let remaining_weight = max_weight.saturating_sub(weight.total());
+			if remaining_weight.all_gt(Weight::zero()) {
+				let _ = <AllPalletsWithSystem as OnIdle<BlockNumberFor<Runtime>>>::on_idle(
+					<frame_system::Pallet<Runtime>>::block_number(),
+					remaining_weight,
+				);
+			}
+		}
+
 		impl_runtime_apis! {
 			$($custom)*
 
@@ -145,15 +170,7 @@ macro_rules! impl_runtime_apis_plus_common {
 						) {
 							// If the transaction was not found, it might be
 							// an eth-xcm transaction that was executed at on_idle
-							let weight = <frame_system::Pallet<Runtime>>::block_weight();
-							let max_weight = <<Runtime as frame_system::Config>::BlockWeights as frame_support::traits::Get<_>>::get().max_block;
-							let remaining_weight = max_weight.saturating_sub(weight.total());
-							if remaining_weight.all_gt(Weight::zero()) {
-								let used_weight = <AllPalletsWithSystem as OnIdle<BlockNumberFor<Runtime>>>::on_idle(
-									<frame_system::Pallet<Runtime>>::block_number(),
-									remaining_weight,
-								);
-							}
+							replay_on_idle();
 						}
 
 						if let Some(EthereumXcmTracingStatus::TransactionExited) = unhashed::get(
@@ -216,15 +233,7 @@ macro_rules! impl_runtime_apis_plus_common {
 
 						// Replay on_idle
 						// Some XCM messages with eth-xcm transaction might be executed at on_idle
-						let weight = <frame_system::Pallet<Runtime>>::block_weight();
-						let max_weight = <<Runtime as frame_system::Config>::BlockWeights as frame_support::traits::Get<_>>::get().max_block;
-						let remaining_weight = max_weight.saturating_sub(weight.total());
-						if remaining_weight.all_gt(Weight::zero()) {
-							let used_weight = <AllPalletsWithSystem as OnIdle<BlockNumberFor<Runtime>>>::on_idle(
-								<frame_system::Pallet<Runtime>>::block_number(),
-								remaining_weight,
-							);
-						}
+						replay_on_idle();
 
 						Ok(())
 					}

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -138,6 +138,12 @@ macro_rules! impl_runtime_apis_plus_common {
 								return Ok(());
 							}
 						}
+
+						// Replay on_idle
+						// Somme XCM messages with eth-xcm transaction might be executed at on_idle
+						Executive::on_idle();
+
+						// The transaction was not-found
 						Err(sp_runtime::DispatchError::Other(
 							"Failed to find Ethereum transaction among the extrinsics.",
 						))
@@ -186,6 +192,10 @@ macro_rules! impl_runtime_apis_plus_common {
 								}
 							};
 						}
+
+						// Replay on_idle
+						// Somme XCM messages with eth-xcm transaction might be executed at on_idle
+						Executive::on_idle();
 
 						Ok(())
 					}

--- a/runtime/moonbase/tests/evm_tracing.rs
+++ b/runtime/moonbase/tests/evm_tracing.rs
@@ -84,6 +84,10 @@ mod tests {
 				let eth_uxt = unchecked_eth_tx(VALID_ETH_TX);
 				let eth_tx = ethereum_transaction(VALID_ETH_TX);
 				let eth_extrinsic_hash = eth_tx.hash();
+
+				// trace block finalize the block, so we need to set the timestamp to avoid panic
+				pallet_timestamp::Call::<Runtime>::set(6_000);
+
 				assert!(Runtime::trace_block(
 					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
 					vec![eth_extrinsic_hash, eth_extrinsic_hash]

--- a/runtime/moonbase/tests/evm_tracing.rs
+++ b/runtime/moonbase/tests/evm_tracing.rs
@@ -85,9 +85,6 @@ mod tests {
 				let eth_tx = ethereum_transaction(VALID_ETH_TX);
 				let eth_extrinsic_hash = eth_tx.hash();
 
-				// trace block finalize the block, so we need to set the timestamp to avoid panic
-				pallet_timestamp::Call::<Runtime>::set(6_000);
-
 				assert!(Runtime::trace_block(
 					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
 					vec![eth_extrinsic_hash, eth_extrinsic_hash]

--- a/runtime/moonbeam/tests/evm_tracing.rs
+++ b/runtime/moonbeam/tests/evm_tracing.rs
@@ -84,6 +84,10 @@ mod tests {
 				let eth_uxt = unchecked_eth_tx(VALID_ETH_TX);
 				let eth_tx = ethereum_transaction(VALID_ETH_TX);
 				let eth_extrinsic_hash = eth_tx.hash();
+
+				// trace block finalize the block, so we need to set the timestamp to avoid panic
+				pallet_timestamp::Call::<Runtime>::set(6_000);
+
 				assert!(Runtime::trace_block(
 					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
 					vec![eth_extrinsic_hash, eth_extrinsic_hash]

--- a/runtime/moonbeam/tests/evm_tracing.rs
+++ b/runtime/moonbeam/tests/evm_tracing.rs
@@ -85,9 +85,6 @@ mod tests {
 				let eth_tx = ethereum_transaction(VALID_ETH_TX);
 				let eth_extrinsic_hash = eth_tx.hash();
 
-				// trace block finalize the block, so we need to set the timestamp to avoid panic
-				pallet_timestamp::Call::<Runtime>::set(6_000);
-
 				assert!(Runtime::trace_block(
 					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
 					vec![eth_extrinsic_hash, eth_extrinsic_hash]

--- a/runtime/moonriver/tests/evm_tracing.rs
+++ b/runtime/moonriver/tests/evm_tracing.rs
@@ -84,6 +84,10 @@ mod tests {
 				let eth_uxt = unchecked_eth_tx(VALID_ETH_TX);
 				let eth_tx = ethereum_transaction(VALID_ETH_TX);
 				let eth_extrinsic_hash = eth_tx.hash();
+
+				// trace block finalize the block, so we need to set the timestamp to avoid panic
+				pallet_timestamp::Call::<Runtime>::set(6_000);
+
 				assert!(Runtime::trace_block(
 					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
 					vec![eth_extrinsic_hash, eth_extrinsic_hash]

--- a/runtime/moonriver/tests/evm_tracing.rs
+++ b/runtime/moonriver/tests/evm_tracing.rs
@@ -85,9 +85,6 @@ mod tests {
 				let eth_tx = ethereum_transaction(VALID_ETH_TX);
 				let eth_extrinsic_hash = eth_tx.hash();
 
-				// trace block finalize the block, so we need to set the timestamp to avoid panic
-				pallet_timestamp::Call::<Runtime>::set(6_000);
-
 				assert!(Runtime::trace_block(
 					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
 					vec![eth_extrinsic_hash, eth_extrinsic_hash]


### PR DESCRIPTION
### What does it do?

If incoming XCM messages consume more than 25% of the block, the extra xcm messages are deferred to on_idle to make room for user transactions.

If some of these sdefered xcm messages contains ethereum-xcm transactions, they are not traceable because vm-tracing does not replay on_idle.

Fix #2626 

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
