### PR TITLE
fix round initialization when in lazy loading

### DIFF
--- a/node/service/src/lazy_loading/backend.rs
+++ b/node/service/src/lazy_loading/backend.rs
@@ -575,7 +575,13 @@ impl<Block: BlockT + DeserializeOwned> BlockImportOperation<Block> {
 			self.storage_updates = storage
 				.top
 				.iter()
-				.map(|(k, v)| (k.clone(), Some(v.clone())))
+				.map(|(k, v)| {
+					if v.is_empty() {
+						(k.clone(), None)
+					} else {
+						(k.clone(), Some(v.clone()))
+					}
+				})
 				.collect();
 		}
 		Ok(root)

--- a/node/service/src/lazy_loading/state_overrides.rs
+++ b/node/service/src/lazy_loading/state_overrides.rs
@@ -15,10 +15,11 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::chain_spec::generate_accounts;
-use moonbeam_core_primitives::Balance;
+use moonbeam_core_primitives::{AccountId, Balance};
+use pallet_parachain_staking::{Bond, CandidateMetadata, CollatorSnapshot, Delegations};
 use parity_scale_codec::Encode;
 use serde::Deserialize;
-use sp_core::blake2_128;
+use sp_core::{blake2_128, twox_64};
 use std::io::Read;
 use std::path::PathBuf;
 
@@ -53,68 +54,128 @@ pub enum StateEntry {
 
 /// Mandatory state overrides that most exist when starting a node in lazy loading mode.
 pub fn base_state_overrides(runtime_code: Option<PathBuf>) -> Vec<StateEntry> {
+	use hex_literal::hex;
+	let alith_address = hex!("f24ff3a9cf04c71dbc94d0b566f7a27b94566cac");
+	let alith_pub = hex!("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
+	let alith_staking_bond: Balance = 1_000_000_000_000_000_000;
 	let mut overrides = vec![
-		StateEntry::Concrete(
-			StateEntryConcrete {
-				pallet: "AuthorMapping".to_string(),
-				storage: "NimbusLookup".to_string(),
-				key: Some(hex_literal::hex!("9dfefc73f89d24437a9c2dce5572808af24ff3a9cf04c71dbc94d0b566f7a27b94566cac").to_vec()), // editorconfig-checker-disable-line
-				value: hex_literal::hex!("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").to_vec() // editorconfig-checker-disable-line
-			}
-		),
-		StateEntry::Concrete(
-			StateEntryConcrete {
-				pallet: "AuthorMapping".to_string(),
-				storage: "MappingWithDeposit".to_string(),
-				key: Some(hex_literal::hex!("de1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").to_vec()), // editorconfig-checker-disable-line
-				value: hex_literal::hex!("f24ff3a9cf04c71dbc94d0b566f7a27b94566cac000010632d5ec76b0500000000000000d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").to_vec() // editorconfig-checker-disable-line
-			}
-		),
-		// Set candidate pool
-		StateEntry::Concrete(
-			StateEntryConcrete {
-				pallet: "ParachainStaking".to_string(),
-				storage: "CandidatePool".to_string(),
-				key: None,
-				value: hex_literal::hex!("04f24ff3a9cf04c71dbc94d0b566f7a27b94566cac0000a0dec5adc9353600000000000000").to_vec() // editorconfig-checker-disable-line
-			}
-		),
-		// Set Alith as selected candidate
-		StateEntry::Concrete(
-			StateEntryConcrete {
-				pallet: "ParachainStaking".to_string(),
-				storage: "SelectedCandidates".to_string(),
-				key: None,
-				value: hex_literal::hex!("04f24ff3a9cf04c71dbc94d0b566f7a27b94566cac").to_vec()
-			}
-		),
-		// AtStake
-		StateEntry::Concrete(
-			StateEntryConcrete {
-				pallet: "ParachainStaking".to_string(),
-				storage: "AtStake".to_string(),
-				key: Some(hex_literal::hex!("5153cb1f00942ff4010000004a6bb7c01d316509f24ff3a9cf04c71dbc94d0b566f7a27b94566cac").to_vec()), // editorconfig-checker-disable-line
-				value: hex_literal::hex!("0000a0dec5adc9353600000000000000000000a0dec5adc9353600000000000000").to_vec() // editorconfig-checker-disable-line
-			}
-		),
-		// Reset SlotInfo
-		StateEntry::Concrete(
-			StateEntryConcrete {
-				pallet: "AsyncBacking".to_string(),
-				storage: "SlotInfo".to_string(),
-				key: None,
-				value: (1u64, 1u32).encode()
-			}
-		),
+		// Override `PendingValidationCode` since it conflicts
+		// with lazy loading
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainSystem".to_string(),
+			storage: "PendingValidationCode".to_string(),
+			key: None,
+			value: Vec::new(),
+		}),
 		// Reset LastRelayChainBlockNumber
-		StateEntry::Concrete(
-			StateEntryConcrete {
-				pallet: "ParachainSystem".to_string(),
-				storage: "LastRelayChainBlockNumber".to_string(),
-				key: None,
-				value: 0u32.encode()
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainSystem".to_string(),
+			storage: "LastRelayChainBlockNumber".to_string(),
+			key: None,
+			value: 0u32.encode(),
+		}),
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "AuthorMapping".to_string(),
+			storage: "NimbusLookup".to_string(),
+			key: Some(
+				[
+					&blake2_128(alith_address.as_slice()),
+					alith_address.as_slice(),
+				]
+				.concat(),
+			),
+			value: alith_pub.to_vec(),
+		}),
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "AuthorMapping".to_string(),
+			storage: "MappingWithDeposit".to_string(),
+			key: Some([&blake2_128(alith_pub.as_slice()), alith_pub.as_slice()].concat()),
+			value: (alith_address, alith_staking_bond, alith_pub).encode(),
+		}),
+		// We only use one collator in lazy-loading
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainStaking".to_string(),
+			storage: "TotalSelected".to_string(),
+			key: None,
+			value: 1u32.encode(),
+		}),
+		// Set candidate pool
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainStaking".to_string(),
+			storage: "CandidateInfo".to_string(),
+			key: Some(
+				[&twox_64(alith_address.as_slice()), alith_address.as_slice()]
+					.concat()
+					.to_vec(),
+			),
+			value: CandidateMetadata::new(alith_staking_bond).encode(),
+		}),
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainStaking".to_string(),
+			storage: "TopDelegations".to_string(),
+			key: Some(
+				[&twox_64(alith_address.as_slice()), alith_address.as_slice()]
+					.concat()
+					.to_vec(),
+			),
+			value: Delegations::<AccountId, Balance> {
+				delegations: Default::default(),
+				total: Default::default(),
 			}
