### PR TITLE
fix: auto-compound fail when free balance is too low

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,8 +364,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
-      - run: |
-          mkdir -p target/release
+      - name: Create local folders
+        run: |
+          mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/
+      - name: "Download branch built runtime"
+        uses: actions/download-artifact@v4
+        with:
+          name: runtimes
+          path: target/release/wbuild/${{ matrix.chain }}-runtime/
       - name: "Download branch built node"
         uses: actions/download-artifact@v4
         with:

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -165,7 +165,7 @@ where
 	) -> DispatchResultWithPostInfo {
 		// check that caller can lock the amount before any changes to storage
 		ensure!(
-			<Pallet<T>>::get_delegator_stakable_free_balance(&delegator) >= amount,
+			<Pallet<T>>::get_delegator_stakable_balance(&delegator) >= amount,
 			Error::<T>::InsufficientBalance
 		);
 		ensure!(

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1737,8 +1737,8 @@ pub mod pallet {
 
 		/// Returns an account's stakable balance which is not locked in delegation staking
 		pub fn get_delegator_stakable_balance(acc: &T::AccountId) -> BalanceOf<T> {
-			let mut stakable_balance = T::Currency::free_balance(acc)
-				.saturating_add(T::Currency::reserved_balance(acc));
+			let mut stakable_balance =
+				T::Currency::free_balance(acc).saturating_add(T::Currency::reserved_balance(acc));
 
 			if let Some(state) = <DelegatorState<T>>::get(acc) {
 				stakable_balance = stakable_balance.saturating_sub(state.total());

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -594,10 +594,7 @@ fn geneses() {
 			}
 			// no delegator staking locks
 			assert_eq!(query_lock_amount(7, DELEGATOR_LOCK_ID), None);
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&7),
-				100
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&7), 100);
 			assert_eq!(query_lock_amount(8, DELEGATOR_LOCK_ID), None);
 			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&8), 9);
 			assert_eq!(query_lock_amount(9, DELEGATOR_LOCK_ID), None);
@@ -647,10 +644,7 @@ fn geneses() {
 			for x in 6..11 {
 				assert!(ParachainStaking::is_delegator(&x));
 				assert_eq!(query_lock_amount(x, DELEGATOR_LOCK_ID), Some(10));
-				assert_eq!(
-					ParachainStaking::get_delegator_stakable_balance(&x),
-					90
-				);
+				assert_eq!(ParachainStaking::get_delegator_stakable_balance(&x), 90);
 			}
 		});
 }

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -585,7 +585,7 @@ fn geneses() {
 			// delegators
 			for x in 3..7 {
 				assert!(ParachainStaking::is_delegator(&x));
-				assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&x), 0);
+				assert_eq!(ParachainStaking::get_delegator_stakable_balance(&x), 0);
 				assert_eq!(query_lock_amount(x, DELEGATOR_LOCK_ID), Some(100));
 			}
 			// uninvolved
@@ -595,13 +595,13 @@ fn geneses() {
 			// no delegator staking locks
 			assert_eq!(query_lock_amount(7, DELEGATOR_LOCK_ID), None);
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&7),
+				ParachainStaking::get_delegator_stakable_balance(&7),
 				100
 			);
 			assert_eq!(query_lock_amount(8, DELEGATOR_LOCK_ID), None);
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&8), 9);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&8), 9);
 			assert_eq!(query_lock_amount(9, DELEGATOR_LOCK_ID), None);
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&9), 4);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&9), 4);
 			// no collator staking locks
 			assert_eq!(
 				ParachainStaking::get_collator_stakable_free_balance(&7),
@@ -648,7 +648,7 @@ fn geneses() {
 				assert!(ParachainStaking::is_delegator(&x));
 				assert_eq!(query_lock_amount(x, DELEGATOR_LOCK_ID), Some(10));
 				assert_eq!(
-					ParachainStaking::get_delegator_stakable_free_balance(&x),
+					ParachainStaking::get_delegator_stakable_balance(&x),
 					90
 				);
 			}

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2130,7 +2130,7 @@ fn delegate_reserves_balance() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&2),
+				ParachainStaking::get_delegator_stakable_balance(&2),
 				10
 			);
 			assert_ok!(ParachainStaking::delegate(
@@ -2140,7 +2140,7 @@ fn delegate_reserves_balance() {
 				0,
 				0
 			));
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 0);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 0);
 		});
 }
 
