### PR TITLE
Remove deployment to Purestake docker-hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,17 +528,6 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Tag it with purestake for 6 month
-        run: |
-          PURESTAKE_TAG=`echo "${{ steps.prep.outputs.tags }}" | sed 's/moonbeamfoundation/purestake/'`
-          docker pull ${{ steps.prep.outputs.tags }}
-          docker tag ${{ steps.prep.outputs.tags }} $PURESTAKE_TAG
-          docker push $PURESTAKE_TAG
 
   chopsticks-upgrade-test:
     runs-on:

--- a/.github/workflows/prepare-binary.yml
+++ b/.github/workflows/prepare-binary.yml
@@ -96,14 +96,4 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Tag it with purestake for 6 month
-        run: |
-          PURESTAKE_TAG=`echo "${{ steps.prep.outputs.tags }}" | sed 's/moonbeamfoundation/purestake/'`
-          docker pull ${{ steps.prep.outputs.tags }}
-          docker tag ${{ steps.prep.outputs.tags }} $PURESTAKE_TAG
-          docker push $PURESTAKE_TAG
+

--- a/.github/workflows/prepare-binary.yml
+++ b/.github/workflows/prepare-binary.yml
@@ -96,4 +96,3 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-

--- a/.github/workflows/publish-docker-runtime.yml
+++ b/.github/workflows/publish-docker-runtime.yml
@@ -30,4 +30,3 @@ jobs:
           docker pull "${DOCKER_IMAGE}:${SHA}"
           docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${DOCKER_TAG}"
           docker push "${DOCKER_IMAGE}:${DOCKER_TAG}"
-

--- a/.github/workflows/publish-docker-runtime.yml
+++ b/.github/workflows/publish-docker-runtime.yml
@@ -31,18 +31,3 @@ jobs:
           docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${DOCKER_TAG}"
           docker push "${DOCKER_IMAGE}:${DOCKER_TAG}"
 
-      - name: Login to Purestake DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Publish runtime docker image
-        run: |
-          DOCKER_IMAGE=purestake/moonbeam
-          DOCKER_TAG="${{ github.event.inputs.tag }}"
-          COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }}'`
-          SHA=sha-${COMMIT::8}
-          echo tagging "${DOCKER_IMAGE}:${SHA}"
-          docker pull "${DOCKER_IMAGE}:${SHA}"
-          docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${DOCKER_TAG}"
-          docker push "${DOCKER_IMAGE}:${DOCKER_TAG}"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -57,4 +57,3 @@ jobs:
             docker tag "${DOCKER_IMAGE}:${VERSION}" "${DOCKER_IMAGE}:latest"
             docker push "${DOCKER_IMAGE}:latest"
           fi
-

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -57,45 +57,4 @@ jobs:
             docker tag "${DOCKER_IMAGE}:${VERSION}" "${DOCKER_IMAGE}:latest"
             docker push "${DOCKER_IMAGE}:latest"
           fi
-      - name: Login to Purestake DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: |
-          DOCKER_IMAGE=purestake/moonbeam
-          VERSION="${{ github.event.inputs.tag }}"
-          COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }}'`
-          SHA=sha-${COMMIT::8}
-          echo using "${DOCKER_IMAGE}:${SHA} as base image"
 
-          mkdir -p build 
-          wget https://github.com/moonbeam-foundation/moonbeam/releases/download/$VERSION/moonbeam -O build/moonbeam
-          wget https://github.com/moonbeam-foundation/moonbeam/releases/download/$VERSION/moonbeam-skylake -O build/moonbeam-skylake
-          wget https://github.com/moonbeam-foundation/moonbeam/releases/download/$VERSION/moonbeam-znver3 -O build/moonbeam-znver3
-
-          echo building "${DOCKER_IMAGE}:${VERSION}"
-          docker build \
-            --build-arg DOCKER_IMAGE="$DOCKER_IMAGE" \
-            --build-arg SHA="$SHA" \
-            -f docker/moonbeam-release.Dockerfile \
-            -t "${DOCKER_IMAGE}:${VERSION}" \
-            . 
-
-          docker push "${DOCKER_IMAGE}:${VERSION}"
-
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            MINOR=${VERSION%.*}
-            echo tagging "${DOCKER_IMAGE}:${MINOR}"
-            docker tag "${DOCKER_IMAGE}:${VERSION}" "${DOCKER_IMAGE}:${MINOR}"
-            docker push "${DOCKER_IMAGE}:${MINOR}"
-
-            MAJOR=${MINOR%.*}
-            echo tagging "${DOCKER_IMAGE}:${MAJOR}"
-            docker tag "${DOCKER_IMAGE}:${VERSION}" "${DOCKER_IMAGE}:${MAJOR}"
-            docker push "${DOCKER_IMAGE}:${MAJOR}"
-
-            echo tagging "${DOCKER_IMAGE}:latest"
-            docker tag "${DOCKER_IMAGE}:${VERSION}" "${DOCKER_IMAGE}:latest"
-            docker push "${DOCKER_IMAGE}:latest"
-          fi


### PR DESCRIPTION
### What does it do?

This PR removes Github Actions workflow's steps that deployed releases to Purestake's dockerhub account.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
