### PR TITLE
`MoonbeamFinalityApi` to fully async/await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6408,10 +6408,10 @@ dependencies = [
 name = "moonbeam-finality-rpc"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "fc-api",
  "fc-db",
  "fc-rpc",
- "futures 0.3.30",
  "jsonrpsee",
  "parity-scale-codec",
  "sp-api",

--- a/client/rpc/finality/Cargo.toml
+++ b/client/rpc/finality/Cargo.toml
@@ -9,15 +9,15 @@ repository = { workspace = true }
 version = "0.1.0"
 
 [dependencies]
-futures = { workspace = true, features = [ "compat" ] }
-jsonrpsee = { workspace = true, features = [ "macros", "server" ] }
-parity-scale-codec = { workspace = true, features = [ "std" ] }
-tokio = { workspace = true, features = [ "sync", "time" ] }
+async-trait = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+parity-scale-codec = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 fc-db = { workspace = true }
 fc-api = { workspace = true }
 fc-rpc = { workspace = true }
-sp-api = { workspace = true, features = [ "std" ] }
+sp-api = { workspace = true, features = ["std"] }
 sp-blockchain = { workspace = true }
-sp-core = { workspace = true, features = [ "std" ] }
-sp-runtime = { workspace = true, features = [ "std" ] }
+sp-core = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }

--- a/client/rpc/finality/Cargo.toml
+++ b/client/rpc/finality/Cargo.toml
@@ -10,14 +10,14 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = { workspace = true }
-jsonrpsee = { workspace = true, features = ["macros", "server"] }
-parity-scale-codec = { workspace = true, features = ["std"] }
-tokio = { workspace = true, features = ["sync", "time"] }
+jsonrpsee = { workspace = true, features = [ "macros", "server" ] }
+parity-scale-codec = { workspace = true, features = [ "std" ] }
+tokio = { workspace = true, features = [ "sync", "time" ] }
 
 fc-db = { workspace = true }
 fc-api = { workspace = true }
 fc-rpc = { workspace = true }
-sp-api = { workspace = true, features = ["std"] }
+sp-api = { workspace = true, features = [ "std" ] }
 sp-blockchain = { workspace = true }
-sp-core = { workspace = true, features = ["std"] }
-sp-runtime = { workspace = true, features = ["std"] }
+sp-core = { workspace = true, features = [ "std" ] }
+sp-runtime = { workspace = true, features = [ "std" ] }

--- a/client/rpc/finality/src/lib.rs
+++ b/client/rpc/finality/src/lib.rs
@@ -15,12 +15,10 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 use fc_rpc::frontier_backend_client::{self, is_canon};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use sp_core::H256;
-use std::{marker::PhantomData, sync::Arc};
-//TODO ideally we wouldn't depend on BlockId here. Can we change frontier
-// so it's load_hash helper returns an H256 instead of wrapping it in a BlockId?
 use sp_blockchain::HeaderBackend;
+use sp_core::H256;
 use sp_runtime::traits::Block;
+use std::{marker::PhantomData, sync::Arc};
 
 /// An RPC endpoint to check for finality of blocks and transactions in Moonbeam
 #[rpc(server)]

--- a/client/rpc/finality/src/lib.rs
+++ b/client/rpc/finality/src/lib.rs
@@ -29,12 +29,12 @@ pub trait MoonbeamFinalityApi {
 	/// Reports whether a Substrate or Ethereum block is finalized.
 	/// Returns false if the block is not found.
 	#[method(name = "moon_isBlockFinalized")]
-	fn is_block_finalized(&self, block_hash: H256) -> RpcResult<bool>;
+	async fn is_block_finalized(&self, block_hash: H256) -> RpcResult<bool>;
 
 	/// Reports whether an Ethereum transaction is finalized.
 	/// Returns false if the transaction is not found
 	#[method(name = "moon_isTxFinalized")]
-	fn is_tx_finalized(&self, tx_hash: H256) -> RpcResult<bool>;
+	async fn is_tx_finalized(&self, tx_hash: H256) -> RpcResult<bool>;
 }
 
 pub struct MoonbeamFinality<B: Block, C> {
@@ -53,42 +53,44 @@ impl<B: Block, C> MoonbeamFinality<B, C> {
 	}
 }
 
+#[async_trait::async_trait]
 impl<B, C> MoonbeamFinalityApiServer for MoonbeamFinality<B, C>
 where
 	B: Block<Hash = H256>,
 	C: HeaderBackend<B> + Send + Sync + 'static,
 {
-	fn is_block_finalized(&self, raw_hash: H256) -> RpcResult<bool> {
+	async fn is_block_finalized(&self, raw_hash: H256) -> RpcResult<bool> {
 		let client = self.client.clone();
-		is_block_finalized_inner::<B, C>(self.backend.as_ref(), &client, raw_hash)
+		is_block_finalized_inner::<B, C>(self.backend.as_ref(), &client, raw_hash).await
 	}
 
-	fn is_tx_finalized(&self, tx_hash: H256) -> RpcResult<bool> {
+	async fn is_tx_finalized(&self, tx_hash: H256) -> RpcResult<bool> {
 		let client = self.client.clone();
 
 		if let Some((ethereum_block_hash, _ethereum_index)) =
-			futures::executor::block_on(frontier_backend_client::load_transactions::<B, C>(
+			frontier_backend_client::load_transactions::<B, C>(
 				&client,
 				self.backend.as_ref(),
 				tx_hash,
 				true,
-			))? {
+			)
+			.await?
+		{
 			is_block_finalized_inner::<B, C>(self.backend.as_ref(), &client, ethereum_block_hash)
+				.await
 		} else {
 			Ok(false)
 		}
 	}
 }
 
-fn is_block_finalized_inner<B: Block<Hash = H256>, C: HeaderBackend<B> + 'static>(
+async fn is_block_finalized_inner<B: Block<Hash = H256>, C: HeaderBackend<B> + 'static>(
 	backend: &(dyn fc_api::Backend<B>),
 	client: &C,
 	raw_hash: H256,
 ) -> RpcResult<bool> {
 	let substrate_hash =
-		match futures::executor::block_on(frontier_backend_client::load_hash::<B, C>(
-			client, backend, raw_hash,
-		))? {
+		match frontier_backend_client::load_hash::<B, C>(client, backend, raw_hash).await? {
 			// If we find this hash in the frontier data base, we know it is an eth hash
 			Some(hash) => hash,
 			// Otherwise, we assume this is a Substrate hash.


### PR DESCRIPTION
### What does it do?
Changes the asynchronous waiting mechanism from `futures::block_on` to `await` to wait for `frontier_backend_client` calls

