### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/precompiles/assets-erc20/src/eip2612.rs
+++ b/precompiles/assets-erc20/src/eip2612.rs
@@ -147,7 +147,7 @@ where
 			Address(address),
 		));
 
-		keccak_256(&domain_separator_inner).into()
+		keccak_256(&domain_separator_inner)
 	}
 
 	pub fn generate_permit(
@@ -180,6 +180,7 @@ where
 
 	// Translated from
 	// https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2ERC20.sol#L81
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn permit(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,
@@ -219,8 +220,8 @@ where
 		);
 
 		let mut sig = [0u8; 65];
-		sig[0..32].copy_from_slice(&r.as_bytes());
-		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[0..32].copy_from_slice(r.as_bytes());
+		sig[32..64].copy_from_slice(s.as_bytes());
 		sig[64] = v;
 
 		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -67,7 +67,7 @@ pub type AssetIdOf<Runtime, Instance = ()> = <Runtime as pallet_assets::Config<I
 /// 1024-2047 Precompiles that are not in Ethereum Mainnet but are neither Moonbeam specific
 /// 2048-4095 Moonbeam specific precompiles
 /// Asset precompiles can only fall between
-/// 	0xFFFFFFFF00000000000000000000000000000000 - 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+///     0xFFFFFFFF00000000000000000000000000000000 - 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 /// The precompile for AssetId X, where X is a u128 (i.e.16 bytes), if 0XFFFFFFFF + Bytes(AssetId)
 /// In order to route the address to Erc20AssetsPrecompile<R>, we first check whether the AssetId
 /// exists in pallet-assets
@@ -335,7 +335,7 @@ where
 		{
 			let caller: Runtime::AccountId =
 				Runtime::AddressMapping::into_account_id(handle.context().caller);
-			let from: Runtime::AccountId = Runtime::AddressMapping::into_account_id(from.clone());
+			let from: Runtime::AccountId = Runtime::AddressMapping::into_account_id(from);
 			let to: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to);
 
 			// If caller is "from", it can spend as much as it wants from its own balance.
@@ -507,6 +507,7 @@ where
 	}
 
 	#[precompile::public("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")]
+	#[allow(clippy::too_many_arguments)]
 	fn eip2612_permit(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -59,7 +59,7 @@ where
 			Address(address),
 		));
 
-		keccak_256(&domain_separator_inner).into()
+		keccak_256(&domain_separator_inner)
 	}
 
 	pub fn generate_permit(
@@ -91,6 +91,7 @@ where
 
 	// Translated from
 	// https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2ERC20.sol#L81
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn permit(
 		handle: &mut impl PrecompileHandle,
 		owner: Address,
@@ -126,8 +127,8 @@ where
 		);
 
 		let mut sig = [0u8; 65];
-		sig[0..32].copy_from_slice(&r.as_bytes());
-		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[0..32].copy_from_slice(r.as_bytes());
+		sig[32..64].copy_from_slice(s.as_bytes());
 		sig[64] = v;
 
 		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -286,7 +286,7 @@ where
 				Some(origin).into(),
 				pallet_balances::Call::<Runtime, Instance>::transfer_allow_death {
 					dest: Runtime::Lookup::unlookup(to),
-					value: value,
+					value,
 				},
 				SYSTEM_ACCOUNT_SIZE,
 			)?;
@@ -352,7 +352,7 @@ where
 				Some(from).into(),
 				pallet_balances::Call::<Runtime, Instance>::transfer_allow_death {
 					dest: Runtime::Lookup::unlookup(to),
-					value: value,
+					value,
 				},
 				SYSTEM_ACCOUNT_SIZE,
 			)?;
@@ -461,6 +461,7 @@ where
 	}
 
 	#[precompile::public("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")]
+	#[allow(clippy::too_many_arguments)]
 	fn eip2612_permit(
 		handle: &mut impl PrecompileHandle,
 		owner: Address,


### PR DESCRIPTION
### What does it do?

This PR fixes some clippy warnings on the following crates:

- `pallet-evm-precompile-balances-erc20`
- `pallet-evm-precompileset-assets-erc20`