### PR TITLE
CI: Add uncompressed runtimes to the artifact during Build step

### DIFF
--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -67,7 +67,8 @@ runs:
       run: |
         mkdir -p runtimes
         cp target/release/wbuild/moon*/moon*_runtime.compact.compressed.wasm runtimes/;
-        cp target/release/wbuild/moon*/moon*_runtime.wasm runtimes/;
+        mkdir -p uncompressed-runtimes;
+        cp target/release/wbuild/moon*/moon*_runtime.wasm uncompressed-runtimes/;
     - name: Save moonbeam binary
       shell: bash
       run: |

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -67,6 +67,7 @@ runs:
       run: |
         mkdir -p runtimes
         cp target/release/wbuild/moon*/moon*_runtime.compact.compressed.wasm runtimes/;
+        cp target/release/wbuild/moon*/moon*_runtime.wasm runtimes/;
     - name: Save moonbeam binary
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,6 +309,11 @@ jobs:
         with:
           name: runtimes
           path: runtimes
+      - name: Upload uncompressed runtimes
+        uses: actions/upload-artifact@v4
+        with:
+          name: uncompressed-runtimes
+          path: uncompressed-runtimes
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### What does it do?

This change makes uncompressed runtimes available in the the `runtimes` artifact for workflows to use.

### What important points reviewers should know?

This change is required to implement WASM difference checks between PR builds and the target branch. WASM blob analysis cannot be done using compressed compact WASM blobs.

### Is there something left for follow-up PRs?

Following PR will implement the difference check by making use of the newly available uncompressed runtimes. Having them available will ease development.

### What alternative implementations were considered?

It was considered to re-build the required WASM runtimes during a new workflow, but considering the build process already creates the required files, it seem better to just make use of it by adding them to the artifact.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
