### PR TITLE
[Moonriver] Set block gas limit to 30mln

### DIFF
--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -150,7 +150,7 @@ pub mod currency {
 
 /// Maximum weight per block
 pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND, u64::MAX)
-	.saturating_mul(2)
+	.saturating_mul(1)
 	.set_proof_size(relay_chain::MAX_POV_SIZE as u64);
 
 pub const MILLISECS_PER_BLOCK: u64 = 6_000;
@@ -383,8 +383,8 @@ impl pallet_evm_chain_id::Config for Runtime {}
 
 /// Current approximation of the gas/s consumption considering
 /// EVM execution over compiled WASM (on 4.4Ghz CPU).
-/// Given the 2s Weight, from which 75% only are used for transactions,
-/// the total EVM execution gas limit is: GAS_PER_SECOND * 2 * 0.75 ~= 60_000_000.
+/// Given the 1000ms Weight, from which 75% only are used for transactions,
+/// the total EVM execution gas limit is: GAS_PER_SECOND * 1 * 0.75 ~= 30_000_000.
 pub const GAS_PER_SECOND: u64 = 40_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
@@ -417,9 +417,9 @@ parameter_types! {
 	///     (max_extrinsic.ref_time() / max_extrinsic.proof_size()) / WEIGHT_PER_GAS
 	/// )
 	/// We should re-check `xcm_config::Erc20XcmBridgeTransferGasLimit` when changing this value
-	pub const GasLimitPovSizeRatio: u64 = 16;
+	pub const GasLimitPovSizeRatio: u64 = 8;
 	/// The amount of gas per storage (in bytes): BLOCK_GAS_LIMIT / BLOCK_STORAGE_LIMIT
-	/// The current definition of BLOCK_STORAGE_LIMIT is 160 KB, resulting in a value of 366.
+	/// The current definition of BLOCK_STORAGE_LIMIT is 80 KB, resulting in a value of 366.
 	pub GasLimitStorageGrowthRatio: u64 = 366;
 }
 
@@ -1802,7 +1802,7 @@ mod tests {
 	#[test]
 	fn test_storage_growth_ratio_is_correct() {
 		// This is the highest amount of new storage that can be created in a block 40 KB
-		let block_storage_limit = 160 * 1024;
+		let block_storage_limit = 80 * 1024;
 		let expected_storage_growth_ratio = BlockGasLimit::get()
 			.low_u64()
 			.saturating_div(block_storage_limit);

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -681,7 +681,7 @@ parameter_types! {
 
 	// To be able to support almost all erc20 implementations,
 	// we provide a sufficiently hight gas limit.
-	pub Erc20XcmBridgeTransferGasLimit: u64 = 800_000;
+	pub Erc20XcmBridgeTransferGasLimit: u64 = 400_000;
 }
 
 impl pallet_erc20_xcm_bridge::Config for Runtime {

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -822,8 +822,8 @@ impl pallet_timestamp::Config for Runtime {
 use sp_core::U256;
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
-/// Block storage limit in bytes. Set to 160 KB.
-const BLOCK_STORAGE_LIMIT: u64 = 160 * 1024;
+/// Block storage limit in bytes. Set to 80 KB.
+const BLOCK_STORAGE_LIMIT: u64 = 80 * 1024;
 
 parameter_types! {
 	pub BlockGasLimit: U256 = U256::from(u64::MAX);


### PR DESCRIPTION
### What does it do?

Updates the block gas limit to 30mln

### What important points reviewers should know?

the changes have been tested in this pr https://github.com/moonbeam-foundation/moonbeam/pull/2819 it's important to verify that the changes are the same

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

replays the same changes and tests applied in #2735 for Moonriver, but with different block gas limit
