### PR TITLE
support eth_call for past blocks with old runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3325,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3356,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3379,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "evm",
  "frame-support",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8483,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8539,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "environmental",
  "evm",
@@ -8565,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fp-evm",
 ]
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8797,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fp-evm",
  "num",
@@ -9107,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9116,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9126,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-storage-cleaner"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -11677,7 +11677,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "environmental",
  "evm",
@@ -11734,7 +11734,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#2c05f9d4d951efacf504d610286da6ac908b1302"
 dependencies = [
  "case",
  "num_enum 0.7.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3325,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3356,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3379,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "hex",
  "impl-serde 0.4.0",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "evm",
  "frame-support",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8483,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8539,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "environmental",
  "evm",
@@ -8565,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fp-evm",
 ]
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8797,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fp-evm",
  "num",
@@ -9107,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9116,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9126,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-storage-cleaner"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -11677,7 +11677,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "environmental",
  "evm",
@@ -11734,7 +11734,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#5d6bf0c78d1d325d4eea6f9593e9a11da18a1ea8"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-v1.7.2#ea9becfa1885a4ce7d63558620b5367cbc4e9289"
 dependencies = [
  "case",
  "num_enum 0.7.2",


### PR DESCRIPTION
### What does it do?

* Update our frontier fork to include [moonbeam-foundation/frontier#203](https://github.com/moonbeam-foundation/frontier/pull/203) (fix EthereumRuntimeRPCApi_call error)
* Cherry-pick polkadot-evm/frontier/pull/1404 on our frontier fork

> Frontier PR [#1257](https://github.com/polkadot-evm/frontier/pull/1257) introduce a regression that make the client not compatible with old runtimes.
> Old runtimes doesn't check properly non transactional evm calls, old runtimes rely on the fact that max_fee_per_gas is None to consider the evm call non transactional.
> It introduced a bug in Moonbeam where eth_call against past blocks produce the BalanceLow error.
> Because we can't change old runtimes, the client should not set max_fee_per_gas as Some(zero), otherwize old runtimes will assume that the evm call is transactional.
> 

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
