### PR TITLE
Fix ci node launch parameters

### DIFF
--- a/.github/workflows/subxt-diff.yml
+++ b/.github/workflows/subxt-diff.yml
@@ -59,6 +59,7 @@ jobs:
           --no-prometheus \
           --unsafe-rpc-external \
           --alice \
+          --unsafe-force-node-key-generation \
           --rpc-port=9911 \
           --tmp
 
@@ -79,6 +80,7 @@ jobs:
           --unsafe-rpc-external \
           --alice \
           --rpc-port=9977 \
+          --unsafe-force-node-key-generation \
           --tmp & sleep 2' &
 
       - name: Run Diffs

--- a/.github/workflows/upgrade-typescript-api.yml
+++ b/.github/workflows/upgrade-typescript-api.yml
@@ -16,8 +16,7 @@ jobs:
           ref: runtime-${{ github.event.inputs.spec_version }}
       - name: Retrieve moonbeam binary
         run: |
-          COMMIT_SHA8=$(git log -1 --format="%H" | cut -c1-8)
-          DOCKER_TAG="moonbeamfoundation/moonbeam:sha-$COMMIT_SHA8"
+          DOCKER_TAG="moonbeamfoundation/moonbeam:runtime-${{ github.event.inputs.spec_version }}"
           # Clear the dummy container if it wasn't properly cleaned up
           docker rm -f dummy 2> /dev/null
           docker create -ti --name dummy $DOCKER_TAG bash
@@ -54,5 +53,5 @@ jobs:
           commit-message: typescript API v0.${{ github.event.inputs.spec_version }}.0
           draft: true
           title: "Upgrade typescript API for runtime-${{ github.event.inputs.spec_version }}"
-          reviewers: "librelois,noandrea,timbrinded"
+          reviewers: "moonsong-coredev"
           labels: "B0-silent,D2-notlive"

--- a/typescript-api/scripts/runtime-upgrade.sh
+++ b/typescript-api/scripts/runtime-upgrade.sh
@@ -26,7 +26,13 @@ npm install
 # Get runtimes metadata
 for CHAIN in ${CHAINS[@]}; do
   echo "Starting $CHAIN node"
-  ../build/moonbeam --no-hardware-benchmarks --no-telemetry --no-prometheus --alice --tmp --chain=$CHAIN-dev --wasm-execution=interpreted-i-know-what-i-do --rpc-port=9933 &> /tmp/node-$CHAIN-start.log &
+  ../build/moonbeam \
+    --no-hardware-benchmarks \
+    --unsafe-force-node-key-generation \
+    --no-telemetry --no-prometheus --alice \
+    --tmp --chain=$CHAIN-dev \
+    --wasm-execution=interpreted-i-know-what-i-do \
+    --rpc-port=9933 &> /tmp/node-$CHAIN-start.log &
   PID=$!
   echo "Waiting node..."
   ( tail -f -n0 /tmp/node-$CHAIN-start.log & ) | grep -q 'Running JSON-RPC server'


### PR DESCRIPTION
### What does it do?

Polkadot-SDK v1.11.0 (used in moonbeam client 0.39.0) does not automatically generates node keys and requires the `--unsafe-force-node-key-generation` to run.

This PR adds the parameter for de subext and typescript api jobs


### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
