### PR TITLE
fix(metadata-hash): use original token symbol (DEV) in moonbase runtime

### DIFF
--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -73,7 +73,7 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 	.with_chain_type(ChainType::Development)
 	.with_properties(
 		serde_json::from_str(
-			"{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\", \"SS58Prefix\": 1287}",
+			"{\"tokenDecimals\": 18, \"tokenSymbol\": \"DEV\", \"SS58Prefix\": 1287}",
 		)
 		.expect("Provided valid json map"),
 	)
@@ -118,7 +118,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 	.with_chain_type(ChainType::Local)
 	.with_properties(
 		serde_json::from_str(
-			"{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\", \"SS58Prefix\": 1287}",
+			"{\"tokenDecimals\": 18, \"tokenSymbol\": \"DEV\", \"SS58Prefix\": 1287}",
 		)
 		.expect("Provided valid json map"),
 	)

--- a/runtime/moonbase/build.rs
+++ b/runtime/moonbase/build.rs
@@ -31,6 +31,6 @@ fn main() {
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
-		.enable_metadata_hash("UNIT", 18)
+		.enable_metadata_hash("DEV", 18)
 		.build()
 }


### PR DESCRIPTION
### What does it do?

Uses the original moonbase token symbol when using `metadata-hash` transaction extension.

The [original token symbol](https://github.com/moonbeam-foundation/moonbeam/blob/6b786e8367c40e248b59047b908c6328cedcf39c/specs/alphanet/parachain-embedded-specs-v8.json#L24) used in moonbase is `DEV` and not `UNIT`. When leveraging metadata hash, the token symbol is included in the metadata digest and would cause the transaction to fail.

<img width="801" alt="image" src="https://github.com/user-attachments/assets/319e01bd-5c84-4ed2-9a03-9aec49c1c39f">

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
