### PR TITLE
added Onfinality bootnodes

### DIFF
--- a/specs/alphanet/parachain-embedded-specs-v8.json
+++ b/specs/alphanet/parachain-embedded-specs-v8.json
@@ -12,7 +12,8 @@
     "/dns/eu-01.unitedbloc.com/tcp/35060/p2p/12D3KooWAu26xXQy9Q8P9rXim3yAGkAZ38BS3xrF2J7uZUbz1A8n",
     "/dns/apac-01.unitedbloc.com/tcp/35060/p2p/12D3KooWH1zRsVBRtTNiEbKHSees6ESw7UPFJBws3StgXcqTUQDt",
     "/dns/sa-01.unitedbloc.com/tcp/35060/p2p/12D3KooWKbo2qnyNdea2uR55z7dfg1BVDJw15Xr9xkUHd1csQnG2",
-    "/dns/na-01a.unitedbloc.com/tcp/30333/p2p/12D3KooWEe1hn1YMxqzhacCDYrQVrNHyP8MXZSSjHkTwnGmKXRhh"
+    "/dns/na-01a.unitedbloc.com/tcp/30333/p2p/12D3KooWEe1hn1YMxqzhacCDYrQVrNHyP8MXZSSjHkTwnGmKXRhh",
+    "/dns4/moonbase-alpha-1.boot.onfinality.io/tcp/25962/ws/p2p/12D3KooWMe4sMVxmTYJ9HfzKc5w6daLtjjDK9Jts4dKN5mTj6YhD"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]

--- a/specs/moonbeam/parachain-embedded-specs.json
+++ b/specs/moonbeam/parachain-embedded-specs.json
@@ -15,7 +15,8 @@
     "/dns/apac-02.unitedbloc.com/tcp/37060/p2p/12D3KooWJsfWGQLajaXXoqYSpn1CZbXHs7RDWqbgvsBXPJrjVGjb",
     "/dns/apac-01.unitedbloc.com/tcp/37060/p2p/12D3KooWCnXymVyowL5YymVk6RNzRzFAWUvurX7eTTYAFcCbs4nj",
     "/dns/sa-01.unitedbloc.com/tcp/37060/p2p/12D3KooWC3FoL2bFJ79C5CeLDjLmL2yRyozPxSjTQbm9RY95KNsV",
-    "/dns/na-01.unitedbloc.com/tcp/37060/p2p/12D3KooWLEZwHD8tWvWiEqKcD976wxdE5JRUnq1JG9a6VJxHUjiS"
+    "/dns/na-01.unitedbloc.com/tcp/37060/p2p/12D3KooWLEZwHD8tWvWiEqKcD976wxdE5JRUnq1JG9a6VJxHUjiS",
+    "/dns4/moonbeam-1.boot.onfinality.io/tcp/28868/ws/p2p/12D3KooWEvop16VcctRftvTDdi5dSGWAA2FA9tXiZyZwzfBpH83L"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]

--- a/specs/moonriver/parachain-embedded-specs.json
+++ b/specs/moonriver/parachain-embedded-specs.json
@@ -14,7 +14,8 @@
     "/dns/apac-02.unitedbloc.com/tcp/36060/p2p/12D3KooWPvom1ZBWpXRAPf7S8zQXYX2iNNF6dSZcBxyfPY517JMd",
     "/dns/apac-01.unitedbloc.com/tcp/36060/p2p/12D3KooWAosKitTohMgbKqTtcaUvyUHpP3vbnL7het3nFBSfheZ7",
     "/dns/sa-01.unitedbloc.com/tcp/36060/p2p/12D3KooWBXSNJudphGqb4TKmgfruZkY79PsN9aGYFnLgYR4ou3SH",
-    "/dns/na-01.unitedbloc.com/tcp/36060/p2p/12D3KooWLVmzvBxKvJyg8u4fUuBgnSBJGS8wQFXKvyHUBzJ1pAuT"
+    "/dns/na-01.unitedbloc.com/tcp/36060/p2p/12D3KooWLVmzvBxKvJyg8u4fUuBgnSBJGS8wQFXKvyHUBzJ1pAuT",
+    "/dns4/moonriver-1.boot.onfinality.io/tcp/28871/ws/p2p/12D3KooWSpLYDMXBdDrX4LaU3NpTc7W4psLFXvnaVfyCcu3Jouq9"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]


### PR DESCRIPTION
### What does it do?

Bootnodes added to the repo.

* /dns4/moonriver-1.boot.onfinality.io/tcp/28871/ws/p2p/12D3KooWSpLYDMXBdDrX4LaU3NpTc7W4psLFXvnaVfyCcu3Jouq9
* /dns4/moonbeam-1.boot.onfinality.io/tcp/28868/ws/p2p/12D3KooWEvop16VcctRftvTDdi5dSGWAA2FA9tXiZyZwzfBpH83L
* /dns4/moonriver-1.boot.onfinality.io/tcp/28871/ws/p2p/12D3KooWSpLYDMXBdDrX4LaU3NpTc7W4psLFXvnaVfyCcu3Jouq9

### What important points reviewers should know?

Moonbeam bootnode is still under data syncing.

### Is there something left for follow-up PRs?

No

### What alternative implementations were considered?

No

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

No

### What value does it bring to the blockchain users?

Increasing the number of bootnodes can enhance the community's experience by facilitating smoother and more efficient node boot-ups.
