### PR TITLE
Divide ref time XCM fees by four

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -154,7 +154,7 @@ pub mod currency {
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI * SUPPLY_FACTOR;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROUNIT * SUPPLY_FACTOR;
-	pub const WEIGHT_FEE: Balance = 50 * KILOWEI * SUPPLY_FACTOR;
+	pub const WEIGHT_FEE: Balance = 25 * KILOWEI * SUPPLY_FACTOR;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 1 * UNIT * SUPPLY_FACTOR + (bytes as Balance) * STORAGE_BYTE_FEE
@@ -481,7 +481,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE * 2).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -154,7 +154,7 @@ pub mod currency {
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI * SUPPLY_FACTOR;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROUNIT * SUPPLY_FACTOR;
-	pub const WEIGHT_FEE: Balance = 25 * KILOWEI * SUPPLY_FACTOR;
+	pub const WEIGHT_FEE: Balance = 50 * KILOWEI * SUPPLY_FACTOR / 4;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 1 * UNIT * SUPPLY_FACTOR + (bytes as Balance) * STORAGE_BYTE_FEE
@@ -481,7 +481,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int((currency::WEIGHT_FEE * 2).saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -3021,7 +3021,9 @@ mod fee_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
-				.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128))
+				.saturating_mul_int(
+					(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128),
+				)
 				.into();
 
 			assert_eq!(expected, actual);
