### PR TITLE
pass the build settings via the github workflow

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -89,6 +89,8 @@ jobs:
           GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
+          RUNTIME_BUILD_OPTS: "--features on-chain-release-build"
+          RUNTIME_BUILD_PROFILE: "production"
         run: |
           # Ensure we have permissions to write to the runtime folder target for the docker user
           mkdir -p runtime/${GH_WORKFLOW_MATRIX_CHAIN}/target

--- a/scripts/build-runtime-srtool.sh
+++ b/scripts/build-runtime-srtool.sh
@@ -13,8 +13,8 @@ CMD="docker run \
   -e CARGO_NET_GIT_FETCH_WITH_CLI=true \
   -e PACKAGE=${GH_WORKFLOW_MATRIX_CHAIN}-runtime \
   -e RUNTIME_DIR=runtime/${GH_WORKFLOW_MATRIX_CHAIN} \
-  -e BUILD_OPTS=--features on-chain-release-build \
-  -e PROFILE=production \
+  -e BUILD_OPTS=${RUNTIME_BUILD_OPTS} \
+  -e PROFILE=${RUNTIME_BUILD_PROFILE} \
   -e WASM_BUILD_STD=0 \
   -v ${PWD}:/build \
   -v /home/${USER}/srtool/.ssh:/home/builder/.ssh \


### PR DESCRIPTION
### What does it do?

move the build parameters from the build script to the github workflow as it allow to change the build behavior by selecting the workflow branch during build

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
