### PR TITLE
Allow bridged assets from Asset Hub

### DIFF
--- a/primitives/xcm/src/origin_conversion.rs
+++ b/primitives/xcm/src/origin_conversion.rs
@@ -85,8 +85,8 @@ where
 
 /// Matches foreign assets from a given origin.
 /// Foreign assets are assets bridged from other consensus systems. i.e parents > 1.
-pub struct IsForeignConcreteAssetFrom<Origin>(PhantomData<Origin>);
-impl<Origin> ContainsPair<Asset, Location> for IsForeignConcreteAssetFrom<Origin>
+pub struct IsBridgedConcreteAssetFrom<Origin>(PhantomData<Origin>);
+impl<Origin> ContainsPair<Asset, Location> for IsBridgedConcreteAssetFrom<Origin>
 where
 	Origin: Get<Location>,
 {

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -265,8 +265,23 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 }
 
 parameter_types! {
+    /// Location of Asset Hub
+    pub AssetHubLocation: MultiLocation = (Parent, Parachain(1000)).into();
+    pub RelayChainNativeAssetFromAssetHub: (MultiAssetFilter, MultiLocation) = (
+        (MultiAsset { id: Concrete(RelayLocation::get()), fun: Fungible(1)}).into(),
+        AssetHubLocation::get()
+    );
 	pub const MaxAssetsIntoHolding: u32 = xcm_primitives::MAX_ASSETS;
 }
+
+type Reserves = (
+    // Assets bridged from different consensus systems held in reserve on Asset Hub.
+    IsForeignConcreteAssetFrom<AssetHubLocation>,
+    // Relaychain (DOT) from Asset Hub
+    Case<RelayChainNativeAssetFromAssetHub>,
+    // Assets which the reserve is the same as the origin.
+    MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>;
+);
 
 pub struct XcmExecutorConfig;
 impl xcm_executor::Config for XcmExecutorConfig {

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -268,7 +268,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 
 parameter_types! {
 	/// Location of Asset Hub
-	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
+	pub AssetHubLocation: Location = Location::new(1, [Parachain(1001)]);
 	pub const RelayLocation: Location = Location::parent();
 	pub RelayLocationFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: xcm::prelude::AssetId(RelayLocation::get()) });
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -61,7 +61,7 @@ use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
-	FirstAssetTrader, IsForeignConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
+	FirstAssetTrader, IsBridgedConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
 	UtilityEncodeCall, XcmTransact,
 };
 
@@ -280,7 +280,7 @@ parameter_types! {
 
 type Reserves = (
 	// Assets bridged from different consensus systems held in reserve on Asset Hub.
-	IsForeignConcreteAssetFrom<AssetHubLocation>,
+	IsBridgedConcreteAssetFrom<AssetHubLocation>,
 	// Relaychain (DOT) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,
 	// Assets which the reserve is the same as the origin.

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -271,9 +271,9 @@ parameter_types! {
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(1001)]);
 	pub const RelayLocation: Location = Location::parent();
 	pub RelayLocationFilter: AssetFilter = Wild(AllOf {
-	  fun: WildFungible,
-	  id: xcm::prelude::AssetId(RelayLocation::get()),
-  });
+		fun: WildFungible,
+		id: xcm::prelude::AssetId(RelayLocation::get()),
+	});
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		RelayLocationFilter::get(),
 		AssetHubLocation::get()

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -270,7 +270,10 @@ parameter_types! {
 	/// Location of Asset Hub
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(1001)]);
 	pub const RelayLocation: Location = Location::parent();
-	pub RelayLocationFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: xcm::prelude::AssetId(RelayLocation::get()) });
+	pub RelayLocationFilter: AssetFilter = Wild(AllOf {
+	  fun: WildFungible,
+	  id: xcm::prelude::AssetId(RelayLocation::get()),
+  });
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		RelayLocationFilter::get(),
 		AssetHubLocation::get()

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -59,7 +59,7 @@ use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
-	FirstAssetTrader, IsForeginConcreteAAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
+	FirstAssetTrader, IsForeignConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
   UtilityEncodeCall, XcmTransact,
 };
 

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -59,7 +59,7 @@ use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
-	FirstAssetTrader, IsForeignConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
+	FirstAssetTrader, IsBridgedConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
   UtilityEncodeCall, XcmTransact,
 };
 
