### PR TITLE
Fixes 🔨 `trace_filter` RPC call by filtering out unknown ethereum transactions

### DIFF
--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -907,8 +907,8 @@ where
 		let traces: Vec<TransactionTrace> =
 			moonbeam_client_evm_tracing::formatters::TraceFilter::format(proxy)
 				.ok_or("Fail to format proxy")?
-				.iter_mut()
-				.filter_map(|trace| {
+				.into_iter()
+				.filter_map(|mut trace| {
 					match eth_transactions_by_index.get(&trace.transaction_position) {
 						Some(transaction_hash) => {
 							trace.block_hash = eth_block_hash;
@@ -924,7 +924,7 @@ where
 								}
 							}
 
-							Some(trace.clone())
+							Some(trace)
 						}
 						None => {
 							log::warn!(

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -908,10 +908,17 @@ where
 			.collect();
 
 		// Fill missing data.
-		for trace in traces
-			.iter_mut()
-			.filter(|t| eth_transactions_by_index.contains_key(&t.transaction_position))
-		{
+		for trace in traces.iter_mut().filter(|t| {
+			let contains_key = eth_transactions_by_index.contains_key(&t.transaction_position);
+			if !contains_key {
+				log::warn!(
+					"A trace in block {} does not map to any known ethereum transaction. Trace: {:?}",
+					height,
+					t,
+				)
+			}
+			return eth_transactions_by_index.contains_key(&t.transaction_position);
+		}) {
 			trace.block_hash = eth_block_hash;
 			trace.block_number = height;
 			trace.transaction_hash =

--- a/test/suites/tracing-tests/test-trace-filter.ts
+++ b/test/suites/tracing-tests/test-trace-filter.ts
@@ -1,5 +1,5 @@
 import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, ALITH_CONTRACT_ADDRESSES, alith } from "@moonwall/util";
+import { ALITH_ADDRESS, ALITH_CONTRACT_ADDRESSES, GLMR, alith } from "@moonwall/util";
 
 describeSuite({
   id: "T14",
@@ -251,6 +251,53 @@ describeSuite({
             expect(error.message).to.eq("count (501) can't be greater than maximum (500)");
           }
         );
+      },
+    });
+
+    it({
+      id: "T10",
+      title: "should only trace transactions included in a block",
+      test: async function () {
+        context
+          .polkadotJs()
+          .tx.xTokens.transfer(
+            {
+              Erc20: {
+                contractAddress: "0x931715fee2d06333043d11f658c8ce934ac61d0c",
+              },
+            }, //enum
+            100n * GLMR,
+            {
+              V2: {
+                parents: 1n,
+                interior: {
+                  X2: [
+                    { Parachain: 2104n },
+                    {
+                      AccountId32: {
+                        network: "Any",
+                        id: "0x608a07e4dfc71e7d99a3d3759ce12ccbb1e4d9f917cc67779c13aaeaea52794d",
+                      },
+                    },
+                  ],
+                },
+              },
+            } as any,
+            {
+              Limited: { refTime: 4000000000, proofSize: 0 },
+            }
+          )
+          .signAsync(alith);
+
+        const response = await customDevRpcRequest("trace_filter", [
+          {
+            fromBlock: "0x03",
+            toBlock: "0x05",
+            fromAddress: [alith.address],
+          },
+        ]);
+
+        expect(response.length).to.equal(3);
       },
     });
   },


### PR DESCRIPTION
### What does it do?

This PR fixes an issue related to `trace_filter` RPC, where a failed `erc20_transfer` call is traced but cannot be found in any ethereum block (as the storage is roll backed when the `erc20_transfer` fails), as consequence the transaction is not processed by the `on_finalize` hook of pallet ethereum. 

The diagram below shows the described behaviour:

![image](https://github.com/moonbeam-foundation/moonbeam/assets/22591718/f906f789-66e5-42df-a1c3-d5a01b12460c)

As a fix, the tracer should filter out those transactions.