### PR TITLE
Fix auto-pause xcm: incoming XCMP messages where dropped when auto-pause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,21 +6005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manual-xcm-rpc"
-version = "0.1.0"
-dependencies = [
- "cumulus-primitives-core",
- "flume 0.10.14",
- "futures 0.3.30",
- "hex-literal 0.3.4",
- "jsonrpsee",
- "parity-scale-codec",
- "staging-xcm",
- "tokio",
- "xcm-primitives 0.1.1",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6549,6 +6534,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "moonbeam-dev-rpc"
+version = "0.1.0"
+dependencies = [
+ "cumulus-primitives-core",
+ "flume 0.10.14",
+ "futures 0.3.30",
+ "hex-literal 0.3.4",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "staging-xcm",
+ "tokio",
+ "xcm-primitives 0.1.1",
+]
+
+[[package]]
 name = "moonbeam-evm-tracer"
 version = "0.1.0"
 dependencies = [
@@ -7057,11 +7057,11 @@ dependencies = [
  "jsonrpsee",
  "libsecp256k1",
  "log",
- "manual-xcm-rpc",
  "maplit",
  "moonbase-runtime",
  "moonbeam-cli-opt",
  "moonbeam-core-primitives",
+ "moonbeam-dev-rpc",
  "moonbeam-finality-rpc",
  "moonbeam-primitives-ext",
  "moonbeam-relay-encoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -7692,7 +7692,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8268,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8307,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -14900,7 +14900,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -18636,7 +18636,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#509c4f44bb49dab0d3dda640a936ac047e109972"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-v1.11.0#597e9e5fcbffa1b2436eaf4b9dc436c0b96708f6"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7252,6 +7252,7 @@ dependencies = [
  "pallet-collective",
  "pallet-conviction-voting",
  "pallet-crowdloan-rewards",
+ "pallet-emergency-para-xcm",
  "pallet-erc20-xcm-bridge",
  "pallet-ethereum",
  "pallet-ethereum-xcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6843,6 +6843,7 @@ dependencies = [
  "pallet-collective",
  "pallet-conviction-voting",
  "pallet-crowdloan-rewards",
+ "pallet-emergency-para-xcm",
  "pallet-erc20-xcm-bridge",
  "pallet-ethereum",
  "pallet-ethereum-xcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 exclude = ["bin/utils/moonkey"]
 members = [
 	"bin/utils/moonkey",
+	"client/rpc/dev",
 	"client/rpc/finality",
-	"client/rpc/manual-xcm",
 	"client/vrf",
 	"node",
 	"node/cli",
@@ -117,8 +117,8 @@ moonbeam-cli = { path = "node/cli", default-features = false }
 moonbeam-cli-opt = { path = "node/cli-opt", default-features = false }
 moonbeam-service = { path = "node/service", default-features = false }
 
-manual-xcm-rpc = { path = "client/rpc/manual-xcm" }
 moonbeam-client-evm-tracing = { path = "client/evm-tracing" }
+moonbeam-dev-rpc = { path = "client/rpc/dev" }
 moonbeam-finality-rpc = { path = "client/rpc/finality" }
 moonbeam-rpc-core-debug = { path = "client/rpc-core/debug" }
 moonbeam-rpc-core-trace = { path = "client/rpc-core/trace" }

--- a/client/rpc/dev/Cargo.toml
+++ b/client/rpc/dev/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "manual-xcm-rpc"
+name = "moonbeam-dev-rpc"
 authors = { workspace = true }
 edition = "2021"
 homepage = "https://moonbeam.network"

--- a/client/rpc/dev/src/lib.rs
+++ b/client/rpc/dev/src/lib.rs
@@ -13,6 +13,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
 use cumulus_primitives_core::ParaId;
 use cumulus_primitives_core::XcmpMessageFormat;
 use jsonrpsee::{
@@ -28,12 +29,10 @@ use xcm::opaque::lts::Weight;
 use xcm::v4::prelude::*;
 use xcm_primitives::DEFAULT_PROOF_SIZE;
 
-/// This RPC interface is used to manually submit XCM messages that will be injected into a
-/// parachain-enabled runtime. This allows testing XCM logic in a controlled way in integration
-/// tests.
+/// This RPC interface is used to provide methods in dev mode only
 #[rpc(server)]
 #[jsonrpsee::core::async_trait]
-pub trait ManualXcmApi {
+pub trait DevApi {
 	/// Inject a downward xcm message - A message that comes from the relay chain.
 	/// You may provide an arbitrary message, or if you provide an emtpy byte array,
 	/// Then a default message (DOT transfer down to ALITH) will be injected
@@ -55,13 +54,13 @@ pub trait ManualXcmApi {
 	async fn inject_hrmp_message(&self, sender: ParaId, message: Vec<u8>) -> RpcResult<()>;
 }
 
-pub struct ManualXcm {
+pub struct DevRpc {
 	pub downward_message_channel: flume::Sender<Vec<u8>>,
 	pub hrmp_message_channel: flume::Sender<(ParaId, Vec<u8>)>,
 }
 
 #[jsonrpsee::core::async_trait]
-impl ManualXcmApiServer for ManualXcm {
+impl DevApiServer for DevRpc {
 	async fn inject_downward_message(&self, msg: Vec<u8>) -> RpcResult<()> {
 		let downward_message_channel = self.downward_message_channel.clone();
 		// If no message is supplied, inject a default one.

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { workspace = true, features = ["macros", "sync"] }
 trie-root = { workspace = true }
 
 # Moonbeam
-manual-xcm-rpc = { workspace = true }
+moonbeam-dev-rpc = { workspace = true }
 moonbeam-cli-opt = { workspace = true }
 moonbeam-core-primitives = { workspace = true }
 moonbeam-finality-rpc = { workspace = true }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1269,7 +1269,12 @@ where
 		// Create channels for mocked XCM messages.
 		let (downward_xcm_sender, downward_xcm_receiver) = flume::bounded::<Vec<u8>>(100);
 		let (hrmp_xcm_sender, hrmp_xcm_receiver) = flume::bounded::<(ParaId, Vec<u8>)>(100);
-		dev_rpc_data = Some((downward_xcm_sender, hrmp_xcm_sender));
+		let additional_relay_offset = Arc::new(std::sync::atomic::AtomicU32::new(0));
+		dev_rpc_data = Some((
+			downward_xcm_sender,
+			hrmp_xcm_sender,
+			additional_relay_offset.clone(),
+		));
 
 		let client_clone = client.clone();
 		let keystore_clone = keystore_container.keystore().clone();
@@ -1304,6 +1309,7 @@ where
 					let maybe_current_para_head = client_set_aside_for_cidp.expect_header(block);
 					let downward_xcm_receiver = downward_xcm_receiver.clone();
 					let hrmp_xcm_receiver = hrmp_xcm_receiver.clone();
+					let additional_relay_offset = additional_relay_offset.clone();
 
 					let client_for_xcm = client_set_aside_for_cidp.clone();
 					async move {
@@ -1324,7 +1330,8 @@ where
 						let mocked_parachain = MockValidationDataInherentDataProvider {
 							current_para_block,
 							current_para_block_head,
-							relay_offset: 1000,
+							relay_offset: 1000
+								+ additional_relay_offset.load(std::sync::atomic::Ordering::SeqCst),
 							relay_blocks_per_para_block: 2,
 							// TODO: Recheck
 							para_blocks_per_relay_epoch: 10,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -774,7 +774,7 @@ where
 				fee_history_cache: fee_history_cache.clone(),
 				network: network.clone(),
 				sync: sync.clone(),
-				xcm_senders: None,
+				dev_rpc_data: None,
 				block_data_cache: block_data_cache.clone(),
 				overrides: overrides.clone(),
 				forced_parent_hashes,
@@ -1204,7 +1204,7 @@ where
 	let overrides = Arc::new(StorageOverrideHandler::new(client.clone()));
 	let fee_history_limit = rpc_config.fee_history_limit;
 	let mut command_sink = None;
-	let mut xcm_senders = None;
+	let mut dev_rpc_data = None;
 	let collator = config.role.is_authority();
 
 	if collator {
@@ -1269,7 +1269,7 @@ where
 		// Create channels for mocked XCM messages.
 		let (downward_xcm_sender, downward_xcm_receiver) = flume::bounded::<Vec<u8>>(100);
 		let (hrmp_xcm_sender, hrmp_xcm_receiver) = flume::bounded::<(ParaId, Vec<u8>)>(100);
-		xcm_senders = Some((downward_xcm_sender, hrmp_xcm_sender));
+		dev_rpc_data = Some((downward_xcm_sender, hrmp_xcm_sender));
 
 		let client_clone = client.clone();
 		let keystore_clone = keystore_container.keystore().clone();
@@ -1440,7 +1440,7 @@ where
 				fee_history_cache: fee_history_cache.clone(),
 				network: network.clone(),
 				sync: sync.clone(),
-				xcm_senders: xcm_senders.clone(),
+				dev_rpc_data: dev_rpc_data.clone(),
 				overrides: overrides.clone(),
 				block_data_cache: block_data_cache.clone(),
 				forced_parent_hashes: None,

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -130,7 +130,7 @@ pub struct FullDeps<C, P, A: ChainApi, BE> {
 	/// Fee history cache.
 	pub fee_history_cache: FeeHistoryCache,
 	/// Channels for manual xcm messages (downward, hrmp)
-	pub xcm_senders: Option<(flume::Sender<Vec<u8>>, flume::Sender<(ParaId, Vec<u8>)>)>,
+	pub dev_rpc_data: Option<(flume::Sender<Vec<u8>>, flume::Sender<(ParaId, Vec<u8>)>)>,
 	/// Ethereum data access overrides.
 	pub overrides: Arc<dyn StorageOverride<Block>>,
 	/// Cache for Ethereum block data.
@@ -173,7 +173,7 @@ where
 		Eth, EthApiServer, EthFilter, EthFilterApiServer, EthPubSub, EthPubSubApiServer, Net,
 		NetApiServer, Web3, Web3ApiServer,
 	};
-	use manual_xcm_rpc::{ManualXcm, ManualXcmApiServer};
+	use moonbeam_dev_rpc::{DevApiServer, DevRpc};
 	use moonbeam_finality_rpc::{MoonbeamFinality, MoonbeamFinalityApiServer};
 	use moonbeam_rpc_debug::{Debug, DebugServer};
 	use moonbeam_rpc_trace::{Trace, TraceServer};
@@ -198,7 +198,7 @@ where
 		max_past_logs,
 		fee_history_limit,
 		fee_history_cache,
-		xcm_senders,
+		dev_rpc_data,
 		overrides,
 		block_data_cache,
 		forced_parent_hashes,
@@ -318,9 +318,9 @@ where
 		)?;
 	};
 
-	if let Some((downward_message_channel, hrmp_message_channel)) = xcm_senders {
+	if let Some((downward_message_channel, hrmp_message_channel)) = dev_rpc_data {
 		io.merge(
-			ManualXcm {
+			DevRpc {
 				downward_message_channel,
 				hrmp_message_channel,
 			}

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -130,7 +130,11 @@ pub struct FullDeps<C, P, A: ChainApi, BE> {
 	/// Fee history cache.
 	pub fee_history_cache: FeeHistoryCache,
 	/// Channels for manual xcm messages (downward, hrmp)
-	pub dev_rpc_data: Option<(flume::Sender<Vec<u8>>, flume::Sender<(ParaId, Vec<u8>)>)>,
+	pub dev_rpc_data: Option<(
+		flume::Sender<Vec<u8>>,
+		flume::Sender<(ParaId, Vec<u8>)>,
+		Arc<std::sync::atomic::AtomicU32>,
+	)>,
 	/// Ethereum data access overrides.
 	pub overrides: Arc<dyn StorageOverride<Block>>,
 	/// Cache for Ethereum block data.
@@ -318,11 +322,14 @@ where
 		)?;
 	};
 
-	if let Some((downward_message_channel, hrmp_message_channel)) = dev_rpc_data {
+	if let Some((downward_message_channel, hrmp_message_channel, additional_relay_offset)) =
+		dev_rpc_data
+	{
 		io.merge(
 			DevRpc {
 				downward_message_channel,
 				hrmp_message_channel,
+				additional_relay_offset,
 			}
 			.into_rpc(),
 		)?;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -760,7 +760,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type SelfParaId = ParachainInfo;
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
-	type XcmpMessageHandler = EmergencyParaXcm;
+	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
 	type CheckAssociatedRelayNumber = EmergencyParaXcm;
 	type ConsensusHook = ConsensusHookWrapperForRelayTimestamp<Runtime, ConsensusHook>;

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -459,17 +459,24 @@ impl pallet_message_queue::Config for Runtime {
 	type IdleMaxServiceWeight = MessageQueueServiceWeight;
 }
 
+pub type FastAuthorizeUpgradeOrigin = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>,
+>;
+
+pub type ResumeXcmOrigin = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>,
+>;
+
 impl pallet_emergency_para_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type CheckAssociatedRelayNumber =
 		cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 	type QueuePausedQuery = (MaintenanceMode, NarrowOriginToSibling<XcmpQueue>);
-	type XcmpMessageHandler = XcmpQueue;
 	type PausedThreshold = ConstU32<300>;
-	type FastAuthorizeUpgradeOrigin =
-		pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>;
-	type PausedToNormalOrigin =
-		pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>;
+	type FastAuthorizeUpgradeOrigin = FastAuthorizeUpgradeOrigin;
+	type PausedToNormalOrigin = ResumeXcmOrigin;
 }
 
 // Our AssetType. For now we only handle Xcm Assets

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -32,6 +32,7 @@ moonbeam-xcm-benchmarks = { workspace = true }
 pallet-asset-manager = { workspace = true }
 pallet-author-mapping = { workspace = true }
 pallet-crowdloan-rewards = { workspace = true }
+pallet-emergency-para-xcm = { workspace = true }
 pallet-erc20-xcm-bridge = { workspace = true }
 pallet-ethereum-xcm = { workspace = true }
 pallet-evm-chain-id = { workspace = true }
@@ -233,6 +234,7 @@ std = [
 	"pallet-collective/std",
 	"pallet-conviction-voting/std",
 	"pallet-crowdloan-rewards/std",
+	"pallet-emergency-para-xcm/std",
 	"pallet-erc20-xcm-bridge/std",
 	"pallet-evm-chain-id/std",
 	"pallet-ethereum-xcm/std",

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -21,8 +21,8 @@
 //! * Moonbeam tokenomics
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
-#![recursion_limit = "256"]
+// `construct_runtime!` does a lot of recursion and requires us to increase the limit to 512.
+#![recursion_limit = "512"]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -710,8 +710,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber =
-		cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
+	type CheckAssociatedRelayNumber = EmergencyParaXcm;
 	type ConsensusHook = ConsensusHookWrapperForRelayTimestamp<Runtime, ConsensusHook>;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type WeightInfo = moonbeam_weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
@@ -1454,6 +1453,7 @@ construct_runtime! {
 		Erc20XcmBridge: pallet_erc20_xcm_bridge::{Pallet} = 110,
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 111,
 		EvmForeignAssets: pallet_moonbeam_foreign_assets::{Pallet, Call, Storage, Event<T>} = 114,
+		EmergencyParaXcm: pallet_emergency_para_xcm::{Pallet, Call, Storage, Event} = 116,
 
 		// Utils
 		RelayStorageRoots: pallet_relay_storage_roots::{Pallet, Storage} = 112,

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -18,9 +18,10 @@
 //!
 
 use super::{
-	governance, AccountId, AssetId, AssetManager, Balance, Balances, DealWithFees, Erc20XcmBridge,
-	MaintenanceMode, MessageQueue, ParachainInfo, ParachainSystem, Perbill, PolkadotXcm, Runtime,
-	RuntimeBlockWeights, RuntimeCall, RuntimeEvent, RuntimeOrigin, Treasury, XcmpQueue,
+	governance, AccountId, AssetId, AssetManager, Balance, Balances, DealWithFees,
+	EmergencyParaXcm, Erc20XcmBridge, MaintenanceMode, MessageQueue, OpenTechCommitteeInstance,
+	ParachainInfo, ParachainSystem, Perbill, PolkadotXcm, Runtime, RuntimeBlockWeights,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, Treasury, XcmpQueue,
 };
 
 use frame_support::{
@@ -442,9 +443,29 @@ impl pallet_message_queue::Config for Runtime {
 	// The XCMP queue pallet is only ever able to handle the `Sibling(ParaId)` origin:
 	type QueueChangeHandler = NarrowOriginToSibling<XcmpQueue>;
 	// NarrowOriginToSibling calls XcmpQueue's is_paused if Origin is sibling. Allows all other origins
-	type QueuePausedQuery = (MaintenanceMode, NarrowOriginToSibling<XcmpQueue>);
+	type QueuePausedQuery = EmergencyParaXcm;
 	type WeightInfo = moonbeam_weights::pallet_message_queue::WeightInfo<Runtime>;
 	type IdleMaxServiceWeight = MessageQueueServiceWeight;
+}
+
+pub type FastAuthorizeUpgradeOrigin = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>,
+>;
+
+pub type ResumeXcmOrigin = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>,
+>;
+
+impl pallet_emergency_para_xcm::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type CheckAssociatedRelayNumber =
+		cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
+	type QueuePausedQuery = (MaintenanceMode, NarrowOriginToSibling<XcmpQueue>);
+	type PausedThreshold = ConstU32<300>;
+	type FastAuthorizeUpgradeOrigin = FastAuthorizeUpgradeOrigin;
+	type PausedToNormalOrigin = ResumeXcmOrigin;
 }
 
 // Our AssetType. For now we only handle Xcm Assets

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -32,6 +32,7 @@ moonbeam-xcm-benchmarks = { workspace = true }
 pallet-asset-manager = { workspace = true }
 pallet-author-mapping = { workspace = true }
 pallet-crowdloan-rewards = { workspace = true }
+pallet-emergency-para-xcm = { workspace = true }
 pallet-erc20-xcm-bridge = { workspace = true }
 pallet-ethereum-xcm = { workspace = true }
 pallet-evm-chain-id = { workspace = true }
@@ -234,6 +235,7 @@ std = [
 	"pallet-collective/std",
 	"pallet-conviction-voting/std",
 	"pallet-crowdloan-rewards/std",
+	"pallet-emergency-para-xcm/std",
 	"pallet-erc20-xcm-bridge/std",
 	"pallet-evm-chain-id/std",
 	"pallet-ethereum-xcm/std",

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -21,8 +21,8 @@
 //! * Moonriver tokenomics
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
-#![recursion_limit = "256"]
+// `construct_runtime!` does a lot of recursion and requires us to increase the limit to 512.
+#![recursion_limit = "512"]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -746,8 +746,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber =
-		cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
+	type CheckAssociatedRelayNumber = EmergencyParaXcm;
 	type ConsensusHook = ConsensusHookWrapperForRelayTimestamp<Runtime, ConsensusHook>;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type WeightInfo = moonriver_weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
@@ -1457,6 +1456,7 @@ construct_runtime! {
 		Erc20XcmBridge: pallet_erc20_xcm_bridge::{Pallet} = 110,
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 111,
 		EvmForeignAssets: pallet_moonbeam_foreign_assets::{Pallet, Call, Storage, Event<T>} = 114,
+		EmergencyParaXcm: pallet_emergency_para_xcm::{Pallet, Call, Storage, Event} = 116,
 
 		// Utils
 		RelayStorageRoots: pallet_relay_storage_roots::{Pallet, Storage} = 112,

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -18,9 +18,10 @@
 //!
 
 use super::{
-	governance, AccountId, AssetId, AssetManager, Balance, Balances, DealWithFees, Erc20XcmBridge,
-	MaintenanceMode, MessageQueue, ParachainInfo, ParachainSystem, Perbill, PolkadotXcm, Runtime,
-	RuntimeBlockWeights, RuntimeCall, RuntimeEvent, RuntimeOrigin, Treasury, XcmpQueue,
+	governance, AccountId, AssetId, AssetManager, Balance, Balances, DealWithFees,
+	EmergencyParaXcm, Erc20XcmBridge, MaintenanceMode, MessageQueue, OpenTechCommitteeInstance,
+	ParachainInfo, ParachainSystem, Perbill, PolkadotXcm, Runtime, RuntimeBlockWeights,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, Treasury, XcmpQueue,
 };
 
 use frame_support::{
@@ -450,9 +451,29 @@ impl pallet_message_queue::Config for Runtime {
 	// The XCMP queue pallet is only ever able to handle the `Sibling(ParaId)` origin:
 	type QueueChangeHandler = NarrowOriginToSibling<XcmpQueue>;
 	// NarrowOriginToSibling calls XcmpQueue's is_paused if Origin is sibling. Allows all other origins
-	type QueuePausedQuery = (MaintenanceMode, NarrowOriginToSibling<XcmpQueue>);
+	type QueuePausedQuery = EmergencyParaXcm;
 	type WeightInfo = moonriver_weights::pallet_message_queue::WeightInfo<Runtime>;
 	type IdleMaxServiceWeight = MessageQueueServiceWeight;
+}
+
+pub type FastAuthorizeUpgradeOrigin = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>,
+>;
+
+pub type ResumeXcmOrigin = EitherOfDiverse<
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, OpenTechCommitteeInstance, 5, 9>,
+>;
+
+impl pallet_emergency_para_xcm::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type CheckAssociatedRelayNumber =
+		cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
+	type QueuePausedQuery = (MaintenanceMode, NarrowOriginToSibling<XcmpQueue>);
+	type PausedThreshold = ConstU32<300>;
+	type FastAuthorizeUpgradeOrigin = FastAuthorizeUpgradeOrigin;
+	type PausedToNormalOrigin = ResumeXcmOrigin;
 }
 
 // Our AssetType. For now we only handle Xcm Assets

--- a/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
@@ -127,13 +127,13 @@ describeSuite({
           allowFailures: false,
         });
 
-        // The sovereign account of foreign parachain sould still have funds
+        // The sovereign account of foreign parachain should now be empty
         const balance2 = (
           await context.polkadotJs().query.system.account(sovereignAddress)
         ).data.free.toBigInt();
         expect(balance2, "Sovereign account not empty, transfer has failed").to.eq(0n);
 
-        // The beneficiary of the XCm message should not have funds
+        // The beneficiary of the XCM message should now have funds
         const randomBalance2 = (
           await context.polkadotJs().query.system.account(random.address)
         ).data.free.toBigInt();

--- a/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
@@ -1,0 +1,146 @@
+import "@moonbeam-network/api-augment";
+import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
+
+import { BN } from "@polkadot/util";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { alith, generateKeyringPair } from "@moonwall/util";
+import {
+  XcmFragment,
+  RawXcmMessage,
+  sovereignAccountOfSibling,
+  injectHrmpMessage,
+} from "../../../../helpers/xcm.js";
+
+const foreign_para_id = 2000;
+
+describeSuite({
+  id: "D014134",
+  title: "Auto-pause XCM",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    let transferredBalance: bigint;
+    let sovereignAddress: string;
+    let random: KeyringPair;
+    let balancesPalletIndex: number;
+
+    beforeAll(async () => {
+      random = generateKeyringPair();
+      sovereignAddress = sovereignAccountOfSibling(context, 2000);
+      transferredBalance = 1_000_000_000_000_000n;
+
+      await context.createBlock(
+        context.polkadotJs().tx.balances.transferAllowDeath(sovereignAddress, transferredBalance),
+        { allowFailures: false }
+      );
+
+      const balance = (
+        await context.polkadotJs().query.system.account(sovereignAddress)
+      ).data.free.toBigInt();
+      expect(balance).to.eq(transferredBalance);
+
+      const metadata = await context.polkadotJs().rpc.state.getMetadata();
+      balancesPalletIndex = metadata.asLatest.pallets
+        .find(({ name }) => name.toString() == "Balances")!
+        .index.toNumber();
+    });
+
+    it({
+      id: "T01",
+      title: "Should automatically pause xcm when block production is stuck",
+      test: async function () {
+        await context.createBlock();
+
+        // XCM Mode should be equal to Normal
+        expect((await context.polkadotJs().query.emergencyParaXcm.mode()).isNormal).to.be.true;
+
+        // Create a dummy xcm message to test auto-pause
+        const xcmMessage = new XcmFragment({
+          assets: [
+            {
+              multilocation: {
+                parents: 0,
+                interior: {
+                  X1: { PalletInstance: balancesPalletIndex },
+                },
+              },
+              fungible: transferredBalance,
+            },
+          ],
+          beneficiary: random.address,
+        })
+          .withdraw_asset()
+          .clear_origin()
+          .buy_execution()
+          .deposit_asset_v3()
+          .as_v4();
+
+        // Inject an XCM message that should be included in the next block but not executed
+        await injectHrmpMessage(context, foreign_para_id, {
+          type: "XcmVersionedXcm",
+          payload: xcmMessage,
+        } as RawXcmMessage);
+
+        // Simulate block production stall (skip more than PausedThreshold relay blocks)
+        await customDevRpcRequest("test_skipRelayBlocks", [301]);
+
+        // Create a new block, this block should pause XCM incoming execution
+        await context.createBlock([], {
+          expectEvents: [context.polkadotJs().events.emergencyParaXcm.EnteredPausedXcmMode],
+          allowFailures: false,
+        });
+
+        // XCM Mode should be equal to Paused
+        expect((await context.polkadotJs().query.emergencyParaXcm.mode()).isPaused).to.be.true;
+
+        // The sovereign account of foreign parachain sould still have funds
+        const balance = (
+          await context.polkadotJs().query.system.account(sovereignAddress)
+        ).data.free.toBigInt();
+        expect(balance, "Sovereign account balance has changed").to.eq(transferredBalance);
+
+        // The beneficiary of the XCm message should not have funds
+        const randomBalance = (
+          await context.polkadotJs().query.system.account(random.address)
+        ).data.free.toBigInt();
+        expect(randomBalance, "beneficiary of the XCM message receive funds").to.eq(0n);
+
+        // Sudo should be able to resume XCM execution
+        await context.createBlock(
+          context
+            .polkadotJs()
+            .tx.sudo.sudo(context.polkadotJs().tx.emergencyParaXcm.pausedToNormal()),
+          {
+            expectEvents: [
+              context.polkadotJs().events.emergencyParaXcm.NormalXcmOperationResumed,
+            ],
+            allowFailures: false,
+          }
+        );
+
+        // XCM Mode should be equal to Normal
+        expect((await context.polkadotJs().query.emergencyParaXcm.mode()).isNormal).to.be.true;
+
+        // The next block should execute previous XCM message
+        await context.createBlock([], {
+          expectEvents: [],
+          allowFailures: false,
+        });
+
+        // The sovereign account of foreign parachain sould still have funds
+        const balance2 = (
+          await context.polkadotJs().query.system.account(sovereignAddress)
+        ).data.free.toBigInt();
+        expect(balance2, "Sovereign account not empty, transfer has failed").to.eq(0n);
+
+        // The beneficiary of the XCm message should not have funds
+        const randomBalance2 = (
+          await context.polkadotJs().query.system.account(random.address)
+        ).data.free.toBigInt();
+        expect(
+          randomBalance2,
+          "beneficiary balance not increased, transfer has failed"
+        ).to.not.eq(0n)
+      },
+    });
+  },
+});

--- a/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
@@ -1,9 +1,8 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 
-import { BN } from "@polkadot/util";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { alith, generateKeyringPair } from "@moonwall/util";
+import { generateKeyringPair } from "@moonwall/util";
 import {
   XcmFragment,
   RawXcmMessage,
@@ -92,13 +91,17 @@ describeSuite({
         // XCM Mode should be equal to Paused
         expect((await context.polkadotJs().query.emergencyParaXcm.mode()).isPaused).to.be.true;
 
+        // Produce some blocks when XCm is Paused
+        await context.createBlock();
+        await context.createBlock();
+
         // The sovereign account of foreign parachain sould still have funds
         const balance = (
           await context.polkadotJs().query.system.account(sovereignAddress)
         ).data.free.toBigInt();
         expect(balance, "Sovereign account balance has changed").to.eq(transferredBalance);
 
-        // The beneficiary of the XCm message should not have funds
+        // The beneficiary of the XCM message should not have funds
         const randomBalance = (
           await context.polkadotJs().query.system.account(random.address)
         ).data.free.toBigInt();

--- a/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
@@ -110,9 +110,7 @@ describeSuite({
             .polkadotJs()
             .tx.sudo.sudo(context.polkadotJs().tx.emergencyParaXcm.pausedToNormal()),
           {
-            expectEvents: [
-              context.polkadotJs().events.emergencyParaXcm.NormalXcmOperationResumed,
-            ],
+            expectEvents: [context.polkadotJs().events.emergencyParaXcm.NormalXcmOperationResumed],
             allowFailures: false,
           }
         );
@@ -136,10 +134,9 @@ describeSuite({
         const randomBalance2 = (
           await context.polkadotJs().query.system.account(random.address)
         ).data.free.toBigInt();
-        expect(
-          randomBalance2,
-          "beneficiary balance not increased, transfer has failed"
-        ).to.not.eq(0n)
+        expect(randomBalance2, "beneficiary balance not increased, transfer has failed").to.not.eq(
+          0n
+        );
       },
     });
   },


### PR DESCRIPTION
### What does it do?

* Add the RPC method `test_skipRelayBlocks` only available in dev mode that allow to alter the relay mock to skip a given number of relay blocks
* Create a dev-test that use `test_skipRelayBlocks` to simulate a chain stall and ensure that xcm is automatically paused 
* Include a moonkit fix, incoming XCMP messages where dropped when xcm auto-pause
* Add auto-pause XCM feature to moonriver and moonbeam

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

https://github.com/Moonsong-Labs/moonkit/pull/53

### What value does it bring to the blockchain users?