@@ -3058,7 +3060,8 @@ mod fee_tests {
 			.unwrap()
 			.into();
 		t.execute_with(|| {
-			let weight_fee_per_gas = currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128);
+			let weight_fee_per_gas =
+				(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -146,7 +146,7 @@ pub mod currency {
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI * SUPPLY_FACTOR;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROGLMR * SUPPLY_FACTOR;
-	pub const WEIGHT_FEE: Balance = 25 * KILOWEI * SUPPLY_FACTOR;
+	pub const WEIGHT_FEE: Balance = 50 * KILOWEI * SUPPLY_FACTOR / 4;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 100 * MILLIGLMR * SUPPLY_FACTOR + (bytes as Balance) * STORAGE_BYTE_FEE
@@ -455,7 +455,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int((currency::WEIGHT_FEE * 2).saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -146,7 +146,7 @@ pub mod currency {
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI * SUPPLY_FACTOR;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROGLMR * SUPPLY_FACTOR;
-	pub const WEIGHT_FEE: Balance = 50 * KILOWEI * SUPPLY_FACTOR;
+	pub const WEIGHT_FEE: Balance = 25 * KILOWEI * SUPPLY_FACTOR;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 100 * MILLIGLMR * SUPPLY_FACTOR + (bytes as Balance) * STORAGE_BYTE_FEE
@@ -455,7 +455,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE * 2).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2779,7 +2779,9 @@ mod fee_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
-				.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128))
+				.saturating_mul_int(
+					(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128),
+				)
 				.into();
 
 			assert_eq!(expected, actual);
@@ -2816,7 +2818,8 @@ mod fee_tests {
 			.unwrap()
 			.into();
 		t.execute_with(|| {
-			let weight_fee_per_gas = currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128);
+			let weight_fee_per_gas =
+				(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -149,7 +149,7 @@ pub mod currency {
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI * SUPPLY_FACTOR;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROMOVR * SUPPLY_FACTOR;
-	pub const WEIGHT_FEE: Balance = 50 * KILOWEI * SUPPLY_FACTOR;
+	pub const WEIGHT_FEE: Balance = 25 * KILOWEI * SUPPLY_FACTOR;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 1 * MOVR * SUPPLY_FACTOR + (bytes as Balance) * STORAGE_BYTE_FEE
@@ -457,7 +457,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE *2).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -149,7 +149,7 @@ pub mod currency {
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI * SUPPLY_FACTOR;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROMOVR * SUPPLY_FACTOR;
-	pub const WEIGHT_FEE: Balance = 25 * KILOWEI * SUPPLY_FACTOR;
+	pub const WEIGHT_FEE: Balance = 50 * KILOWEI * SUPPLY_FACTOR / 4;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 1 * MOVR * SUPPLY_FACTOR + (bytes as Balance) * STORAGE_BYTE_FEE
@@ -457,7 +457,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int((currency::WEIGHT_FEE *2).saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -2688,7 +2688,9 @@ mod fee_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
-				.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128))
+				.saturating_mul_int(
+					(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128),
+				)
 				.into();
 
 			assert_eq!(expected, actual);
@@ -2725,7 +2727,8 @@ mod fee_tests {
 			.unwrap()
 			.into();
 		t.execute_with(|| {
-			let weight_fee_per_gas = currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128);
+			let weight_fee_per_gas =
+				(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
@@ -84,7 +84,9 @@ describeSuite({
 
         // note that this is not really affected by the high multiplier because most of its fee is
         // derived from the length_fee, which is not scaled by the multiplier
-        expect(initialBalance - afterBalance).to.equal(449_284_776_265_723_667_008n);
+        // ~/4 to compensate for the ref time XCM fee changes
+        // Previous value: 449_284_776_265_723_667_008n
+        expect(initialBalance - afterBalance).to.equal(119_241_285_640_723_667_008n);
       },
     });
 
@@ -111,7 +113,9 @@ describeSuite({
         // grab the first withdraw event and hope it's the right one...
         const withdrawEvent = result?.events.filter(({ event }) => event.method == "Withdraw")[0];
         const amount = withdrawEvent.event.data.amount.toBigInt();
-        expect(amount).to.equal(6_000_000_012_598_000_941_192n);
+        // ~/4 to compensate for the ref time XCM fee changes
+        // Previous value: 6_000_000_012_598_000_941_192n
+        expect(amount).to.equal(1_500_000_003_223_000_941_192n);
       },
     });
 

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-utils.ts
@@ -147,8 +147,8 @@ describeSuite({
           // PalletInstance: Selector (04) + palconst instance 1 byte (03)
           [x2_pallet_instance_enum_selector + x2_instance],
         ];
-
-        const expectedUnitsPerSecond = 50_000n * 1_000_000_000_000n;
+        // Dividing by four the xcm fees constant to match the x4 cpu per block
+        const expectedUnitsPerSecond = (50_000n / 4n) * 1_000_000_000_000n;
 
         expect(
           await context.readPrecompile!({

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-5.ts
@@ -80,7 +80,8 @@ describeSuite({
         );
         // We are charging chargedWeight
         // chargedWeight * 50000 = chargedFee
-        const chargedFee = chargedWeight * 50000n;
+        // Dividing by four the xcm fees constant to match the x4 cpu per block
+        const chargedFee = (chargedWeight * 50000n) / 4n;
 
         // Send an XCM and create block to execute it
         await injectHrmpMessageAndSeal(context, foreign_para_id, {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
@@ -232,7 +232,8 @@ describeSuite({
         );
         // We are charging chargedWeight
         // chargedWeight * 50000 = chargedFee
-        const chargedFee = chargedWeight * 50000n;
+        // Dividing by four the xcm fees constant to match the x4 cpu per block
+        const chargedFee = (chargedWeight * 50000n) / 4n;
 
         const amountOfTrappedAssets = feeAssetAmount - chargedFee;
         const claimConfig = {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
@@ -280,7 +280,8 @@ describeSuite({
         );
         // We are charging chargedWeightForClaim
         // chargedWeightForClaim * 50000 = chargedFeeForClaim
-        const chargedFeeForClaim = chargedWeightForClaim * 50000n;
+        // Dividing by four the xcm fees constant to match the x4 cpu per block
+        const chargedFeeForClaim = (chargedWeightForClaim * 50000n) / 4n;
 
         const balanceAfter = (
           await polkadotJs.query.system.account(paraSovereign)

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-4.ts
@@ -81,7 +81,8 @@ describeSuite({
         );
         // We are charging chargedWeight
         // chargedWeight * 50000 = chargedFee
-        const chargedFee = chargedWeight * 50000n;
+        // Dividing by four the xcm fees constant to match the x4 cpu per block
+        const chargedFee = (chargedWeight * 50000n) / 4n;
 
         // Send an XCM and create block to execute it
         await injectHrmpMessageAndSeal(context, foreign_para_id, {

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-payment-api.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-payment-api.ts
@@ -135,7 +135,7 @@ describeSuite({
 
         expect(weightToNativeFee.isOk).to.be.true;
         // 0.0005 GLMR
-        expect(BigInt(weightToNativeFee.asOk.toJSON())).to.eq(500_000_000_000_000n);
+        expect(BigInt(weightToNativeFee.asOk.toJSON())).to.eq(125_000_000_000_000n);
 
         const weightToForeignFee = await polkadotJs.call.xcmPaymentApi.queryWeightToAssetFee(
           {

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-1.ts
@@ -75,8 +75,8 @@ describeSuite({
           context,
           context.polkadotJs().createType("XcmVersionedXcm", xcmMessage)
         );
-
-        const chargedFee = chargedWeight * 50000n;
+        // Dividing by four the xcm fees constant to match the x4 cpu per block
+        const chargedFee = (chargedWeight * 50000n) / 4n;
 
         await injectHrmpMessageAndSeal(context, foreign_para_id, {
           type: "XcmVersionedXcm",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-2.ts
@@ -75,8 +75,8 @@ describeSuite({
           context,
           context.polkadotJs().createType("XcmVersionedXcm", xcmMessage)
         );
-
-        const chargedFee = chargedWeight * 50000n;
+        // Dividing by four the xcm fees constant to match the x4 cpu per block
+        const chargedFee = (chargedWeight * 50000n) / 4n;
 
         await injectHrmpMessageAndSeal(context, foreign_para_id, {
           type: "XcmVersionedXcm",


### PR DESCRIPTION
### What does it do?

Since we have 4 times more cpu time per block, we need to divide as well the xcm fees constant that account for cpu time

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