@@ -262,7 +262,7 @@ parameter_types! {
 
 type Reserves = (
 	// Assets bridged from different consensus systems held in reserve on Asset Hub.
-	IsForeignConcreteAssetFrom<AssetHubLocation>,
+	IsBridgedConcreteAssetFrom<AssetHubLocation>,
 	// Relaychain (DOT) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,
 	// Assets which the reserve is the same as the origin.

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -40,7 +40,7 @@ use sp_core::{ConstU32, H160, H256};
 
 use xcm_builder::{
 	AccountKey20Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-	AllowTopLevelPaidExecutionFrom, ConvertedConcreteId, DescribeAllTerminal, DescribeFamily,
+	AllowTopLevelPaidExecutionFrom, Case, ConvertedConcreteId, DescribeAllTerminal, DescribeFamily,
 	EnsureXcmOrigin, FungibleAdapter as XcmCurrencyAdapter, FungiblesAdapter, HashedDescription,
 	NoChecking, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
 	SiblingParachainConvertsVia, SignedAccountKey20AsNative, SovereignSignedViaLocation,
@@ -49,16 +49,18 @@ use xcm_builder::{
 
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use xcm::latest::prelude::{
-	Asset, GlobalConsensus, InteriorLocation, Junction, Location, NetworkId, PalletInstance,
-	Parachain,
+	AllOf, Asset, AssetFilter, GlobalConsensus, InteriorLocation, Junction, Location, NetworkId,
+  PalletInstance, Parachain, Wild, WildFungible
 };
+
 use xcm_executor::traits::{CallDispatcher, ConvertLocation, JustTry};
 
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
+	FirstAssetTrader, IsForeginConcreteAAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
+  UtilityEncodeCall, XcmTransact,
 };
 
 use parity_scale_codec::{Decode, Encode};
@@ -247,8 +249,26 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 }
 
 parameter_types! {
+ 	/// Location of Asset Hub
+	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
+	pub const RelayLocation: Location = Location::parent();
+	pub RelayLocationFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: xcm::prelude::AssetId(RelayLocation::get()) });
+	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
+		RelayLocationFilter::get(),
+		AssetHubLocation::get()
+	);
 	pub const MaxAssetsIntoHolding: u32 = xcm_primitives::MAX_ASSETS;
 }
+
+type Reserves = (
+	// Assets bridged from different consensus systems held in reserve on Asset Hub.
+	IsForeignConcreteAssetFrom<AssetHubLocation>,
+	// Relaychain (DOT) from Asset Hub
+	Case<RelayChainNativeAssetFromAssetHub>,
+	// Assets which the reserve is the same as the origin.
+	MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>,
+);
+
 
 // Our implementation of the Moonbeam Call
 // Attachs the right origin in case the call is made to pallet-ethereum-xcm
@@ -269,7 +289,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	// Filter to the reserve withdraw operations
 	// Whenever the reserve matches the relative or absolute value
 	// of our chain, we always return the relative reserve
