### PR TITLE
Fix `ExpectedBlockTime` const

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -878,7 +878,7 @@ impl pallet_author_slot_filter::Config for Runtime {
 impl pallet_async_backing::Config for Runtime {
 	type AllowMultipleBlocksPerSlot = ConstBool<true>;
 	type GetAndVerifySlot = pallet_async_backing::RelaySlot;
-	type ExpectedBlockTime = ConstU64<6>;
+	type ExpectedBlockTime = ConstU64<6000>;
 }
 
 parameter_types! {


### PR DESCRIPTION
### What does it do?

Changes the value of `ExpectedBlockTime` pallet-async-backing const to `6000` milliseconds.