### PR TITLE
Fix staking reward smoke test for old runtimes (<2801): always use max inflation

### DIFF
--- a/test/suites/smoke/test-staking-rewards.ts
+++ b/test/suites/smoke/test-staking-rewards.ts
@@ -543,7 +543,7 @@ describeSuite({
         // Always apply max inflation
         // It work because the total staked amound is already 1000 times more than the max on
         // production, so it's very unlikely to change before RT2801 deployment on moonbeam
-        totalRoundIssuance =  range.max;
+        totalRoundIssuance = range.max;
       }
 
       const totalCollatorCommissionReward = new Perbill(collatorCommissionRate).of(

--- a/test/suites/smoke/test-staking-rewards.ts
+++ b/test/suites/smoke/test-staking-rewards.ts
@@ -498,7 +498,6 @@ describeSuite({
       // calculate reward amounts
       const parachainBondInfo = await apiAtPriorRewarded.query.parachainStaking.parachainBondInfo();
       const parachainBondPercent = new Percent(parachainBondInfo.percent);
-      const totalStaked = await apiAtPriorRewarded.query.parachainStaking.totalSelected();
       const totalPoints = await apiAtPriorRewarded.query.parachainStaking.points(
         originalRoundNumber
       );
@@ -541,11 +540,10 @@ describeSuite({
 
         totalRoundIssuance = roundDuration.mul(idealIssuance).div(idealDuration);
       } else {
-        totalRoundIssuance = totalStaked.lt(inflation.expect.min)
-          ? range.min
-          : totalStaked.gt(inflation.expect.max)
-          ? range.max
-          : range.ideal;
+        // Always apply max inflation
+        // It work because the total staked amound is already 1000 times more than the max on
+        // production, so it's very unlikely to change before RT2801 deployment on moonbeam
+        totalRoundIssuance =  range.max;
       }
 
       const totalCollatorCommissionReward = new Perbill(collatorCommissionRate).of(


### PR DESCRIPTION
### What does it do?

The staking reward smoke test fail on moonbeam because of a wrong new logic that use the number of selected collators  as a replacement of the total staked amount to figure out the inflation rate.

Since it impact only moonbeam (moonriver alreay have RT2801) and the total staked amount is around 1000 times more than the max, always suuming the amx inflation on the smoke tests will work, it's very unlikely to change before RT2801 deployment on moonbeam.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