@@ -2598,13 +2598,13 @@ fn delegator_bond_more_reserves_balance() {
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 5);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 5);
 			assert_ok!(ParachainStaking::delegator_bond_more(
 				RuntimeOrigin::signed(2),
 				1,
 				5
 			));
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 0);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 0);
 		});
 }
 
@@ -3071,7 +3071,7 @@ fn execute_revoke_delegation_unreserves_balance() {
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 0);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 0);
 			assert_ok!(ParachainStaking::schedule_revoke_delegation(
 				RuntimeOrigin::signed(2),
 				1
@@ -3083,7 +3083,7 @@ fn execute_revoke_delegation_unreserves_balance() {
 				1
 			));
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&2),
+				ParachainStaking::get_delegator_stakable_balance(&2),
 				10
 			);
 		});
@@ -3320,7 +3320,7 @@ fn delegator_bond_more_after_revoke_delegation_does_not_effect_exit() {
 			));
 			assert!(ParachainStaking::is_delegator(&2));
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&2),
+				ParachainStaking::get_delegator_stakable_balance(&2),
 				10
 			);
 		});
@@ -3387,7 +3387,7 @@ fn delegator_bond_less_after_revoke_delegation_does_not_effect_exit() {
 			);
 			assert!(ParachainStaking::is_delegator(&2));
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&2),
+				ParachainStaking::get_delegator_stakable_balance(&2),
 				22
 			);
 		});
@@ -3403,7 +3403,7 @@ fn execute_delegator_bond_less_unreserves_balance() {
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 0);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 0);
 			assert_ok!(ParachainStaking::schedule_delegator_bond_less(
 				RuntimeOrigin::signed(2),
 				1,
@@ -3415,7 +3415,7 @@ fn execute_delegator_bond_less_unreserves_balance() {
 				2,
 				1
 			));
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 5);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 5);
 		});
 }
 
@@ -5282,11 +5282,11 @@ fn multiple_delegations() {
 			assert_eq!(Balances::locks(&6)[0].amount, 40);
 			assert_eq!(Balances::locks(&7)[0].amount, 90);
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&6),
+				ParachainStaking::get_delegator_stakable_balance(&6),
 				60
 			);
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&7),
+				ParachainStaking::get_delegator_stakable_balance(&7),
 				10
 			);
 			roll_to_round_begin(8);
@@ -5320,11 +5320,11 @@ fn multiple_delegations() {
 				3usize
 			);
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&6),
+				ParachainStaking::get_delegator_stakable_balance(&6),
 				70
 			);
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&7),
+				ParachainStaking::get_delegator_stakable_balance(&7),
 				90
 			);
 		});
@@ -8309,7 +8309,7 @@ fn test_delegate_with_auto_compound_reserves_balance() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(
-				ParachainStaking::get_delegator_stakable_free_balance(&2),
+				ParachainStaking::get_delegator_stakable_balance(&2),
 				10
 			);
 			assert_ok!(ParachainStaking::delegate_with_auto_compound(
@@ -8321,7 +8321,7 @@ fn test_delegate_with_auto_compound_reserves_balance() {
 				0,
 				0,
 			));
-			assert_eq!(ParachainStaking::get_delegator_stakable_free_balance(&2), 0);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 0);
 		});
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2129,10 +2129,7 @@ fn delegate_reserves_balance() {
 		.with_candidates(vec![(1, 30)])
 		.build()
 		.execute_with(|| {
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&2),
-				10
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 10);
 			assert_ok!(ParachainStaking::delegate(
 				RuntimeOrigin::signed(2),
 				1,
@@ -3082,10 +3079,7 @@ fn execute_revoke_delegation_unreserves_balance() {
 				2,
 				1
 			));
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&2),
-				10
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 10);
 		});
 }
 
@@ -3319,10 +3313,7 @@ fn delegator_bond_more_after_revoke_delegation_does_not_effect_exit() {
 				1
 			));
 			assert!(ParachainStaking::is_delegator(&2));
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&2),
-				10
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 10);
 		});
 }
 
@@ -3386,10 +3377,7 @@ fn delegator_bond_less_after_revoke_delegation_does_not_effect_exit() {
 				},
 			);
 			assert!(ParachainStaking::is_delegator(&2));
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&2),
-				22
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 22);
 		});
 }
 
