### PR TITLE
fix: propagate error instead of panicking in manual sealing

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1808,7 +1808,9 @@ where
 			.client
 			.header(hash)
 			.map_err(|e| sp_inherents::Error::Application(Box::new(e)))?
-			.expect("Best block header should be present")
+			.ok_or(sp_inherents::Error::Application(
+				"Best block header should be present".into(),
+			))?
 			.digest;
 		// Get the nimbus id from the digest.
 		let nimbus_id = digest
@@ -1816,15 +1818,18 @@ where
 			.iter()
 			.find_map(|x| {
 				if let DigestItem::PreRuntime(nimbus_primitives::NIMBUS_ENGINE_ID, nimbus_id) = x {
-					Some(
-						NimbusId::from_slice(nimbus_id.as_slice())
-							.expect("Nimbus pre-runtime digest should be valid"),
-					)
+					Some(NimbusId::from_slice(nimbus_id.as_slice()).map_err(|_| {
+						sp_inherents::Error::Application(
+							"Nimbus pre-runtime digest should be valid".into(),
+						)
+					}))
 				} else {
 					None
 				}
 			})
-			.expect("Nimbus pre-runtime digest should be present");
+			.ok_or(sp_inherents::Error::Application(
+				"Nimbus pre-runtime digest should be present".into(),
+			))??;
 		// Remove the old VRF digest.
 		let pos = digest.logs.iter().position(|x| {
 			matches!(


### PR DESCRIPTION
### What does it do?

Fixes https://github.com/moonbeam-foundation/moonbeam/issues/2917, by propagating the error instead of panicking.

By propagating the error, the frontier RPC will now return the error below instead of crashing the node:

```
Failed to deploy contract: ProviderError: Create pending runtime api error: Failed to create pending inherent data, Nimbus pre-runtime digest should be present
```

### What important points reviewers should know?

This only affects the dev mode (Manual sealing).
