### PR TITLE
fix warning related to deprecated '--execution' argument

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -221,18 +221,8 @@ fn validate_trace_environment(cli: &Cli) -> Result<()> {
 
 /// Parse command line arguments into service configuration.
 pub fn run() -> Result<()> {
-	let mut cli = Cli::from_args();
+	let cli = Cli::from_args();
 	let _ = validate_trace_environment(&cli)?;
-	// Set --execution wasm as default
-	let execution_strategies = cli.run.base.base.import_params.execution_strategies.clone();
-	if execution_strategies.execution.is_none() {
-		cli.run
-			.base
-			.base
-			.import_params
-			.execution_strategies
-			.execution = Some(sc_cli::ExecutionStrategy::Wasm);
-	}
 
 	match &cli.subcommand {
 		Some(Subcommand::BuildSpec(params)) => {


### PR DESCRIPTION
### What does it do?

This PR fixes a deprecation warning during node startup:

```bash
CLI parameter `--execution` has no effect anymore and will be removed in the future!
```

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
