### PR TITLE
Add RadiumBlock bootnode to Moonbeam and Moonriver spec

### DIFF
--- a/specs/moonbeam/parachain-embedded-specs.json
+++ b/specs/moonbeam/parachain-embedded-specs.json
@@ -16,7 +16,9 @@
     "/dns/apac-01.unitedbloc.com/tcp/37060/p2p/12D3KooWCnXymVyowL5YymVk6RNzRzFAWUvurX7eTTYAFcCbs4nj",
     "/dns/sa-01.unitedbloc.com/tcp/37060/p2p/12D3KooWC3FoL2bFJ79C5CeLDjLmL2yRyozPxSjTQbm9RY95KNsV",
     "/dns/na-01.unitedbloc.com/tcp/37060/p2p/12D3KooWLEZwHD8tWvWiEqKcD976wxdE5JRUnq1JG9a6VJxHUjiS",
-    "/dns4/moonbeam-1.boot.onfinality.io/tcp/28868/ws/p2p/12D3KooWEvop16VcctRftvTDdi5dSGWAA2FA9tXiZyZwzfBpH83L"
+    "/dns4/moonbeam-1.boot.onfinality.io/tcp/28868/ws/p2p/12D3KooWEvop16VcctRftvTDdi5dSGWAA2FA9tXiZyZwzfBpH83L",
+    "/dns/moonbeam-rb-bootnode.radiumblock.com/tcp/30333/p2p/12D3KooWD8onR51M6TR3tuHEZFnEPJC7yp5tYoKrQyoK2Mb4egky",
+    "/dns/moonbeam-rb-bootnode.radiumblock.com/tcp/30336/wss/p2p/12D3KooWD8onR51M6TR3tuHEZFnEPJC7yp5tYoKrQyoK2Mb4egky"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]


### PR DESCRIPTION
What does it do?
Add RadiumBlock bootnode to Moonbeam and Moonriver spec

Is there something left for follow-up PRs?
No

What alternative implementations were considered?
None

Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
None

What value does it bring to the blockchain users?
Have another bootnode to discover peers