-	type IsReserve = MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>;
+	type IsReserve =  Reserves;
 	type IsTeleporter = (); // No teleport
 	type UniversalLocation = UniversalLocation;
 	type Barrier = XcmBarrier;

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -252,7 +252,10 @@ parameter_types! {
 	 /// Location of Asset Hub
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
 	pub const RelayLocation: Location = Location::parent();
-	pub RelayLocationFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: xcm::prelude::AssetId(RelayLocation::get()) });
+	pub RelayLocationFilter: AssetFilter = Wild(AllOf {
+	  fun: WildFungible,
+	  id: xcm::prelude::AssetId(RelayLocation::get()),
+  });
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		RelayLocationFilter::get(),
 		AssetHubLocation::get()

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -253,9 +253,9 @@ parameter_types! {
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
 	pub const RelayLocation: Location = Location::parent();
 	pub RelayLocationFilter: AssetFilter = Wild(AllOf {
-	  fun: WildFungible,
-	  id: xcm::prelude::AssetId(RelayLocation::get()),
-  });
+		fun: WildFungible,
+		id: xcm::prelude::AssetId(RelayLocation::get()),
+	});
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		RelayLocationFilter::get(),
 		AssetHubLocation::get()

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -50,7 +50,7 @@ use xcm_builder::{
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use xcm::latest::prelude::{
 	AllOf, Asset, AssetFilter, GlobalConsensus, InteriorLocation, Junction, Location, NetworkId,
-  PalletInstance, Parachain, Wild, WildFungible
+	PalletInstance, Parachain, Wild, WildFungible,
 };
 
 use xcm_executor::traits::{CallDispatcher, ConvertLocation, JustTry};
@@ -60,7 +60,7 @@ use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
 	FirstAssetTrader, IsBridgedConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
-  UtilityEncodeCall, XcmTransact,
+	UtilityEncodeCall, XcmTransact,
 };
 
 use parity_scale_codec::{Decode, Encode};
@@ -249,7 +249,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 }
 
 parameter_types! {
- 	/// Location of Asset Hub
+	 /// Location of Asset Hub
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
 	pub const RelayLocation: Location = Location::parent();
 	pub RelayLocationFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: xcm::prelude::AssetId(RelayLocation::get()) });
@@ -268,7 +268,6 @@ type Reserves = (
 	// Assets which the reserve is the same as the origin.
 	MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>,
 );
-
 
 // Our implementation of the Moonbeam Call
 // Attachs the right origin in case the call is made to pallet-ethereum-xcm
@@ -289,7 +288,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	// Filter to the reserve withdraw operations
 	// Whenever the reserve matches the relative or absolute value
 	// of our chain, we always return the relative reserve
-	type IsReserve =  Reserves;
+	type IsReserve = Reserves;
 	type IsTeleporter = (); // No teleport
 	type UniversalLocation = UniversalLocation;
 	type Barrier = XcmBarrier;

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -40,7 +40,7 @@ use sp_core::{ConstU32, H160, H256};
 
 use xcm_builder::{
 	AccountKey20Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-	AllowTopLevelPaidExecutionFrom, ConvertedConcreteId, DescribeAllTerminal, DescribeFamily,
+	AllowTopLevelPaidExecutionFrom, Case, ConvertedConcreteId, DescribeAllTerminal, DescribeFamily,
 	EnsureXcmOrigin, FungibleAdapter as XcmCurrencyAdapter, FungiblesAdapter, HashedDescription,
 	NoChecking, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
 	SiblingParachainConvertsVia, SignedAccountKey20AsNative, SovereignSignedViaLocation,
@@ -49,16 +49,18 @@ use xcm_builder::{
 
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use xcm::latest::prelude::{
-	Asset, GlobalConsensus, InteriorLocation, Junction, Location, NetworkId, PalletInstance,
-	Parachain,
+	AllOf, Asset, AssetFilter, GlobalConsensus, InteriorLocation, Junction, Location, NetworkId,
+  PalletInstance, Parachain, Wild, WildFungible
 };
+
 use xcm_executor::traits::{CallDispatcher, ConvertLocation, JustTry};
 
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
+	FirstAssetTrader, IsForeignConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
+  UtilityEncodeCall, XcmTransact,
 };
 
 use parity_scale_codec::{Decode, Encode};
@@ -255,8 +257,25 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 }
 
 parameter_types! {
+	/// Location of Asset Hub
+	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
+	pub const RelayLocation: Location = Location::parent();
+	pub RelayLocationFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: xcm::prelude::AssetId(RelayLocation::get()) });
+	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
+		RelayLocationFilter::get(),
+		AssetHubLocation::get()
+	);
 	pub const MaxAssetsIntoHolding: u32 = xcm_primitives::MAX_ASSETS;
 }
