### PR TITLE
Suspend XCM checks for Litms until November 30

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -120,7 +120,7 @@ export const ForeignChainsEndpoints = [
       {
         name: "Litmus",
         paraId: 2106,
-        mutedUntil: new Date("2024-10-01").getTime(),
+        mutedUntil: new Date("2024-11-30").getTime(),
       },
       {
         name: "Mangata",


### PR DESCRIPTION
### What does it do?

Pauses XCM checks for Litmus chain until their lease end (November 30)

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
