### PR TITLE
Pause XCM check on parachain 2019

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -164,7 +164,7 @@ export const ForeignChainsEndpoints = [
       {
         name: "Composable",
         paraId: 2019,
-        mutedUntil: new Date("2024-10-15").getTime(),
+        mutedUntil: new Date("2025-01-27").getTime(),
       },
       {
         name: "Nodle",


### PR DESCRIPTION
### What does it do?

Pauses the XCM check on parachain 2019 until January 27, 2025

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
