### PR TITLE
add bootnode to moonbeam

### DIFF
--- a/specs/moonbeam/parachain-embedded-specs.json
+++ b/specs/moonbeam/parachain-embedded-specs.json
@@ -16,7 +16,8 @@
     "/dns/apac-01.unitedbloc.com/tcp/37060/p2p/12D3KooWCnXymVyowL5YymVk6RNzRzFAWUvurX7eTTYAFcCbs4nj",
     "/dns/sa-01.unitedbloc.com/tcp/37060/p2p/12D3KooWC3FoL2bFJ79C5CeLDjLmL2yRyozPxSjTQbm9RY95KNsV",
     "/dns/na-01.unitedbloc.com/tcp/37060/p2p/12D3KooWLEZwHD8tWvWiEqKcD976wxdE5JRUnq1JG9a6VJxHUjiS",
-    "/dns4/moonbeam-1.boot.onfinality.io/tcp/28868/ws/p2p/12D3KooWEvop16VcctRftvTDdi5dSGWAA2FA9tXiZyZwzfBpH83L"
+    "/dns4/moonbeam-1.boot.onfinality.io/tcp/28868/ws/p2p/12D3KooWEvop16VcctRftvTDdi5dSGWAA2FA9tXiZyZwzfBpH83L",
+    "/dns/moonbeam-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]

--- a/specs/moonbeam/parachain-embedded-specs.json
+++ b/specs/moonbeam/parachain-embedded-specs.json
@@ -17,7 +17,8 @@
     "/dns/sa-01.unitedbloc.com/tcp/37060/p2p/12D3KooWC3FoL2bFJ79C5CeLDjLmL2yRyozPxSjTQbm9RY95KNsV",
     "/dns/na-01.unitedbloc.com/tcp/37060/p2p/12D3KooWLEZwHD8tWvWiEqKcD976wxdE5JRUnq1JG9a6VJxHUjiS",
     "/dns4/moonbeam-1.boot.onfinality.io/tcp/28868/ws/p2p/12D3KooWEvop16VcctRftvTDdi5dSGWAA2FA9tXiZyZwzfBpH83L",
-    "/dns/moonbeam-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh"
+    "/dns/moonbeam-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh",
+    "/dns/moonbeam-boot-ng.dwellir.com/tcp/30364/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]


### PR DESCRIPTION
### What does it do?
Adds a dwellir bootnode to the specfile for moonbeam. Verify with:
```
./moonbeam --chain=moonbeam --reserved-only --reserved-nodes=/dns/moonbeam-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh
```
```
./moonbeam --chain=moonbeam --reserved-only --reserved-nodes=/dns/moonbeam-boot-ng.dwellir.com/tcp/30364/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh
```

### What important points reviewers should know?
As noted above
### Is there something left for follow-up PRs?
No
### What alternative implementations were considered?
N/A
### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
No
### What value does it bring to the blockchain users?
Adds more resilience to the network by increasing the amount and locations of bootnodes.