### PR TITLE
add smoke test: XCM Mode should be equal to Normal

### DIFF
--- a/test/suites/smoke/test-xcm-autopause.ts
+++ b/test/suites/smoke/test-xcm-autopause.ts
@@ -1,0 +1,22 @@
+import "@moonbeam-network/api-augment/moonbase";
+import { describeSuite, expect } from "@moonwall/cli";
+
+describeSuite({
+  id: "S26",
+  title: `XCM Mode should be equal to Normal`,
+  foundationMethods: "read_only",
+  testCases: ({ context, it, log }) => {
+    it({
+      id: "C100",
+      title: "XCM Mode should be equal to Normal",
+      test: async function (context) {
+        if ((await context.polkadotJs().consts.system.version.specVersion) < 3200) {
+          context.skip();
+        }
+
+        // XCM Mode should be equal to Normal
+        expect((await context.polkadotJs().query.emergencyParaXcm.mode()).isNormal).to.be.true;
+      },
+    });
+  },
+});


### PR DESCRIPTION
### What does it do?

Add a smoke test that ensure XCM Mode is Normal, the goal is to get notified if XCM is paused automatically.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