-		),
+			.encode(),
+		}),
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainStaking".to_string(),
+			storage: "CandidatePool".to_string(),
+			key: None,
+			value: {
+				let bond = Bond::<AccountId, Balance> {
+					owner: AccountId::from(alith_address),
+					amount: alith_staking_bond,
+				};
+
+				vec![bond].encode()
+			},
+		}),
+		// Set Alith as selected candidate
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainStaking".to_string(),
+			storage: "SelectedCandidates".to_string(),
+			key: None,
+			value: vec![alith_address].encode(),
+		}),
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "ParachainStaking".to_string(),
+			storage: "AtStake".to_string(),
+			key: {
+				let round: u32 = 1;
+				Some(
+					[
+						&twox_64(&round.encode()),
+						round.encode().as_slice(),
+						&twox_64(alith_address.as_slice()),
+						alith_address.as_slice(),
+					]
+					.concat()
+					.to_vec(),
+				)
+			},
+			value: {
+				CollatorSnapshot::<AccountId, Balance> {
+					bond: alith_staking_bond.clone(),
+					delegations: Default::default(),
+					total: alith_staking_bond,
+				}
+				.encode()
+			},
+		}),
+		// Reset SlotInfo
+		StateEntry::Concrete(StateEntryConcrete {
+			pallet: "AsyncBacking".to_string(),
+			storage: "SlotInfo".to_string(),
+			key: None,
+			value: (1u64, 1u32).encode(),
+		}),
 	];
 
 	// Default mnemonic if none was provided


### PR DESCRIPTION
### What does it do?

Fixes an error `all members of CandidateQ must be candidates` which happen after a completing a staking round when using lazy loading.