### PR TITLE
Fast General Admin Track for opening HRMP channels 

### DIFF
--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -149,7 +149,7 @@ pub mod pallet {
 		// The origin that is allowed to manipulate (open, close, accept, cancel) an Hrmp channel
 		type HrmpManipulatorOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
-		// The origin that is allowed to open an Hrmp channel
+		// The origin that is allowed to open and accept an Hrmp channel
 		type HrmpOpenOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Convert `T::AccountId` to `Location`.

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -396,6 +396,7 @@ impl Config for Test {
 	type ReserveProvider = orml_traits::location::RelativeReserveProvider;
 	type WeightInfo = ();
 	type HrmpManipulatorOrigin = EnsureRoot<u64>;
+	type HrmpOpenOrigin = EnsureRoot<u64>;
 	type MaxHrmpFee = MaxHrmpRelayFee;
 }
 

--- a/precompiles/relay-encoder/src/mock.rs
+++ b/precompiles/relay-encoder/src/mock.rs
@@ -309,6 +309,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type ReserveProvider = orml_traits::location::RelativeReserveProvider;
 	type WeightInfo = ();
 	type HrmpManipulatorOrigin = frame_system::EnsureRoot<AccountId>;
+	type HrmpOpenOrigin = frame_system::EnsureRoot<AccountId>;
 	type MaxHrmpFee = ();
 }
 

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -334,6 +334,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type ReserveProvider = orml_traits::location::RelativeReserveProvider;
 	type WeightInfo = ();
 	type HrmpManipulatorOrigin = frame_system::EnsureRoot<AccountId>;
+	type HrmpOpenOrigin = frame_system::EnsureRoot<AccountId>;
 	type MaxHrmpFee = ();
 }
 

