### PR TITLE
add cli option --block-authoring-duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,6 +1499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-num"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e063d263364859dc54fb064cedb7c122740cd4733644b14b176c097f51e8ab7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6348,6 +6357,7 @@ name = "moonbeam-cli"
 version = "0.37.0"
 dependencies = [
  "clap",
+ "clap-num",
  "cumulus-client-cli",
  "cumulus-client-service",
  "cumulus-primitives-core",
@@ -7738,7 +7748,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.53",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,6 +367,7 @@ assert_cmd = "2.0.10"
 async-io = "1.3"
 bip32 = { version = "0.5.1", default-features = false, features = ["bip39"] }
 clap = { version = "4.0.9", features = ["derive"] }
+clap-num = "=1.1.1"
 exit-future = "0.2"
 flume = "0.10.9"
 futures = { version = "0.3.21" }

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.37.0"
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
+clap-num = { workspace = true }
 log = { workspace = true }
 parity-scale-codec = { workspace = true }
 

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -24,6 +24,7 @@ use moonbeam_cli_opt::{account_key::GenerateAccountKey, EthApi, FrontierBackendT
 use moonbeam_service::chain_spec;
 use sc_cli::{Error as CliError, SubstrateCli};
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, clap::Subcommand)]
@@ -232,6 +233,16 @@ pub struct RunCmd {
 	/// Removes moonbeam prefix from Prometheus metrics
 	#[clap(long)]
 	pub no_prometheus_prefix: bool,
+
+	/// Maximum duration in milliseconds to produce a block
+	#[clap(long, default_value = "1500", value_parser=block_authoring_duration_parser)]
+	pub block_authoring_duration: Duration,
+}
+
+fn block_authoring_duration_parser(s: &str) -> Result<Duration, String> {
+	Ok(Duration::from_millis(clap_num::number_range(
+		s, 250, 2_000,
+	)?))
 }
 
 impl RunCmd {

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -795,6 +795,7 @@ pub fn run() -> Result<()> {
 						id,
 						rpc_config,
 						false,
+						cli.run.block_authoring_duration,
 						hwbench,
 					)
 					.await
@@ -811,6 +812,7 @@ pub fn run() -> Result<()> {
 						id,
 						rpc_config,
 						false,
+						cli.run.block_authoring_duration,
 						hwbench,
 					)
 					.await
@@ -827,6 +829,7 @@ pub fn run() -> Result<()> {
 						id,
 						rpc_config,
 						true,
+						cli.run.block_authoring_duration,
 						hwbench,
 					)
 					.await

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -598,6 +598,7 @@ async fn start_node_impl<RuntimeApi, Customizations>(
 	para_id: ParaId,
 	rpc_config: RpcConfig,
 	async_backing: bool,
+	block_authoring_duration: Duration,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(TaskManager, Arc<FullClient<RuntimeApi>>)>
 where
@@ -884,6 +885,7 @@ where
 			announce_block,
 			force_authoring,
 			relay_chain_slot_duration,
+			block_authoring_duration,
 			sync_service.clone(),
 		)?;
 		/*let parachain_consensus = build_consensus(
@@ -946,6 +948,7 @@ fn start_consensus<RuntimeApi, SO>(
 	announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
 	force_authoring: bool,
 	relay_chain_slot_duration: Duration,
+	block_authoring_duration: Duration,
 	sync_oracle: SO,
 ) -> Result<(), sc_service::Error>
 where
@@ -1024,7 +1027,7 @@ where
 				additional_relay_keys: vec![
 					moonbeam_core_primitives::well_known_relay_keys::TIMESTAMP_NOW.to_vec(),
 				],
-				authoring_duration: Duration::from_millis(1500),
+				authoring_duration: block_authoring_duration,
 				block_import,
 				code_hash_provider,
 				collator_key,
@@ -1085,6 +1088,7 @@ pub async fn start_node<RuntimeApi, Customizations>(
 	para_id: ParaId,
 	rpc_config: RpcConfig,
 	async_backing: bool,
+	block_authoring_duration: Duration,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(TaskManager, Arc<FullClient<RuntimeApi>>)>
 where
@@ -1101,6 +1105,7 @@ where
 		para_id,
 		rpc_config,
 		async_backing,
+		block_authoring_duration,
 		hwbench,
 	)
 	.await


### PR DESCRIPTION
### What does it do?

Depending on the performance of a collator, it can happen that a collator fits more computing weight in a block than a validator is able to process, causing the collator to fail to produce blocks and get the rewards.

This PR add an option to the command line client `--block-authoring-duration` that accepts a positive integer representing the amount of time in milliseconds that the client has to produce a block. 

The  value for the block time limit is bounded between 250 and 2000 (0.25s to 2s) with default to 1.5s.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