@@ -5281,14 +5269,8 @@ fn multiple_delegations() {
 			);
 			assert_eq!(Balances::locks(&6)[0].amount, 40);
 			assert_eq!(Balances::locks(&7)[0].amount, 90);
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&6),
-				60
-			);
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&7),
-				10
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&6), 60);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&7), 10);
 			roll_to_round_begin(8);
 			roll_blocks(1);
 			assert_ok!(ParachainStaking::execute_leave_candidates(
@@ -5319,14 +5301,8 @@ fn multiple_delegations() {
 					.len(),
 				3usize
 			);
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&6),
-				70
-			);
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&7),
-				90
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&6), 70);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&7), 90);
 		});
 }
 
@@ -8308,10 +8284,7 @@ fn test_delegate_with_auto_compound_reserves_balance() {
 		.with_candidates(vec![(1, 30)])
 		.build()
 		.execute_with(|| {
-			assert_eq!(
-				ParachainStaking::get_delegator_stakable_balance(&2),
-				10
-			);
+			assert_eq!(ParachainStaking::get_delegator_stakable_balance(&2), 10);
 			assert_ok!(ParachainStaking::delegate_with_auto_compound(
 				RuntimeOrigin::signed(2),
 				1,

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -1499,7 +1499,7 @@ impl<
 		match additional_required_balance {
 			BondAdjust::Increase(amount) => {
 				ensure!(
-					<Pallet<T>>::get_delegator_stakable_free_balance(&self.id.clone().into())
+					<Pallet<T>>::get_delegator_stakable_balance(&self.id.clone().into())
 						>= amount.into(),
 					Error::<T>::InsufficientBalance,
 				);

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
@@ -34,13 +34,7 @@ describeSuite({
         await context.createBlock(
           context.polkadotJs().tx.preimage.notePreimage(encodedPreimage).signAsync(baltathar)
         );
-        // Stake some tokens (less than the preimage deposit)
-        const freeBalance = (
-          await context.polkadotJs().query.system.account(BALTATHAR_ADDRESS)
-        ).data.free.toBigInt();
-        console.log(freeBalance);
-
-        // Auto compound
+        // Stake some tokens (less than the preimage deposit) with auto-compound
         const { result } = await context.createBlock(
           context
             .polkadotJs()

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
@@ -59,7 +59,7 @@ describeSuite({
         const rewardDelay = context.polkadotJs().consts.parachainStaking.rewardPaymentDelay;
         await jumpRounds(context, rewardDelay.addn(1).toNumber());
 
-        // The enxt block should reward baltathat and auto-compound his rewards
+        // The next block should reward baltathar and auto-compound his rewards
         const blockHash = (await context.createBlock()).block.hash.toString();
         const events = await getRewardedAndCompoundedEvents(context, blockHash);
         const rewardedEvent = events.rewarded.find(

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
@@ -1,0 +1,87 @@
+import "@moonbeam-network/api-augment";
+import { describeSuite, expect } from "@moonwall/cli";
+import {
+  BALTATHAR_ADDRESS,
+  DEFAULT_GENESIS_BALANCE,
+  MIN_GLMR_DELEGATOR,
+  alith,
+  baltathar,
+  checkBalance,
+} from "@moonwall/util";
+import { blake2AsHex } from "@polkadot/util-crypto";
+import fs from "node:fs";
+import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
+
+describeSuite({
+  id: "D013490",
+  title: "Test auto-compound with reserved balance",
+  foundationMethods: "dev",
+  testCases: ({ context, it }) => {
+    it({
+      id: "T01",
+      title: "should be able to auto-compound with reserved funds only (without free balance)",
+      test: async function () {
+        expect(
+          await checkBalance(context, BALTATHAR_ADDRESS),
+          "Balance should be untouched from genesis amount"
+        ).toBe(DEFAULT_GENESIS_BALANCE);
+
+        // Submit a preimage (to have a reserve that exceed min stake)
+        const wasm = fs.readFileSync("../target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm");
+        const encodedPreimage = `0x${wasm.toString("hex")}`;
+        const encodedHash = blake2AsHex(encodedPreimage);
+        await context.createBlock(
+          context.polkadotJs().tx.preimage.notePreimage(encodedPreimage).signAsync(baltathar)
+        );
+        const reservedBalance = (await context.polkadotJs().query.system.account(BALTATHAR_ADDRESS))
+            .data.reserved.toBigInt();
+
+        // Stake some tokens (less than the preimage deposit)
+        const freeBalance = (await context.polkadotJs().query.system.account(BALTATHAR_ADDRESS))
+          .data.free.toBigInt();
+        console.log(freeBalance);
+
+        // Auto compound
+        const { result } = await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.parachainStaking.delegateWithAutoCompound(
+              alith.address,
+              MIN_GLMR_DELEGATOR,
+              50,
+              0,
+              0,
+              0
+            )
+            .signAsync(baltathar)
+        );
+        expect(result!.successful).to.be.true;
+        const frozenBalance = (await context.polkadotJs().query.system.account(BALTATHAR_ADDRESS))
+        .data.frozen.toBigInt();
+
+        // Withdraw all Baltathar free founds
+        await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.balances.transferAll(alith.address, false)
+            .signAsync(baltathar)
+        );
+
+        // Move forward to rewardDelay rounds
+        const rewardDelay = context.polkadotJs().consts.parachainStaking.rewardPaymentDelay;
+        await jumpRounds(context, rewardDelay.addn(1).toNumber());
+
+        // The enxt block should reward baltathat and auto-compound his rewards
+        const blockHash = (await context.createBlock()).block.hash.toString();
+        const events = await getRewardedAndCompoundedEvents(context, blockHash);
+        const rewardedEvent = events.rewarded.find(({ account }: any) => account === baltathar.address);
+        const compoundedEvent = events.compounded.find(
+          ({ delegator }: any) => delegator === baltathar.address
+        );
+
+        expect(rewardedEvent, "delegator was not rewarded").to.not.be.undefined;
+        expect(compoundedEvent, "delegator reward was not auto-compounded").to.not.be.undefined;
+      },
+    });
+  },
+});

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
@@ -26,25 +26,15 @@ describeSuite({
           "Balance should be untouched from genesis amount"
         ).toBe(DEFAULT_GENESIS_BALANCE);
 
-        // Submit a preimage
-        const encodedProposal =
-          context
-            .polkadotJs()
-            .tx.parachainStaking.setParachainBondAccount(
-              privateKeyToAccount(generatePrivateKey()).address
-            )
-            .method.toHex() || "";
-        await context.createBlock(context.polkadotJs().tx.preimage.notePreimage(encodedProposal));
-        /*const runtimePath = (await MoonwallContext.getContext()).rtUpgradePath;
-        if (!runtimePath) {
-          throw new Error("Runtime upgrade path not set");
-        }
-        const wasm = fs.readFileSync(runtimePath);
+        // Submit a huge preimage (to have a deposit greather than the satked amount)
+        const wasm = fs.readFileSync(
+          "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm"
+        );
         const encodedPreimage = `0x${wasm.toString("hex")}`;
-        //const encodedHash = blake2AsHex(encodedPreimage);
         await context.createBlock(
           context.polkadotJs().tx.preimage.notePreimage(encodedPreimage).signAsync(baltathar)
-        );*/
+        );
+
         // Stake some tokens (less than the preimage deposit) with auto-compound
         const { result } = await context.createBlock(
           context

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
@@ -25,7 +25,7 @@ describeSuite({
           "Balance should be untouched from genesis amount"
         ).toBe(DEFAULT_GENESIS_BALANCE);
 
-        // Submit a huge preimage (to have a deposit greather than the satked amount)
+        // Submit a huge preimage (to have a deposit greater than the staked amount)
         const wasm = fs.readFileSync(
           "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm"
         );

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
@@ -1,5 +1,5 @@
 import "@moonbeam-network/api-augment";
-import { MoonwallContext, describeSuite, expect } from "@moonwall/cli";
+import { describeSuite, expect } from "@moonwall/cli";
 import {
   BALTATHAR_ADDRESS,
   DEFAULT_GENESIS_BALANCE,
@@ -10,7 +10,6 @@ import {
 } from "@moonwall/util";
 import fs from "node:fs";
 import { jumpRounds, getRewardedAndCompoundedEvents } from "../../../../helpers";
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 describeSuite({
   id: "D013490",


### PR DESCRIPTION
### What does it do?

This PR fix a bug that impact the auto-compound of staking rewards and add a dev test to reproduce the bug. 

The bug is that the auto-compound logic check if stakable amount is high enough, but this check doesn't take into account the reserve, so in some corner cases the auto-compound fail silently, then the user receive less staking rewards than expected.

Old buggy logic: stakable amount is `free- frozen`
New logic (fix): stakable amount is `free + reserve - frozen`

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