+
+type Reserves = (
+	// Assets bridged from different consensus systems held in reserve on Asset Hub.
+	IsForeignConcreteAssetFrom<AssetHubLocation>,
+	// Relaychain (DOT) from Asset Hub
+	Case<RelayChainNativeAssetFromAssetHub>,
+	// Assets which the reserve is the same as the origin.
+	MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>,
+);
 
 // Our implementation of the Moonbeam Call
 // Attachs the right origin in case the call is made to pallet-ethereum-xcm
@@ -277,7 +296,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	// Filter to the reserve withdraw operations
 	// Whenever the reserve matches the relative or absolute value
 	// of our chain, we always return the relative reserve
-	type IsReserve = MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>;
+	type IsReserve = Reserves;
 	type IsTeleporter = (); // No teleport
 	type UniversalLocation = UniversalLocation;
 	type Barrier = XcmBarrier;

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -50,7 +50,7 @@ use xcm_builder::{
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 use xcm::latest::prelude::{
 	AllOf, Asset, AssetFilter, GlobalConsensus, InteriorLocation, Junction, Location, NetworkId,
-  PalletInstance, Parachain, Wild, WildFungible
+	PalletInstance, Parachain, Wild, WildFungible,
 };
 
 use xcm_executor::traits::{CallDispatcher, ConvertLocation, JustTry};
@@ -60,7 +60,7 @@ use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
 	FirstAssetTrader, IsBridgedConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
-  UtilityEncodeCall, XcmTransact,
+	UtilityEncodeCall, XcmTransact,
 };
 
 use parity_scale_codec::{Decode, Encode};

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -260,7 +260,10 @@ parameter_types! {
 	/// Location of Asset Hub
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
 	pub const RelayLocation: Location = Location::parent();
-	pub RelayLocationFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: xcm::prelude::AssetId(RelayLocation::get()) });
+	pub RelayLocationFilter: AssetFilter = Wild(AllOf {
+	  fun: WildFungible,
+	  id: xcm::prelude::AssetId(RelayLocation::get()),
+  });
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		RelayLocationFilter::get(),
 		AssetHubLocation::get()

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -59,7 +59,7 @@ use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToLocation, AsAssetType,
-	FirstAssetTrader, IsForeignConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
+	FirstAssetTrader, IsBridgedConcreteAssetFrom, SignedToAccountId20, UtilityAvailableCalls,
   UtilityEncodeCall, XcmTransact,
 };
 
@@ -270,7 +270,7 @@ parameter_types! {
 
 type Reserves = (
 	// Assets bridged from different consensus systems held in reserve on Asset Hub.
-	IsForeignConcreteAssetFrom<AssetHubLocation>,
+	IsBridgedConcreteAssetFrom<AssetHubLocation>,
 	// Relaychain (DOT) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,
 	// Assets which the reserve is the same as the origin.

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -261,9 +261,9 @@ parameter_types! {
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(1000)]);
 	pub const RelayLocation: Location = Location::parent();
 	pub RelayLocationFilter: AssetFilter = Wild(AllOf {
-	  fun: WildFungible,
-	  id: xcm::prelude::AssetId(RelayLocation::get()),
-  });
+		fun: WildFungible,
+		id: xcm::prelude::AssetId(RelayLocation::get()),
+	});
 	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
 		RelayLocationFilter::get(),
 		AssetHubLocation::get()


### PR DESCRIPTION
### What does it do?
Allows Asset Hub to be a reserve for bridged assets (parents > 2).
Allows Asset Hub to be a reserve for DOT.

### What important points reviewers should know?

> Allows Asset Hub to be a reserve for DOT.

This may be an issue supporting DOT from both the relaychain and Asset Hub. We need to support our Oneclick transfers feature. We can remove this, but then users would need to bridge to Asset Hub and then move the asset from Asset Hub to Moonbeam in a separate step. More info in this forum post: https://forum.polkadot.network/t/managing-sas-on-multiple-reserve-chains-for-same-asset/7538

Important: Does the Moonbeam runtime allow for execution to be paid in DOT?

### Is there something left for follow-up PRs?
We still need to bed down UX .e.g How do users get assets from Asset Hub to Moonbeam and back. This may require follow up PRs.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
Bridging in liquidity from Kusama and Ethereum to Polkadot. Allowing these assets to be used on Dapps on Moonbeam.
