### PR TITLE
Fix passing BUILD_OPTS for runtime build

### DIFF
--- a/scripts/build-runtime-srtool.sh
+++ b/scripts/build-runtime-srtool.sh
@@ -13,7 +13,7 @@ CMD="docker run \
   -e CARGO_NET_GIT_FETCH_WITH_CLI=true \
   -e PACKAGE=${GH_WORKFLOW_MATRIX_CHAIN}-runtime \
   -e RUNTIME_DIR=runtime/${GH_WORKFLOW_MATRIX_CHAIN} \
-  -e BUILD_OPTS='--features on-chain-release-build' \
+  -e BUILD_OPTS=--features on-chain-release-build \
   -e PROFILE=production \
   -e WASM_BUILD_STD=0 \
   -v ${PWD}:/build \


### PR DESCRIPTION
### What does it do?

Fix the build scripts to build the rutntime release

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
