### PR TITLE
Fix smoke tests S16C100 & S25C1200

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -103,6 +103,7 @@ export const ForeignChainsEndpoints = [
       {
         name: "Heiko",
         paraId: 2085,
+        mutedUntil: new Date("2024-10-01").getTime(),
       },
       {
         name: "Picasso",

--- a/test/suites/smoke/test-polkadot-decoding.ts
+++ b/test/suites/smoke/test-polkadot-decoding.ts
@@ -52,7 +52,7 @@ describeSuite({
                   pageSize,
                   startKey,
                 });
-              } else {
+              } else if (fn != "code") {
                 await module[fn]();
               }
 


### PR DESCRIPTION
### What does it do?

Fix 2 smoke tests failures:

* S16C100: a smoke test that try to decode all storage item timeout to fetch the runtime bytecode value, but it doesn't make sense to fetch to runtime bytecode because it's not SCALE encoded
* S25C1200: Parallel Heiko parachain was off board on kusama, this PR silent the alert for 2 month (if on 2 months they don't onboard again we will ask moonbeam community to close the HRMP channel)

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
