### PR TITLE
fix: support runtime api Core::initialize_block for old runtimes

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -442,15 +442,30 @@ where
 				// The block is initialized inside "trace_block"
 				api.trace_block(parent_block_hash, exts, eth_tx_hashes, &header)
 			} else {
-				// Pre pallet-message-queue
+				// Get core runtime api version
+				let core_api_version = if let Ok(Some(api_version)) =
+					api.api_version::<dyn Core<B>>(parent_block_hash)
+				{
+					api_version
+				} else {
+					return Err(internal_err(
+						"Runtime api version call failed (core)".to_string(),
+					));
+				};
 
 				// Initialize block: calls the "on_initialize" hook on every pallet
 				// in AllPalletsWithSystem
 				// This was fine before pallet-message-queue because the XCM messages
 				// were processed by the "setValidationData" inherent call and not on an
 				// "on_initialize" hook, which runs before enabling XCM tracing
-				api.initialize_block(parent_block_hash, &header)
-					.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+				if core_api_version >= 5 {
+					api.initialize_block(parent_block_hash, &header)
+						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+				} else {
+					#[allow(deprecated)]
+					api.initialize_block_before_version_5(parent_block_hash, &header)
+						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+				}
 
 				#[allow(deprecated)]
 				api.trace_block_before_version_5(parent_block_hash, exts, eth_tx_hashes)
@@ -583,15 +598,34 @@ where
 						// The block is initialized inside "trace_transaction"
 						api.trace_transaction(parent_block_hash, exts, &transaction, &header)
 					} else {
+						// Get core runtime api version
+						let core_api_version = if let Ok(Some(api_version)) =
+							api.api_version::<dyn Core<B>>(parent_block_hash)
+						{
+							api_version
+						} else {
+							return Err(internal_err(
+								"Runtime api version call failed (core)".to_string(),
+							));
+						};
+
 						// Initialize block: calls the "on_initialize" hook on every pallet
 						// in AllPalletsWithSystem
 						// This was fine before pallet-message-queue because the XCM messages
 						// were processed by the "setValidationData" inherent call and not on an
 						// "on_initialize" hook, which runs before enabling XCM tracing
-						api.initialize_block(parent_block_hash, &header)
-							.map_err(|e| {
-								internal_err(format!("Runtime api access error: {:?}", e))
-							})?;
+						if core_api_version >= 5 {
+							api.initialize_block(parent_block_hash, &header)
+								.map_err(|e| {
+									internal_err(format!("Runtime api access error: {:?}", e))
+								})?;
+						} else {
+							#[allow(deprecated)]
+							api.initialize_block_before_version_5(parent_block_hash, &header)
+								.map_err(|e| {
+									internal_err(format!("Runtime api access error: {:?}", e))
+								})?;
+						}
 
 						if trace_api_version == 4 {
 							// Pre pallet-message-queue

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -859,15 +859,28 @@ where
 					&block_header,
 				)
 			} else {
-				// Pre pallet-message-queue
+				// Get core runtime api version
+				let core_api_version = if let Ok(Some(api_version)) =
+					api.api_version::<dyn Core<B>>(substrate_parent_hash)
+				{
+					api_version
+				} else {
+					return Err("Runtime api version call failed (core)".to_string());
+				};
 
 				// Initialize block: calls the "on_initialize" hook on every pallet
 				// in AllPalletsWithSystem
 				// This was fine before pallet-message-queue because the XCM messages
 				// were processed by the "setValidationData" inherent call and not on an
 				// "on_initialize" hook, which runs before enabling XCM tracing
-				api.initialize_block(substrate_parent_hash, &block_header)
-					.map_err(|e| format!("Runtime api access error: {:?}", e))?;
+				if core_api_version >= 5 {
+					api.initialize_block(substrate_parent_hash, &block_header)
+						.map_err(|e| format!("Runtime api access error: {:?}", e))?;
+				} else {
+					#[allow(deprecated)]
+					api.initialize_block_before_version_5(substrate_parent_hash, &block_header)
+						.map_err(|e| format!("Runtime api access error: {:?}", e))?;
+				}
 
 				#[allow(deprecated)]
 				api.trace_block_before_version_5(substrate_parent_hash, extrinsics, eth_tx_hashes)


### PR DESCRIPTION
### What does it do?

Backport fix from perm-v0.39.1 https://github.com/moonbeam-foundation/moonbeam/commit/184ca3743baca8b7c43ae33f4d584d21bae82d33

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
