### PR TITLE
local assets removal: Remove all asset approvals before clearing the pallet storage

### DIFF
--- a/pallets/moonbeam-lazy-migrations/Cargo.toml
+++ b/pallets/moonbeam-lazy-migrations/Cargo.toml
@@ -12,6 +12,8 @@ log = {workspace = true}
 frame-support = {workspace = true}
 frame-system = {workspace = true}
 pallet-scheduler = {workspace = true}
+pallet-assets = {workspace = true}
+pallet-balances = {workspace = true}
 parity-scale-codec = {workspace = true}
 scale-info = {workspace = true, features = ["derive"]}
 sp-core = {workspace = true}

--- a/pallets/moonbeam-lazy-migrations/src/lib.rs
+++ b/pallets/moonbeam-lazy-migrations/src/lib.rs
@@ -37,6 +37,7 @@ pub use pallet::*;
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
+	use frame_support::traits::ReservableCurrency;
 	use frame_system::pallet_prelude::*;
 	use sp_core::H160;
 
@@ -61,7 +62,7 @@ pub mod pallet {
 
 	/// Configuration trait of this pallet.
 	#[pallet::config]
-	pub trait Config: frame_system::Config + pallet_evm::Config {
+	pub trait Config: frame_system::Config + pallet_evm::Config + pallet_balances::Config {
 		type WeightInfo: WeightInfo;
 	}
 
@@ -103,33 +104,93 @@ pub mod pallet {
 				Error::<T>::AllStorageEntriesHaveBeenRemoved
 			);
 
-			let hashed_prefix = sp_io::hashing::twox_128("LocalAssets".as_bytes());
+			let mut allowed_removals = limit;
 
-			let keys_removed = match sp_io::storage::clear_prefix(&hashed_prefix, Some(limit)) {
-				sp_io::KillStorageResult::AllRemoved(value) => {
-					LocalAssetsMigrationCompleted::<T>::set(true);
-					weight
-						.saturating_accrue(<T as frame_system::Config>::DbWeight::get().writes(1));
-					value
+			const PALLET_PREFIX: &'static str = "LocalAssets";
+
+			struct LocalAssetsStorageAsset;
+			impl frame_support::traits::StorageInstance for LocalAssetsStorageAsset {
+				const STORAGE_PREFIX: &'static str = "Asset";
+				fn pallet_prefix() -> &'static str {
+					PALLET_PREFIX
 				}
-				sp_io::KillStorageResult::SomeRemaining(value) => value,
-			} as u64;
+			}
+			struct LocalAssetsStorageApprovals;
+			impl frame_support::traits::StorageInstance for LocalAssetsStorageApprovals {
+				const STORAGE_PREFIX: &'static str = "Approvals";
+				fn pallet_prefix() -> &'static str {
+					PALLET_PREFIX
+				}
+			}
 
-			log::info!("Removed {} keys 🧹", keys_removed);
+			/// Data concerning an approval.
+			/// Duplicated the type from pallet_assets (The original type is private)
+			#[derive(
+				Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, MaxEncodedLen, TypeInfo,
+			)]
+			pub struct Approval<Balance, DepositBalance> {
+				/// The amount of funds approved for the balance transfer from the owner to some delegated
+				/// target.
+				pub(super) amount: Balance,
+				/// The amount reserved on the owner's account to hold this item in storage.
+				pub(super) deposit: DepositBalance,
+			}
 
-			Ok(Some(
-				weight
-					.saturating_add(Weight::from_parts(
-						0,
-						INTERMEDIATES_NODES_SIZE
-							+ MAX_LOCAL_ASSETS_STORAGE_ENTRY_SIZE * keys_removed,
-					))
-					.saturating_add(
-						<T as frame_system::Config>::DbWeight::get()
-							.reads_writes(keys_removed, keys_removed),
+			let asset_id_iter = frame_support::storage::types::StorageMap::<
+				LocalAssetsStorageAsset,
+				Blake2_128Concat,
+				u128,
+				// It is fine to add a dummy `Value` type
+				// The value is not going to be decoded, since we only care about the keys)
+				(),
+			>::iter_keys();
+
+			for asset_id in asset_id_iter {
+				let approvals_iter = frame_support::storage::types::StorageNMap::<
+					LocalAssetsStorageApprovals,
+					(
+						NMapKey<Blake2_128Concat, u128>,         // asset id
+						NMapKey<Blake2_128Concat, T::AccountId>, // owner
+						NMapKey<Blake2_128Concat, T::AccountId>, // delegate
 					),
-			)
-			.into())
+					Approval<T::Balance, T::Balance>,
+				>::drain_prefix((asset_id,));
+				for ((owner, _), approval) in approvals_iter {
+					allowed_removals = allowed_removals.saturating_sub(1);
+					// Unreserve deposit (most likely will be zero)
+					pallet_balances::Pallet::<T>::unreserve(&owner, approval.deposit);
+					// Check if the removal limit was reached
+					if allowed_removals < 1 {
+						break;
+					}
+				}
+			}
+
+			// Remove remaining storage
+			if allowed_removals > 0 {
+				let hashed_prefix = sp_io::hashing::twox_128(PALLET_PREFIX.as_bytes());
+
+				let keys_removed =
+					match sp_io::storage::clear_prefix(&hashed_prefix, Some(allowed_removals)) {
+						sp_io::KillStorageResult::AllRemoved(value) => {
+							LocalAssetsMigrationCompleted::<T>::set(true);
+							weight.saturating_accrue(
+								<T as frame_system::Config>::DbWeight::get().writes(1),
+							);
+							value
+						}
+						sp_io::KillStorageResult::SomeRemaining(value) => value,
+					};
+
+				allowed_removals = allowed_removals.saturating_sub(keys_removed);
+			}
+
+			log::info!(
+				"Removed {} storge keys 🧹",
+				limit.saturating_sub(allowed_removals)
+			);
+
+			Ok(Pays::No.into())
 		}
 
 		// TODO(rodrigo): This extrinsic should be removed once the storage of destroyed contracts


### PR DESCRIPTION
### What does it do?

Update `clear_local_assets_storage` lazy migration call to un-reserve any reserved deposits from pallet LocalAssets.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
