### PR TITLE
chore(ci): fix failure when uploading artifact in dev-tests

### DIFF
--- a/.github/workflow-templates/dev-tests/action.yml
+++ b/.github/workflow-templates/dev-tests/action.yml
@@ -52,5 +52,5 @@ runs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: dev-test-report
+        name: ${{ inputs.moonwall_environment }}-dev-test-report
         path: test/html


### PR DESCRIPTION
### What does it do?

Since version 4 of upload-artifact github action, artifacts cannot be overwritten by default. This change adds distinct names to dev-test reports.