--- a/runtime/moonbase/src/governance/referenda.rs
+++ b/runtime/moonbase/src/governance/referenda.rs
@@ -51,8 +51,8 @@ parameter_types! {
 
 pub type GeneralAdminOrRoot = EitherOf<EnsureRoot<AccountId>, origins::GeneralAdmin>;
 
-/// The policy allows for Root, GeneralAdmin, or FastGeneralAdmin.
-pub type FastGeneralAdminOrRoot = EitherOf<GeneralAdminOrRoot, origins::FastGeneralAdmin>;
+/// The policy allows for Root or FastGeneralAdmin.
+pub type FastGeneralAdminOrRoot = EitherOf<EnsureRoot<AccountId>, origins::FastGeneralAdmin>;
 
 impl custom_origins::Config for Runtime {}
 

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -72,7 +72,7 @@ use sp_std::{
 
 use orml_traits::parameter_type_with_key;
 
-use crate::governance::referenda::FastGeneralAdminOrRoot;
+use crate::governance::referenda::{FastGeneralAdminOrRoot, GeneralAdminOrRoot};
 
 parameter_types! {
 	// The network Id of the relay
@@ -658,7 +658,8 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type AssetTransactor = AssetTransactors;
 	type ReserveProvider = AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 	type WeightInfo = moonbeam_weights::pallet_xcm_transactor::WeightInfo<Runtime>;
-	type HrmpManipulatorOrigin = FastGeneralAdminOrRoot;
+	type HrmpManipulatorOrigin = GeneralAdminOrRoot;
+	type HrmpOpenOrigin = FastGeneralAdminOrRoot;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 }
 

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -840,6 +840,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type ReserveProvider = xcm_primitives::AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 	type WeightInfo = ();
 	type HrmpManipulatorOrigin = EnsureRoot<AccountId>;
+	type HrmpOpenOrigin = EnsureRoot<AccountId>;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 }
 

--- a/runtime/moonbeam/src/governance/origins.rs
+++ b/runtime/moonbeam/src/governance/origins.rs
@@ -41,6 +41,8 @@ pub mod custom_origins {
 		ReferendumCanceller,
 		/// Origin able to kill referenda.
 		ReferendumKiller,
+		/// Fast General Admin
+		FastGeneralAdmin,
 	}
 
 	macro_rules! decl_unit_ensures {
@@ -77,6 +79,7 @@ pub mod custom_origins {
 		ReferendumCanceller,
 		ReferendumKiller,
 		WhitelistedCaller,
-		GeneralAdmin
+		GeneralAdmin,
+		FastGeneralAdmin,
 	);
 }

--- a/runtime/moonbeam/src/governance/referenda.rs
+++ b/runtime/moonbeam/src/governance/referenda.rs
@@ -50,6 +50,8 @@ parameter_types! {
 
 // Origin for general admin or root
 pub type GeneralAdminOrRoot = EitherOf<EnsureRoot<AccountId>, origins::GeneralAdmin>;
+// The policy allows for Root or FastGeneralAdmin.
+pub type FastGeneralAdminOrRoot = EitherOf<EnsureRoot<AccountId>, origins::FastGeneralAdmin>;
 
 impl custom_origins::Config for Runtime {}
 

--- a/runtime/moonbeam/src/governance/tracks.rs
+++ b/runtime/moonbeam/src/governance/tracks.rs
@@ -28,7 +28,7 @@ const fn permill(x: i32) -> sp_runtime::FixedI64 {
 }
 
 use pallet_referenda::Curve;
-const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 5] = [
+const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 6] = [
 	(
 		0,
 		pallet_referenda::TrackInfo {
@@ -109,6 +109,20 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 5]
 			min_enactment_period: 10 * MINUTES,
 			min_approval: Curve::make_reciprocal(1, 14, percent(96), percent(50), percent(100)),
 			min_support: Curve::make_reciprocal(1, 14, percent(1), percent(0), percent(10)),
+		},
+	),
+	(
+		5,
+		pallet_referenda::TrackInfo {
+			name: "fast_general_admin",
+			max_deciding: 10,
+			decision_deposit: 100 * GLMR * SUPPLY_FACTOR,
+			prepare_period: 1 * HOURS,
+			decision_period: 14 * DAYS,
+			confirm_period: 3 * HOURS,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: Curve::make_reciprocal(4, 14, percent(80), percent(50), percent(100)),
+			min_support: Curve::make_reciprocal(5, 14, percent(1), percent(0), percent(50)),
 		},
 	),
 ];

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -72,7 +72,7 @@ use sp_std::{
 
 use orml_traits::parameter_type_with_key;
 
-use crate::governance::referenda::GeneralAdminOrRoot;
+use crate::governance::referenda::{FastGeneralAdminOrRoot, GeneralAdminOrRoot};
 
 parameter_types! {
 	// The network Id of the relay
@@ -651,6 +651,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type ReserveProvider = AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 	type WeightInfo = moonbeam_weights::pallet_xcm_transactor::WeightInfo<Runtime>;
 	type HrmpManipulatorOrigin = GeneralAdminOrRoot;
+	type HrmpOpenOrigin = FastGeneralAdminOrRoot;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -800,6 +800,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type ReserveProvider = xcm_primitives::AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 	type WeightInfo = ();
 	type HrmpManipulatorOrigin = EnsureRoot<AccountId>;
+	type HrmpOpenOrigin = EnsureRoot<AccountId>;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 }
 

--- a/runtime/moonriver/src/governance/origins.rs
+++ b/runtime/moonriver/src/governance/origins.rs
@@ -40,6 +40,8 @@ pub mod custom_origins {
 		ReferendumCanceller,
 		/// Origin able to kill referenda.
 		ReferendumKiller,
+		/// Fast General Admin
+		FastGeneralAdmin,
 	}
 
 	macro_rules! decl_unit_ensures {
@@ -76,6 +78,7 @@ pub mod custom_origins {
 		ReferendumCanceller,
 		ReferendumKiller,
 		WhitelistedCaller,
-		GeneralAdmin
+		GeneralAdmin,
+		FastGeneralAdmin,
 	);
 }

--- a/runtime/moonriver/src/governance/referenda.rs
+++ b/runtime/moonriver/src/governance/referenda.rs
@@ -50,6 +50,8 @@ parameter_types! {
 
 // Origin for general admin or root
 pub type GeneralAdminOrRoot = EitherOf<EnsureRoot<AccountId>, origins::GeneralAdmin>;
+// The policy allows for Root or FastGeneralAdmin.
+pub type FastGeneralAdminOrRoot = EitherOf<EnsureRoot<AccountId>, origins::FastGeneralAdmin>;
 
 impl custom_origins::Config for Runtime {}
 

--- a/runtime/moonriver/src/governance/tracks.rs
+++ b/runtime/moonriver/src/governance/tracks.rs
@@ -28,7 +28,7 @@ const fn permill(x: i32) -> sp_runtime::FixedI64 {
 }
 
 use pallet_referenda::Curve;
-const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 5] = [
+const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 6] = [
 	(
 		0,
 		pallet_referenda::TrackInfo {
@@ -109,6 +109,20 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 5]
 			min_enactment_period: 10 * MINUTES,
 			min_approval: Curve::make_reciprocal(1, 14, percent(96), percent(50), percent(100)),
 			min_support: Curve::make_reciprocal(1, 14, percent(1), percent(0), percent(10)),
+		},
+	),
+	(
+		5,
+		pallet_referenda::TrackInfo {
+			name: "fast_general_admin",
+			max_deciding: 10,
+			decision_deposit: 500 * MOVR * SUPPLY_FACTOR,
+			prepare_period: 1 * HOURS,
+			decision_period: 14 * DAYS,
+			confirm_period: 3 * HOURS,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: Curve::make_reciprocal(4, 14, percent(80), percent(50), percent(100)),
+			min_support: Curve::make_reciprocal(5, 14, percent(1), percent(0), percent(50)),
 		},
 	),
 ];

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -72,7 +72,7 @@ use sp_std::{
 
 use orml_traits::parameter_type_with_key;
 
-use crate::governance::referenda::GeneralAdminOrRoot;
+use crate::governance::referenda::{FastGeneralAdminOrRoot, GeneralAdminOrRoot};
 
 parameter_types! {
 	// The network Id of the relay
@@ -664,6 +664,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type ReserveProvider = AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 	type WeightInfo = moonbeam_weights::pallet_xcm_transactor::WeightInfo<Runtime>;
 	type HrmpManipulatorOrigin = GeneralAdminOrRoot;
+	type HrmpOpenOrigin = FastGeneralAdminOrRoot;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 }
 

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -805,6 +805,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type ReserveProvider = xcm_primitives::AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 	type WeightInfo = ();
 	type HrmpManipulatorOrigin = EnsureRoot<AccountId>;
+	type HrmpOpenOrigin = EnsureRoot<AccountId>;
 	type MaxHrmpFee = xcm_builder::Case<MaxHrmpRelayFee>;
 }
 


### PR DESCRIPTION
### What does it do?

Introduce a new origin `HrmpOpenOrigin` that is allowed to open a Hrmp channel. 

On Moonbase this change limits the scope of opening the Hrmp channel to the Fast General Admin track, removing the possibility to make operation on the channel. 

On Moonriver and Moonbeam this change adds the Fast General Admin track that allows to open a new Hrmp channel. 

The Fast General Admin track is similar to the General Admin track but with less strict requirements


### What important points reviewers should know?

Here is the forum post describing the change https://forum.moonbeam.network/t/new-track-for-opening-hrmp-xcm-channels/1669
