### PR TITLE
Don't override fork strategy at block import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -7453,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8026,7 +8026,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8083,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8441,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9421,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9709,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -14277,7 +14277,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -17904,7 +17904,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#bca9e28b36008609860bf7970d5d7b8d361588b3"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.7.2#ce07d1aeb648f0667d08a4694a5aafc59de3c86b"
 dependencies = [
  "sp-runtime",
 ]

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -519,7 +519,6 @@ where
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
 				config.prometheus_registry(),
-				!dev_service,
 			)?,
 			BlockImportPipeline::Dev(frontier_block_import),
 		)
@@ -533,7 +532,6 @@ where
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
 				config.prometheus_registry(),
-				!dev_service,
 			)?,
 			BlockImportPipeline::Parachain(parachain_block_import),
 		)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -524,10 +524,8 @@ where
 			BlockImportPipeline::Dev(frontier_block_import),
 		)
 	} else {
-		let parachain_block_import = ParachainBlockImport::new_with_delayed_best_block(
-			frontier_block_import,
-			backend.clone(),
-		);
+		let parachain_block_import =
+			ParachainBlockImport::new(frontier_block_import, backend.clone());
 		(
 			nimbus_consensus::import_queue(
 				client.clone(),


### PR DESCRIPTION
### What does it do?

Historically aura for parachain was overcharing fork strategy for parachain at block import, but it's no longer necessary.

This PR update our moonkit fork to [remove the NimbusBlockImport type](https://github.com/Moonsong-Labs/moonkit/commit/ce07d1aeb648f0667d08a4694a5aafc59de3c86b), a wrapper that impl `BlockImport` only to override the fork strategy.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
