### PR TITLE
Extract Storage Read costs for dev tests involved in #2786

### DIFF
--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -77,6 +77,8 @@ export const RUNTIME_CONSTANTS = {
     EXTRINSIC_GAS_LIMIT: 52_000_000n,
     // Maximum Gas to PoV ratio used in the gasometer
     GAS_PER_POV_BYTES: 16n,
+    // Storage read and write costs in weight
+    STORAGE_READ_COST: 41_742_000n,
   },
   MOONRIVER: {
     MIN_FEE_MULTIPLIER: 1_000_000_000_000_000_000n,

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -79,7 +79,8 @@ export const RUNTIME_CONSTANTS = {
     GAS_PER_POV_BYTES: 16n,
     // Storage read/write costs
     STORAGE_READ_COST: 41_742_000n,
-    STORAGE_READ_GAS_COST: 1669n,
+    // Weight to gas convertion ratio
+    WEIGHT_TO_GAS_RATIO: 25_000n,
   },
   MOONRIVER: {
     MIN_FEE_MULTIPLIER: 1_000_000_000_000_000_000n,

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -77,8 +77,9 @@ export const RUNTIME_CONSTANTS = {
     EXTRINSIC_GAS_LIMIT: 52_000_000n,
     // Maximum Gas to PoV ratio used in the gasometer
     GAS_PER_POV_BYTES: 16n,
-    // Storage read and write costs in weight
+    // Storage read/write costs
     STORAGE_READ_COST: 41_742_000n,
+    STORAGE_READ_GAS_COST: 1669n,
   },
   MOONRIVER: {
     MIN_FEE_MULTIPLIER: 1_000_000_000_000_000_000n,

--- a/test/suites/dev/moonbase/test-pov/test-xcm-to-evm-pov.ts
+++ b/test/suites/dev/moonbase/test-pov/test-xcm-to-evm-pov.ts
@@ -24,9 +24,10 @@ describeSuite({
     let contracts: HeavyContract[];
     const EXPECTED_POV_ROUGH = 350_000; // bytes
     let balancesPalletIndex: number;
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST: bigint;
 
     beforeAll(async function () {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
       // Get Pallet balances index
       const metadata = await context.polkadotJs().rpc.state.getMetadata();
       const foundPallet = metadata.asLatest.pallets.find(

--- a/test/suites/dev/moonbase/test-pov/test-xcm-to-evm-pov.ts
+++ b/test/suites/dev/moonbase/test-pov/test-xcm-to-evm-pov.ts
@@ -9,7 +9,7 @@ import {
   descendOriginFromAddress20,
   injectHrmpMessage,
 } from "../../../../helpers/xcm.js";
-import { GAS_LIMIT_POV_RATIO } from "../../../../helpers/constants";
+import { ConstantStore, GAS_LIMIT_POV_RATIO } from "../../../../helpers/constants";
 
 describeSuite({
   id: "D012706",
@@ -24,6 +24,7 @@ describeSuite({
     let contracts: HeavyContract[];
     const EXPECTED_POV_ROUGH = 350_000; // bytes
     let balancesPalletIndex: number;
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
 
     beforeAll(async function () {
       // Get Pallet balances index
@@ -123,7 +124,7 @@ describeSuite({
             Transact: {
               originKind: "SovereignAccount",
               requireWeightAtMost: {
-                refTime: 50_041_742_000,
+                refTime: 50_000_000_000n + STORAGE_READ_COST,
                 proofSize: GAS_LIMIT / GAS_LIMIT_POV_RATIO,
               },
               call: {
@@ -223,7 +224,7 @@ describeSuite({
             Transact: {
               originKind: "SovereignAccount",
               requireWeightAtMost: {
-                refTime: 160_041_742_000,
+                refTime: 160_000_000_000n + STORAGE_READ_COST,
                 proofSize: GAS_LIMIT / GAS_LIMIT_POV_RATIO,
               },
               call: {

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-batch.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-batch.ts
@@ -91,7 +91,9 @@ describeSuite({
           .viem("public")
           .getTransactionReceipt({ hash: batchSomeUntilFailureResult as `0x${string}` });
 
-        const STORAGE_READ_GAS_COST = ConstantStore(context).STORAGE_READ_GAS_COST;
+        const STORAGE_READ_GAS_COST = // One storage read gas cost
+          ConstantStore(context).STORAGE_READ_COST / ConstantStore(context).WEIGHT_TO_GAS_RATIO;
+
         expect(batchAllReceipt["gasUsed"]).to.equal(43932n + STORAGE_READ_GAS_COST);
         expect(batchSomeReceipt["gasUsed"]).to.equal(43932n + STORAGE_READ_GAS_COST);
         expect(batchSomeUntilFailureReceipt["gasUsed"]).to.equal(43932n + STORAGE_READ_GAS_COST);

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-batch.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-batch.ts
@@ -11,7 +11,7 @@ import {
   sendRawTransaction,
 } from "@moonwall/util";
 import { encodeFunctionData, fromHex } from "viem";
-import { expectEVMResult, getSignatureParameters } from "../../../../helpers";
+import { ConstantStore, expectEVMResult, getSignatureParameters } from "../../../../helpers";
 
 describeSuite({
   id: "D012822",
@@ -91,9 +91,10 @@ describeSuite({
           .viem("public")
           .getTransactionReceipt({ hash: batchSomeUntilFailureResult as `0x${string}` });
 
-        expect(batchAllReceipt["gasUsed"]).to.equal(45601n);
-        expect(batchSomeReceipt["gasUsed"]).to.equal(45601n);
-        expect(batchSomeUntilFailureReceipt["gasUsed"]).to.equal(45601n);
+        const STORAGE_READ_GAS_COST = ConstantStore(context).STORAGE_READ_GAS_COST;
+        expect(batchAllReceipt["gasUsed"]).to.equal(43932n + STORAGE_READ_GAS_COST);
+        expect(batchSomeReceipt["gasUsed"]).to.equal(43932n + STORAGE_READ_GAS_COST);
+        expect(batchSomeUntilFailureReceipt["gasUsed"]).to.equal(43932n + STORAGE_READ_GAS_COST);
       },
     });
 

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
@@ -1,5 +1,5 @@
 import "@moonbeam-network/api-augment";
-import { describeSuite, expect } from "@moonwall/cli";
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { GLMR, generateKeyringPair } from "@moonwall/util";
 import { XcmVersionedXcm } from "@polkadot/types/lookup";
 import { u8aToHex } from "@polkadot/util";
@@ -12,7 +12,10 @@ describeSuite({
   title: "Precompiles - xcm utils",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST;
+    beforeAll(async function () {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    });
     it({
       id: "T01",
       title: "allows to retrieve parent-based ML account",

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
@@ -3,7 +3,7 @@ import { describeSuite, expect } from "@moonwall/cli";
 import { GLMR, generateKeyringPair } from "@moonwall/util";
 import { XcmVersionedXcm } from "@polkadot/types/lookup";
 import { u8aToHex } from "@polkadot/util";
-import { expectEVMResult, descendOriginFromAddress20 } from "../../../../helpers";
+import { expectEVMResult, descendOriginFromAddress20, ConstantStore } from "../../../../helpers";
 
 export const CLEAR_ORIGIN_WEIGHT = 5_194_000n;
 
@@ -12,6 +12,7 @@ describeSuite({
   title: "Precompiles - xcm utils",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
     it({
       id: "T01",
       title: "allows to retrieve parent-based ML account",
@@ -172,7 +173,7 @@ describeSuite({
             {
               Transact: {
                 originType: "SovereignAccount",
-                requireWeightAtMost: 566_742_000n, // 21_000 gas limit
+                requireWeightAtMost: 525_000_000n + STORAGE_READ_COST, // 21_000 gas limit
                 call: {
                   encoded: transferCallEncoded,
                 },
@@ -233,7 +234,7 @@ describeSuite({
             {
               Transact: {
                 originType: "SovereignAccount",
-                requireWeightAtMost: 566_742_000n, // 21_000 gas limit
+                requireWeightAtMost: 525_000_000n + STORAGE_READ_COST, // 21_000 gas limit
                 call: {
                   encoded: transferCallEncoded,
                 },

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-1.ts
@@ -20,9 +20,10 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST: bigint;
 
     beforeAll(async () => {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(context);
       sendingAddress = originAddress;
       descendAddress = descendOriginAddress;

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-1.ts
@@ -9,6 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
 } from "../../../../helpers/xcm.js";
+import { ConstantStore } from "../../../../helpers/constants.js";
 
 describeSuite({
   id: "D014020",
@@ -19,6 +20,7 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
 
     beforeAll(async () => {
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(context);
@@ -53,8 +55,6 @@ describeSuite({
 
         const amountToTransfer = transferredBalance / 10n;
         const TX_GAS_LIMIT = 21_000;
-        // TODO: move this to the constant file
-        const STORAGE_READ_COST = 41_742_000n;
 
         const xcmTransactions = [
           {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
@@ -9,6 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
 } from "../../../../helpers/xcm.js";
+import { ConstantStore } from "../../../../helpers/constants.js";
 
 describeSuite({
   id: "D014023",
@@ -19,6 +20,7 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
 
     beforeAll(async () => {
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(context);
@@ -54,8 +56,6 @@ describeSuite({
         const amountToTransfer = transferredBalance / 10n;
 
         const GAS_LIMIT = 500_000;
-        // TODO: move this to the constant file
-        const STORAGE_READ_COST = 41_742_000n;
 
         // We will put a very high gas limit. However, the weight accounted
         // for the block should only

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
@@ -20,9 +20,10 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST;
 
     beforeAll(async () => {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(context);
       sendingAddress = originAddress;
       descendAddress = descendOriginAddress;

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
@@ -55,9 +55,10 @@ describeSuite({
 
     const assetsToTransfer = 100_000_000_000n;
 
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST: bigint;
 
     beforeAll(async () => {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
       const { contractAddress, abi } = await context.deployContract!("Incrementor");
 
       contractDeployed = contractAddress;

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
@@ -14,6 +14,7 @@ import {
   weightMessage,
 } from "../../../../helpers/xcm.js";
 import { registerOldForeignAsset } from "../../../../helpers/assets.js";
+import { ConstantStore } from "../../../../helpers/constants.js";
 
 describeSuite({
   id: "D014025",
@@ -53,6 +54,8 @@ describeSuite({
     let contractABI: Abi;
 
     const assetsToTransfer = 100_000_000_000n;
+
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
 
     beforeAll(async () => {
       const { contractAddress, abi } = await context.deployContract!("Incrementor");
@@ -171,8 +174,6 @@ describeSuite({
         ];
 
         let expectedCalls = 0n;
-        // TODO: move this to the constant file
-        const STORAGE_READ_COST = 41_742_000n;
 
         for (const xcmTransaction of xcmTransactions) {
           expectedCalls++;

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-6.ts
@@ -9,6 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
 } from "../../../../helpers/xcm.js";
+import { ConstantStore } from "../../../../helpers/constants.js";
 
 describeSuite({
   id: "D014028",
@@ -21,6 +22,8 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
+
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
 
     beforeAll(async () => {
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(
@@ -72,8 +75,6 @@ describeSuite({
 
         const amountToTransfer = transferredBalance / 10n;
         const GAS_LIMIT = 21_000;
-        // TODO: move this to the constant file
-        const STORAGE_READ_COST = 41_742_000n;
 
         const xcmTransactions = [
           {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-6.ts
@@ -22,10 +22,11 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
-
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST: bigint;
 
     beforeAll(async () => {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(
         context,
         charleth.address as `0x${string}`

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-1.ts
@@ -9,6 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
 } from "../../../../helpers/xcm.js";
+import { ConstantStore } from "../../../../helpers/constants.js";
 
 describeSuite({
   id: "D014117",
@@ -19,6 +20,8 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
+
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
 
     beforeAll(async () => {
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(context);
@@ -52,8 +55,6 @@ describeSuite({
           .index.toNumber();
 
         const amountToTransfer = transferredBalance / 10n;
-        // TODO: move this to the constant file
-        const STORAGE_READ_COST = 41_742_000n;
 
         const xcmTransactions = [
           {

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-1.ts
@@ -21,9 +21,10 @@ describeSuite({
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
 
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST: bigint;
 
     beforeAll(async () => {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(context);
       sendingAddress = originAddress;
       descendAddress = descendOriginAddress;

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-6.ts
@@ -23,9 +23,10 @@ describeSuite({
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
 
-    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
+    let STORAGE_READ_COST: bigint;
 
     beforeAll(async () => {
+      STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(
         context,
         charleth.address as `0x${string}`

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-6.ts
@@ -9,6 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
 } from "../../../../helpers/xcm.js";
+import { ConstantStore } from "../../../../helpers/constants.js";
 
 describeSuite({
   id: "D014122",
@@ -21,6 +22,8 @@ describeSuite({
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
+
+    const STORAGE_READ_COST = ConstantStore(context).STORAGE_READ_COST;
 
     beforeAll(async () => {
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(
@@ -71,9 +74,6 @@ describeSuite({
           .index.toNumber();
 
         const amountToTransfer = transferredBalance / 10n;
-
-        // TODO: move this to the constant file
-        const STORAGE_READ_COST = 41_742_000n;
 
         const xcmTransactions = [
           {


### PR DESCRIPTION
### What does it do?

This PR extracts two `moonbase` constants used in several dev-tests involved in PR #2786 in order to ease future changes. Constants extracted are now included in `helpers/constants.ts` and exposed via the `ConstantStore` fn:

```typescript
MOONBASE: {
    ...
    // Storage read/write costs
    STORAGE_READ_COST: 41_742_000n,
    STORAGE_READ_GAS_COST: 1669n,
}
```

Only tests changed in #2786 were updated to use the new constants.

### What important points reviewers should know?

Constants were extracted by identifying which tests had changes in #2786 to expected values related to either `41_742_000n` or `1669n`, which reference Storage Read weight and gas cost. Expected values had the Storage costs deducted and then added using the new constants.

Tests which already used named variables for the Storage read costs only had the local variable removed in favor of importing it through the `ConstantStore`.

One of the more obscure extractions is in `test/suites/dev/moonbase/test-precompile/test-precompile-batch.ts`. The used gas changes in #2786 match the changes from `1000` to `1669` reflected in rust-tests. This led to the extraction of the Storage Read gas cost into a new constant.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
