### PR TITLE
Add RadiumBlock Moonbeam Bootnode to Moonbeam spec

### DIFF
--- a/specs/moonriver/parachain-embedded-specs.json
+++ b/specs/moonriver/parachain-embedded-specs.json
@@ -15,7 +15,9 @@
     "/dns/apac-01.unitedbloc.com/tcp/36060/p2p/12D3KooWAosKitTohMgbKqTtcaUvyUHpP3vbnL7het3nFBSfheZ7",
     "/dns/sa-01.unitedbloc.com/tcp/36060/p2p/12D3KooWBXSNJudphGqb4TKmgfruZkY79PsN9aGYFnLgYR4ou3SH",
     "/dns/na-01.unitedbloc.com/tcp/36060/p2p/12D3KooWLVmzvBxKvJyg8u4fUuBgnSBJGS8wQFXKvyHUBzJ1pAuT",
-    "/dns4/moonriver-1.boot.onfinality.io/tcp/28871/ws/p2p/12D3KooWSpLYDMXBdDrX4LaU3NpTc7W4psLFXvnaVfyCcu3Jouq9"
+    "/dns4/moonriver-1.boot.onfinality.io/tcp/28871/ws/p2p/12D3KooWSpLYDMXBdDrX4LaU3NpTc7W4psLFXvnaVfyCcu3Jouq9",
+    "/dns/moonriver-rb-bootnode.radiumblock.com/tcp/30333/p2p/12D3KooWS9M1gTQUJPA9VRcg44DKPv1iaCMBfE6ffGBB95YziYiG",
+    "/dns/moonriver-rb-bootnode.radiumblock.com/tcp/30336/wss/p2p/12D3KooWS9M1gTQUJPA9VRcg44DKPv1iaCMBfE6ffGBB95YziYiG"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]


### PR DESCRIPTION
What does it do?
Add RadiumBlock bootnode to Moonbeam spec

Is there something left for follow-up PRs?
No

What alternative implementations were considered?
None

Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
None

What value does it bring to the blockchain users?
Have another bootnode to discover peers