### PR TITLE
test/smoke: Add randomization to polkadot-decoding smoke test

### DIFF
--- a/test/suites/smoke/test-polkadot-decoding.ts
+++ b/test/suites/smoke/test-polkadot-decoding.ts
@@ -7,6 +7,64 @@ import { fail } from "assert";
 
 const pageSize = (process.env.PAGE_SIZE && parseInt(process.env.PAGE_SIZE)) || 500;
 
+const extractStorageKeyComponents = (storageKey: string) => {
+  // The full storage key is composed of
+  // - The 0x prefix (2 characters)
+  // - The module prefix (32 characters)
+  // - The method name (32 characters)
+  // - The parameters (variable length)
+  const moduleKey = storageKey.substring(0, 2 + 32); // Includes the 0x prefix
+  const fnKey = storageKey.substring(2 + 32, 2 + 32 + 32);
+  const paramsKey = storageKey.substring(2 + 32 + 32);
+  return {
+    moduleKey,
+    fnKey,
+    paramsKey,
+  };
+};
+
+// A PRNG used for generating random numbers in a deterministic way
+class SeededPRNG {
+  private seed: number;
+  private modulus: number;
+  private multiplier: number;
+  private increment: number;
+
+  constructor(seed: number) {
+    this.seed = seed;
+    this.modulus = 2 ** 31 - 1; // A large prime number
+    this.multiplier = 48271; // A commonly used multiplier
+    this.increment = 0; // Increment is often set to 0 in LCG
+  }
+
+  // Get the current seed
+  public getSeed(): number {
+    return this.seed;
+  }
+
+  // Generate the next random number
+  private next(): number {
+    this.seed = (this.multiplier * this.seed + this.increment) % this.modulus;
+    return this.seed;
+  }
+
+  // Get a random number within a range [min, max)
+  public randomInRange(min: number, max: number): number {
+    const randomValue = this.next() / this.modulus;
+    return Math.floor(randomValue * (max - min) + min);
+  }
+
+  // Get a random hex string of a given length
+  public randomHex(length: number): string {
+    const hexChars = "0123456789abcdef";
+    let result = "";
+    for (let i = 0; i < length; i++) {
+      result += hexChars[this.randomInRange(0, hexChars.length)];
+    }
+    return result;
+  }
+}
+
 // TODO: This test case really spams the logs, we should find a way to make it less verbose
 describeSuite({
   id: "S16",
@@ -17,12 +75,16 @@ describeSuite({
     let apiAt: ApiDecoration<"promise">;
     let specVersion: number = 0;
     let paraApi: ApiPromise;
+    let PRNG = new SeededPRNG(42);
 
     beforeAll(async function () {
       paraApi = context.polkadotJs("para");
       atBlockNumber = (await paraApi.rpc.chain.getHeader()).number.toNumber();
       apiAt = await paraApi.at(await paraApi.rpc.chain.getBlockHash(atBlockNumber));
       specVersion = apiAt.consts.system.version.specVersion.toNumber();
+      // Initialize PRNG with current timestamp
+      PRNG = new SeededPRNG(new Date().getTime());
+      log(`Initializing PRNG with seed "${PRNG.getSeed()}"`);
     });
 
     // This test simply load all the storage items to make sure they can be loaded.
@@ -33,6 +95,8 @@ describeSuite({
       title: "should be decodable",
       timeout: ONE_HOURS,
       test: async function () {
+        let currentStartKey = "";
+        let currentSeed = PRNG.getSeed();
         const modules = Object.keys(paraApi.query);
         for (const moduleName of modules) {
           log(`  - ${moduleName}`);
@@ -43,22 +107,68 @@ describeSuite({
             const keys = Object.keys(module[fn]);
             try {
               if (keys.includes("keysPaged")) {
-                const startKey = "";
-                // Trying to decode all storage entries may cause the node to timeout, decoding
-                // the first storage entries should be enough to verify if a storage migration
-                // was missed.
-                await module[fn].entriesPaged({
+                // Generate a first query with an empty startKey
+                currentStartKey = "";
+                const emptyKeyEntries = await module[fn].entriesPaged({
                   args: [],
                   pageSize,
-                  startKey,
+                  startKey: currentStartKey,
                 });
+
+                // Skip if no entries are found
+                if (emptyKeyEntries.length === 0) {
+                  log(`     - ${fn}:  ${chalk.green(`✔ No entries found`)}`);
+                  continue;
+                }
+                // Skip if all entries are checked
+                if (emptyKeyEntries.length < pageSize) {
+                  log(
+                    `     - ${fn}:  ${chalk.green(
+                      `✔ All ${emptyKeyEntries.length} entries checked`
+                    )}`
+                  );
+                  continue;
+                }
+                // Log emptyKeyFirstEntry
+                const emptyKeyFirstEntryKey = emptyKeyEntries[0][0].toString();
+                log(`     - ${fn}:  ${chalk.green(`🔎`)} (first key : ${emptyKeyFirstEntryKey})`);
+
+                // If there are more entries, perform a random check
+                // 1. Get the first entry storage key
+                const firstEntry = emptyKeyEntries[0];
+                const storageKey = firstEntry[0].toString();
+
+                // 2. Extract the module, fn and params keys
+                const { moduleKey, fnKey, paramsKey } = extractStorageKeyComponents(storageKey);
+
+                // 3. Generate a random startKey
+                // Overwrite the PRNG seed to check particular cases by
+                // uncommenting the following line
+                // PRNG = new SeededPRNG(42);
+                currentSeed = PRNG.getSeed();
+                currentStartKey = moduleKey + fnKey + PRNG.randomHex(paramsKey.length);
+
+                // 4. Fetch the storage entries with the random startKey
+                // Trying to decode all storage entries may cause the node to timeout, decoding
+                // random storage entries should be enough to verify if a storage migration
+                // was missed.
+                const randomEntries = await module[fn].entriesPaged({
+                  args: [],
+                  pageSize,
+                  startKey: currentStartKey,
+                });
+                // Log first entry storage key
+                const firstRandomEntryKey = randomEntries[0][0].toString();
+                log(`     - ${fn}:  ${chalk.green(`🔎`)} (random key: ${firstRandomEntryKey})`);
               } else if (fn != "code") {
                 await module[fn]();
               }
 
               log(`     - ${fn}:  ${chalk.green(`✔`)}`);
             } catch (e) {
-              const msg = chalk.red(`Failed to fetch storage at (${moduleName}::${fn})`);
+              const msg = chalk.red(
+                `Failed to fetch storage at (${moduleName}::${fn}) using seed "${PRNG.getSeed()}" and startKey "${currentStartKey}"`
+              );
               log(msg, e);
               fail(msg);
             }

--- a/test/suites/smoke/test-polkadot-decoding.ts
+++ b/test/suites/smoke/test-polkadot-decoding.ts
@@ -166,9 +166,9 @@ describeSuite({
 
               log(`     - ${fn}:  ${chalk.green(`✔`)}`);
             } catch (e) {
-              const msg = chalk.red(
-                `Failed to fetch storage at (${moduleName}::${fn}) using seed "${PRNG.getSeed()}" and startKey "${currentStartKey}"`
-              );
+              const failMsg = `Failed to fetch storage at (${moduleName}::${fn}) `;
+              const PRNGDetails = `using seed "${currentSeed}" and startKey "${currentStartKey}"`;
+              const msg = chalk.red(`${failMsg} ${PRNGDetails}`);
               log(msg, e);
               fail(msg);
             }

--- a/test/suites/smoke/test-polkadot-decoding.ts
+++ b/test/suites/smoke/test-polkadot-decoding.ts
@@ -13,9 +13,14 @@ const extractStorageKeyComponents = (storageKey: string) => {
   // - The module prefix (32 characters)
   // - The method name (32 characters)
   // - The parameters (variable length)
-  const moduleKey = storageKey.substring(0, 2 + 32); // Includes the 0x prefix
-  const fnKey = storageKey.substring(2 + 32, 2 + 32 + 32);
-  const paramsKey = storageKey.substring(2 + 32 + 32);
+  const regex = /(?<moduleKey>0x[a-f0-9]{32})(?<fnKey>[a-f0-9]{32})(?<paramsKey>[a-f0-9]*)/i;
+  const match = regex.exec(storageKey);
+
+  if (!match) {
+    throw new Error("Invalid storage key format");
+  }
+
+  const { moduleKey, fnKey, paramsKey } = match.groups!;
   return {
     moduleKey,
     fnKey,


### PR DESCRIPTION
### What does it do?

This PR replaces the naive consistency check that only verified the first 500 entries of each module's method. The new test picks a random storage key and then verifies 500 entries from that starting point. Now, every time the test runs, it will check a different portion of the storage.

### What important points reviewers should know?

There is an extra log at lines L132-L134 that is kept for reviewing purposes. It allows checking that the randomly generated storage keys actually make the test access different entries (not only the first one). This log could be removed once we are confident about how the new test works.

### Is there something left for follow-up PRs?

There already was a TODO in the code stating that we should reduce the log spamming of this particular test. The change adds up to the log spamming. If it turns out to be a problem, we could refactor the test in order to make it less verbose.

### What alternative implementations were considered?

Aside from this implementation, particular storage items and modules could be randomly tested by generating sensible inputs (for example creating a random wallet and deriving the storage key for `system::accounts` from it) or looking into the chain for past events and using those as inputs.

After some research this was a better solution for general purpose storage checks without developing custom storage key generators for particular modules.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
