### PR TITLE
Enable async backing on moonriver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7066,6 +7066,7 @@ dependencies = [
  "orml-xtokens",
  "pallet-asset-manager",
  "pallet-assets",
+ "pallet-async-backing",
  "pallet-author-inherent",
  "pallet-author-mapping",
  "pallet-author-slot-filter",

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -162,6 +162,7 @@ parachains-common = { workspace = true }
 async-backing-primitives = { workspace = true }
 moonkit-xcm-primitives = { workspace = true }
 nimbus-primitives = { workspace = true }
+pallet-async-backing = { workspace = true }
 pallet-author-inherent = { workspace = true }
 pallet-author-slot-filter = { workspace = true }
 pallet-relay-storage-roots = { workspace = true }
@@ -221,6 +222,7 @@ std = [
 	"orml-xtokens/std",
 	"pallet-asset-manager/std",
 	"pallet-assets/std",
+	"pallet-async-backing/std",
 	"pallet-author-inherent/std",
 	"pallet-author-mapping/std",
 	"pallet-author-slot-filter/std",
@@ -409,6 +411,7 @@ try-runtime = [
 	"pallet-identity/try-runtime",
 	"orml-xtokens/try-runtime",
 	"pallet-assets/try-runtime",
+	"pallet-async-backing/try-runtime",
 	"pallet-xcm-transactor/try-runtime",
 	"pallet-proxy-genesis-companion/try-runtime",
 	"pallet-moonbeam-orbiters/try-runtime",

--- a/runtime/moonriver/src/migrations.rs
+++ b/runtime/moonriver/src/migrations.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-//! # Moonbase specific Migrations
+//! # Moonriver specific Migrations
 
 use crate::Runtime;
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};

--- a/runtime/moonriver/src/migrations.rs
+++ b/runtime/moonriver/src/migrations.rs
@@ -1,0 +1,43 @@
+// Copyright 2024 Moonbeam Foundation Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! # Moonbase specific Migrations
+
+use crate::Runtime;
+use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
+use pallet_migrations::{GetMigrations, Migration};
+use pallet_parachain_staking::migrations::MultiplyRoundLenBy2;
+use sp_std::{prelude::*, vec};
+
+pub struct MoonriverMigrations;
+
+impl GetMigrations for MoonriverMigrations {
+	fn get_migrations() -> Vec<Box<dyn Migration>> {
+		vec![Box::new(PalletStakingMultiplyRoundLenBy2)]
+	}
+}
+
+// This migration should only be applied to runtimes with async backing enabled
+pub struct PalletStakingMultiplyRoundLenBy2;
+impl Migration for PalletStakingMultiplyRoundLenBy2 {
+	fn friendly_name(&self) -> &str {
+		"MM_MultiplyRoundLenBy2"
+	}
+
+	fn migrate(&self, _available_weight: Weight) -> Weight {
+		MultiplyRoundLenBy2::<Runtime>::on_runtime_upgrade()
+	}
+}

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -26,12 +26,13 @@ pub use moonriver_runtime::{
 	asset_config::AssetRegistrarMetadata,
 	currency::{GIGAWEI, MOVR, SUPPLY_FACTOR, WEI},
 	xcm_config::AssetType,
-	AccountId, AssetId, AssetManager, AuthorInherent, Balance, Balances, CrowdloanRewards,
+	AccountId, AssetId, AssetManager, AsyncBacking, AuthorInherent, Balance, Balances, CrowdloanRewards,
 	Ethereum, Executive, Header, InflationInfo, ParachainStaking, Range, Runtime, RuntimeCall,
 	RuntimeEvent, System, TransactionConverter, TransactionPaymentAsGasPrice, UncheckedExtrinsic,
 	HOURS, WEEKS,
 };
 use nimbus_primitives::{NimbusId, NIMBUS_ENGINE_ID};
+use sp_consensus_slots::Slot;
 use sp_core::{Encode, H160};
 use sp_runtime::{traits::Dispatchable, BuildStorage, Digest, DigestItem, Perbill, Percent};
 
@@ -377,4 +378,12 @@ pub fn ethereum_transaction(raw_hex_tx: &str) -> pallet_ethereum::Transaction {
 	let transaction = ethereum::EnvelopedDecodable::decode(&bytes[..]);
 	assert!(transaction.is_ok());
 	transaction.unwrap()
+}
+
+pub(crate) fn increase_last_relay_slot_number(amount: u64) {
+	let last_relay_slot = u64::from(AsyncBacking::slot_info().unwrap_or_default().0);
+	frame_support::storage::unhashed::put(
+		&frame_support::storage::storage_prefix(b"AsyncBacking", b"SlotInfo"),
+		&((Slot::from(last_relay_slot + amount), 0)),
+	);
 }

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -26,10 +26,10 @@ pub use moonriver_runtime::{
 	asset_config::AssetRegistrarMetadata,
 	currency::{GIGAWEI, MOVR, SUPPLY_FACTOR, WEI},
 	xcm_config::AssetType,
-	AccountId, AssetId, AssetManager, AsyncBacking, AuthorInherent, Balance, Balances, CrowdloanRewards,
-	Ethereum, Executive, Header, InflationInfo, ParachainStaking, Range, Runtime, RuntimeCall,
-	RuntimeEvent, System, TransactionConverter, TransactionPaymentAsGasPrice, UncheckedExtrinsic,
-	HOURS, WEEKS,
+	AccountId, AssetId, AssetManager, AsyncBacking, AuthorInherent, Balance, Balances,
+	CrowdloanRewards, Ethereum, Executive, Header, InflationInfo, ParachainStaking, Range, Runtime,
+	RuntimeCall, RuntimeEvent, System, TransactionConverter, TransactionPaymentAsGasPrice,
+	UncheckedExtrinsic, HOURS, WEEKS,
 };
 use nimbus_primitives::{NimbusId, NIMBUS_ENGINE_ID};
 use sp_consensus_slots::Slot;

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -620,7 +620,7 @@ fn reward_block_authors() {
 
 			// Just before round 3
 			run_to_block(2399, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
-			
+
 			// no rewards doled out yet
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
@@ -628,7 +628,7 @@ fn reward_block_authors() {
 			);
 			assert_eq!(Balances::usable_balance(AccountId::from(BOB)), 9500 * MOVR,);
 			run_to_block(2401, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
-	
+
 			// rewards minted and distributed
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -616,25 +616,27 @@ fn reward_block_authors() {
 		)])
 		.build()
 		.execute_with(|| {
-			set_parachain_inherent_data();
-			for x in 2..1199 {
-				run_to_block(x, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
-			}
+			increase_last_relay_slot_number(1);
+
+			// Just before round 3
+			run_to_block(2399, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
+			
 			// no rewards doled out yet
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
 				10_100 * MOVR,
 			);
 			assert_eq!(Balances::usable_balance(AccountId::from(BOB)), 9500 * MOVR,);
-			run_to_block(1201, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
+			run_to_block(2401, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
+	
 			// rewards minted and distributed
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
-				11547666666208000000000,
+				10101206388888506666666,
 			);
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(BOB)),
-				9557333332588000000000,
+				9500047777777156666667,
 			);
 		});
 }
@@ -660,12 +662,13 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 		)])
 		.build()
 		.execute_with(|| {
-			set_parachain_inherent_data();
+			increase_last_relay_slot_number(1);
 			assert_ok!(ParachainStaking::set_parachain_bond_account(
 				root_origin(),
 				AccountId::from(CHARLIE),
 			),);
 
+			// Stop just before round 2
 			run_to_block(1199, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
 
 			// no collator rewards doled out yet
@@ -675,26 +678,31 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 			);
 			assert_eq!(Balances::usable_balance(AccountId::from(BOB)), 9500 * MOVR,);
 
+			// Go to round 2
+			run_to_block(1201, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
+
 			// 30% reserved for parachain bond
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(CHARLIE)),
-				452515000000000000000,
+				1376262500000000000,
 			);
 
-			run_to_block(1201, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
+			// Go to round 3
+			run_to_block(2401, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
+
 			// rewards minted and distributed
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
-				11117700475903800000000,
+				10100848083729919833333,
 			);
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(BOB)),
-				9535834523343675000000,
+				9500029862102786395833,
 			);
 			// 30% reserved for parachain bond again
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(CHARLIE)),
-				910802725000000000000,
+				1376262500000000000,
 			);
 		});
 }


### PR DESCRIPTION
### What does it do?

Enable asynchrnous backing on moonriver:

- Add pallet async_backing for moonriver runtime
- Add migration PalletStakingMultiplyRoundLenBy2 for moonriver runtime
- Use relay chain slot instead of parachain block number for staking round clock

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
