### PR TITLE
Schedule recurrent build for benchmarks

### DIFF
--- a/.github/workflows/check-benchmarks.yml
+++ b/.github/workflows/check-benchmarks.yml
@@ -2,6 +2,10 @@ name: Check benchmarks
 
 on:
   workflow_dispatch:
+    on:
+  schedule:
+    - cron: "0 5 * * 0"  # Runs every Sunday at 5:00 AM UTC
+    - cron: "0 5 * * 3"  # Runs every Wednesday at 5:00 AM UTC
 
 jobs:
   set-tags:

--- a/.github/workflows/check-benchmarks.yml
+++ b/.github/workflows/check-benchmarks.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     on:
   schedule:
-    - cron: "0 5 * * 0"  # Runs every Sunday at 5:00 AM UTC
-    - cron: "0 5 * * 3"  # Runs every Wednesday at 5:00 AM UTC
+    - cron: "0 5 * * 0" # Runs every Sunday at 5:00 AM UTC
+    - cron: "0 5 * * 3" # Runs every Wednesday at 5:00 AM UTC
 
 jobs:
   set-tags:

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -89,7 +89,7 @@ jobs:
           GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
-          RUNTIME_BUILD_OPTS: "--features on-chain-release-build"
+          RUNTIME_BUILD_OPTS: "--features=on-chain-release-build"
           RUNTIME_BUILD_PROFILE: "production"
         run: |
           # Ensure we have permissions to write to the runtime folder target for the docker user

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -38,7 +38,7 @@ jobs:
       - id: get-version
         run: |
           RUST_VERSION=$(cat rust-toolchain | grep channel | grep --only-matching --perl-regexp "(\d+\.){2}\d+(-nightly)?")
-          echo "::set-output name=rust_version::$RUST_VERSION"
+          echo "rust_version=$RUST_VERSION" >> $GITHUB_OUTPUT
 
   build-srtool-runtimes:
     needs: ["setup-scripts", "read-rust-version"]


### PR DESCRIPTION
### What does it do?

- Schedule benchmark checks every Wednesday and Sunday at 5AM UTC. 
- Include a fix for the `publish-runtime.yml` workflow


### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
