### PR TITLE
Fix encoding for debug_traceBlock

### DIFF
--- a/client/evm-tracing/src/types/single.rs
+++ b/client/evm-tracing/src/types/single.rs
@@ -120,5 +120,6 @@ pub struct Log {
 	/// Event topics
 	pub topics: Vec<H256>,
 	/// Event data
+	#[serde(serialize_with = "bytes_0x_serialize")]
 	pub data: Vec<u8>,
 }


### PR DESCRIPTION
### What does it do?
The `data` field in ethereum Logs is an arbitrary array of bytes. We weren't encoding it properly so users of the RPC were not able to decode it

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
