### PR TITLE
Fix `S22C500` smoke test

### DIFF
--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -144,17 +144,17 @@
         {
           "name": "ethers",
           "type": "ethers",
-          "endpoints": ["wss://wss.api.moondev.network"]
+          "endpoints": ["wss://stagenet-unlimited.api.moondev.network"]
         },
         {
           "name": "viem",
           "type": "viem",
-          "endpoints": ["wss://wss.api.moondev.network"]
+          "endpoints": ["wss://stagenet-unlimited.api.moondev.network"]
         },
         {
           "name": "para",
           "type": "polkadotJs",
-          "endpoints": ["wss://wss.api.moondev.network"],
+          "endpoints": ["wss://stagenet-unlimited.api.moondev.network"],
           "rpc": {
             "moon": {
               "isBlockFinalized": {
@@ -173,7 +173,7 @@
           "name": "relay",
           "type": "polkadotJs",
           "endpoints": [
-            "wss://deo-moon-moondev-1-stagenet-relay-rpc-1.rv.moondev.network "
+            "wss://stagenet-relay.api.moondev.network"
           ]
         }
       ]

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -172,9 +172,7 @@
         {
           "name": "relay",
           "type": "polkadotJs",
-          "endpoints": [
-            "wss://stagenet-relay.api.moondev.network"
-          ]
+          "endpoints": ["wss://stagenet-relay.api.moondev.network"]
         }
       ]
     },
@@ -341,9 +339,7 @@
         {
           "name": "relay",
           "type": "polkadotJs",
-          "endpoints": [
-            "wss://relay.api.moonbase.moonbeam.network"
-          ]
+          "endpoints": ["wss://relay.api.moonbase.moonbeam.network"]
         }
       ]
     },

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -312,17 +312,17 @@
         {
           "name": "ethers",
           "type": "ethers",
-          "endpoints": ["wss://wss.api.moonbase.moonbeam.network"]
+          "endpoints": ["wss://trace.api.moonbase.moonbeam.network"]
         },
         {
           "name": "viem",
           "type": "viem",
-          "endpoints": ["wss://wss.api.moonbase.moonbeam.network"]
+          "endpoints": ["wss://trace.api.moonbase.moonbeam.network"]
         },
         {
           "name": "para",
           "type": "polkadotJs",
-          "endpoints": ["wss://wss.api.moonbase.moonbeam.network"],
+          "endpoints": ["wss://trace.api.moonbase.moonbeam.network"],
           "rpc": {
             "moon": {
               "isBlockFinalized": {
@@ -342,7 +342,7 @@
           "name": "relay",
           "type": "polkadotJs",
           "endpoints": [
-            "wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network"
+            "wss://relay.api.moonbase.moonbeam.network"
           ]
         }
       ]

--- a/test/suites/smoke/test-staking-rewards.ts
+++ b/test/suites/smoke/test-staking-rewards.ts
@@ -181,22 +181,22 @@ describeSuite({
             scheduledRequest === undefined
               ? delegationAmount
               : scheduledRequest.action.isDecrease
-              ? delegationAmount.sub(scheduledRequest.action.asDecrease)
-              : scheduledRequest.action.isRevoke
-              ? delegationAmount.sub(scheduledRequest.action.asRevoke)
-              : delegationAmount;
+                ? delegationAmount.sub(scheduledRequest.action.asDecrease)
+                : scheduledRequest.action.isRevoke
+                  ? delegationAmount.sub(scheduledRequest.action.asRevoke)
+                  : delegationAmount;
 
           const match = expected.eq(delegatorSnapshot.amount);
           if (!match) {
             log(
               "Snapshot amount " +
-                delegatorSnapshot.amount.toString() +
-                " does not match storage amount " +
-                delegationAmount.toString() +
-                " for delegator: " +
-                delegatorSnapshot.owner.toString() +
-                " on candidate: " +
-                accountId.toString()
+              delegatorSnapshot.amount.toString() +
+              " does not match storage amount " +
+              delegationAmount.toString() +
+              " for delegator: " +
+              delegatorSnapshot.owner.toString() +
+              " on candidate: " +
+              accountId.toString()
             );
           }
           return {
@@ -233,10 +233,10 @@ describeSuite({
         const estimatedTime = ((delegationCount + atStakeSnapshot.length) / 600).toFixed(2);
         log(
           "With a count of " +
-            delegationCount +
-            " delegations, this may take upto " +
-            estimatedTime +
-            " mins."
+          delegationCount +
+          " delegations, this may take upto " +
+          estimatedTime +
+          " mins."
         );
 
         const results = await Promise.all(promises);
@@ -283,13 +283,13 @@ describeSuite({
           if (!match) {
             log(
               "Snapshot autocompound " +
-                delegatorSnapshot.autoCompound.toString() +
-                "% does not match storage autocompound " +
-                autoCompoundAmount.toString() +
-                "% for delegator: " +
-                delegatorSnapshot.owner.toString() +
-                " on candidate: " +
-                collatorId.toString()
+              delegatorSnapshot.autoCompound.toString() +
+              "% does not match storage autocompound " +
+              autoCompoundAmount.toString() +
+              "% for delegator: " +
+              delegatorSnapshot.owner.toString() +
+              " on candidate: " +
+              collatorId.toString()
             );
           }
           return {
@@ -438,27 +438,27 @@ describeSuite({
       log(
         `
       latest  ${latestRound.current.toString()} ` +
-          `(${latestBlockNumber} / ${latestBlockHash.toHex()})
+        `(${latestBlockNumber} / ${latestBlockHash.toHex()})
       rewarded round ${payment.rewardRound.data.current.toString()} - ` +
-          `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
+        `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
         reward: #${payment.firstRewardBlock.header.number.toString()} / ` +
-          `[${payment.firstRewardBlock.header.hash.toHex()}]
+        `[${payment.firstRewardBlock.header.hash.toHex()}]
          first: #${payment.rewardRound.firstBlock.header.number.toString()} / ` +
-          `[${payment.rewardRound.firstBlock.header.hash.toHex()}]
+        `[${payment.rewardRound.firstBlock.header.hash.toHex()}]
          prior: #${payment.rewardRound.priorBlock.header.number.toString()} / ` +
-          `[${payment.rewardRound.priorBlock.header.hash.toHex()}]
+        `[${payment.rewardRound.priorBlock.header.hash.toHex()}]
       delayed payout computation round ${payment.delayedPayoutRound.data.current.toString()} - ` +
-          `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
+        `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
          first: #${payment.delayedPayoutRound.firstBlock.header.number.toString()} / ` +
-          `[${payment.delayedPayoutRound.firstBlock.header.hash.toHex()}]
+        `[${payment.delayedPayoutRound.firstBlock.header.hash.toHex()}]
          prior: #${payment.delayedPayoutRound.priorBlock.header.number.toString()} / ` +
-          `[${payment.delayedPayoutRound.priorBlock.header.hash.toHex()}]
+        `[${payment.delayedPayoutRound.priorBlock.header.hash.toHex()}]
       round to pay ${payment.roundToPay.data.current.toString()} - ` +
-          `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
+        `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
          first: #${payment.roundToPay.firstBlock.header.number.toString()} / ` +
-          `[${payment.roundToPay.firstBlock.header.hash.toHex()}]
+        `[${payment.roundToPay.firstBlock.header.hash.toHex()}]
          prior: #${payment.roundToPay.priorBlock.header.number.toString()} / ` +
-          `[${payment.roundToPay.priorBlock.header.hash.toHex()}]`
+        `[${payment.roundToPay.priorBlock.header.hash.toHex()}]`
       );
 
       // collect info about staked value from collators and delegators
@@ -535,7 +535,7 @@ describeSuite({
           if (!Object.keys(collatorInfo.delegators).includes(topDelegation)) {
             throw new Error(
               `${topDelegation} is missing from collatorInfo ` +
-                `for round ${payment.roundToPay.data.current.toString()}`
+              `for round ${payment.roundToPay.data.current.toString()}`
             );
           }
         }
@@ -543,7 +543,7 @@ describeSuite({
           if (!topDelegations.has(delegator as any)) {
             throw new Error(
               `${delegator} is missing from topDelegations for round` +
-                ` ${payment.roundToPay.data.current.toString()}`
+              ` ${payment.roundToPay.data.current.toString()}`
             );
           }
         }
@@ -612,7 +612,7 @@ describeSuite({
       // calculate total staking reward
       const firstBlockRewardedEvents =
         await payment.delayedPayoutRound.firstBlockApi.query.system.events();
-      const reservedInflation = new BN(0);
+      let reservedInflation = new BN(0);
       for (const { phase, event } of firstBlockRewardedEvents) {
         if (!phase.isInitialization) {
           continue;
@@ -620,7 +620,7 @@ describeSuite({
         const eventTypes = payment.delayedPayoutRound.firstBlockApi.events;
         // only deduct parachainBondReward if it was transferred (event must exist)
         if (eventTypes.parachainStaking.InflationDistributed.is(event)) {
-          reservedInflation.addn(event.data.value.toNumber());
+          reservedInflation = reservedInflation.add(new BN(event.data.value.toString()));
         }
       }
 
@@ -780,16 +780,14 @@ describeSuite({
         );
         expect(
           notRewarded,
-          `delegators "${[...notRewarded].join(", ")}" were not rewarded for collator "${
-            rewarded.collator
+          `delegators "${[...notRewarded].join(", ")}" were not rewarded for collator "${rewarded.collator
           }" at block ${blockNumber}`
         ).to.be.empty;
         expect(
           unexpectedlyRewarded,
           `delegators "${[...unexpectedlyRewarded].join(
             ", "
-          )}" were unexpectedly rewarded for collator "${
-            rewarded.collator
+          )}" were unexpectedly rewarded for collator "${rewarded.collator
           }" at block ${blockNumber}`
         ).to.be.empty;
 
@@ -814,16 +812,14 @@ describeSuite({
             notAutoCompounded,
             `delegators "${[...notAutoCompounded].join(
               ", "
-            )}" were not auto-compounded for collator "${
-              rewarded.collator
+            )}" were not auto-compounded for collator "${rewarded.collator
             }" at block ${blockNumber}`
           ).to.be.empty;
           expect(
             unexpectedlyAutoCompounded,
             `delegators "${[...unexpectedlyAutoCompounded].join(
               ", "
-            )}" were unexpectedly auto-compounded for collator "${
-              rewarded.collator
+            )}" were unexpectedly auto-compounded for collator "${rewarded.collator
             }" at block ${blockNumber}`
           ).to.be.empty;
         }

--- a/test/suites/smoke/test-staking-rewards.ts
+++ b/test/suites/smoke/test-staking-rewards.ts
@@ -181,22 +181,22 @@ describeSuite({
             scheduledRequest === undefined
               ? delegationAmount
               : scheduledRequest.action.isDecrease
-                ? delegationAmount.sub(scheduledRequest.action.asDecrease)
-                : scheduledRequest.action.isRevoke
-                  ? delegationAmount.sub(scheduledRequest.action.asRevoke)
-                  : delegationAmount;
+              ? delegationAmount.sub(scheduledRequest.action.asDecrease)
+              : scheduledRequest.action.isRevoke
+              ? delegationAmount.sub(scheduledRequest.action.asRevoke)
+              : delegationAmount;
 
           const match = expected.eq(delegatorSnapshot.amount);
           if (!match) {
             log(
               "Snapshot amount " +
-              delegatorSnapshot.amount.toString() +
-              " does not match storage amount " +
-              delegationAmount.toString() +
-              " for delegator: " +
-              delegatorSnapshot.owner.toString() +
-              " on candidate: " +
-              accountId.toString()
+                delegatorSnapshot.amount.toString() +
+                " does not match storage amount " +
+                delegationAmount.toString() +
+                " for delegator: " +
+                delegatorSnapshot.owner.toString() +
+                " on candidate: " +
+                accountId.toString()
             );
           }
           return {
@@ -233,10 +233,10 @@ describeSuite({
         const estimatedTime = ((delegationCount + atStakeSnapshot.length) / 600).toFixed(2);
         log(
           "With a count of " +
-          delegationCount +
-          " delegations, this may take upto " +
-          estimatedTime +
-          " mins."
+            delegationCount +
+            " delegations, this may take upto " +
+            estimatedTime +
+            " mins."
         );
 
         const results = await Promise.all(promises);
@@ -283,13 +283,13 @@ describeSuite({
           if (!match) {
             log(
               "Snapshot autocompound " +
-              delegatorSnapshot.autoCompound.toString() +
-              "% does not match storage autocompound " +
-              autoCompoundAmount.toString() +
-              "% for delegator: " +
-              delegatorSnapshot.owner.toString() +
-              " on candidate: " +
-              collatorId.toString()
+                delegatorSnapshot.autoCompound.toString() +
+                "% does not match storage autocompound " +
+                autoCompoundAmount.toString() +
+                "% for delegator: " +
+                delegatorSnapshot.owner.toString() +
+                " on candidate: " +
+                collatorId.toString()
             );
           }
           return {
@@ -438,27 +438,27 @@ describeSuite({
       log(
         `
       latest  ${latestRound.current.toString()} ` +
-        `(${latestBlockNumber} / ${latestBlockHash.toHex()})
+          `(${latestBlockNumber} / ${latestBlockHash.toHex()})
       rewarded round ${payment.rewardRound.data.current.toString()} - ` +
-        `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
+          `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
         reward: #${payment.firstRewardBlock.header.number.toString()} / ` +
-        `[${payment.firstRewardBlock.header.hash.toHex()}]
+          `[${payment.firstRewardBlock.header.hash.toHex()}]
          first: #${payment.rewardRound.firstBlock.header.number.toString()} / ` +
-        `[${payment.rewardRound.firstBlock.header.hash.toHex()}]
+          `[${payment.rewardRound.firstBlock.header.hash.toHex()}]
          prior: #${payment.rewardRound.priorBlock.header.number.toString()} / ` +
-        `[${payment.rewardRound.priorBlock.header.hash.toHex()}]
+          `[${payment.rewardRound.priorBlock.header.hash.toHex()}]
       delayed payout computation round ${payment.delayedPayoutRound.data.current.toString()} - ` +
-        `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
+          `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
          first: #${payment.delayedPayoutRound.firstBlock.header.number.toString()} / ` +
-        `[${payment.delayedPayoutRound.firstBlock.header.hash.toHex()}]
+          `[${payment.delayedPayoutRound.firstBlock.header.hash.toHex()}]
          prior: #${payment.delayedPayoutRound.priorBlock.header.number.toString()} / ` +
-        `[${payment.delayedPayoutRound.priorBlock.header.hash.toHex()}]
+          `[${payment.delayedPayoutRound.priorBlock.header.hash.toHex()}]
       round to pay ${payment.roundToPay.data.current.toString()} - ` +
-        `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
+          `spec: ${payment.rewardRound.firstBlockSpecVersion.toString()}
          first: #${payment.roundToPay.firstBlock.header.number.toString()} / ` +
-        `[${payment.roundToPay.firstBlock.header.hash.toHex()}]
+          `[${payment.roundToPay.firstBlock.header.hash.toHex()}]
          prior: #${payment.roundToPay.priorBlock.header.number.toString()} / ` +
-        `[${payment.roundToPay.priorBlock.header.hash.toHex()}]`
+          `[${payment.roundToPay.priorBlock.header.hash.toHex()}]`
       );
 
       // collect info about staked value from collators and delegators
@@ -535,7 +535,7 @@ describeSuite({
           if (!Object.keys(collatorInfo.delegators).includes(topDelegation)) {
             throw new Error(
               `${topDelegation} is missing from collatorInfo ` +
-              `for round ${payment.roundToPay.data.current.toString()}`
+                `for round ${payment.roundToPay.data.current.toString()}`
             );
           }
         }
@@ -543,7 +543,7 @@ describeSuite({
           if (!topDelegations.has(delegator as any)) {
             throw new Error(
               `${delegator} is missing from topDelegations for round` +
-              ` ${payment.roundToPay.data.current.toString()}`
+                ` ${payment.roundToPay.data.current.toString()}`
             );
           }
         }
@@ -780,14 +780,16 @@ describeSuite({
         );
         expect(
           notRewarded,
-          `delegators "${[...notRewarded].join(", ")}" were not rewarded for collator "${rewarded.collator
+          `delegators "${[...notRewarded].join(", ")}" were not rewarded for collator "${
+            rewarded.collator
           }" at block ${blockNumber}`
         ).to.be.empty;
         expect(
           unexpectedlyRewarded,
           `delegators "${[...unexpectedlyRewarded].join(
             ", "
-          )}" were unexpectedly rewarded for collator "${rewarded.collator
+          )}" were unexpectedly rewarded for collator "${
+            rewarded.collator
           }" at block ${blockNumber}`
         ).to.be.empty;
 
@@ -812,14 +814,16 @@ describeSuite({
             notAutoCompounded,
             `delegators "${[...notAutoCompounded].join(
               ", "
-            )}" were not auto-compounded for collator "${rewarded.collator
+            )}" were not auto-compounded for collator "${
+              rewarded.collator
             }" at block ${blockNumber}`
           ).to.be.empty;
           expect(
             unexpectedlyAutoCompounded,
             `delegators "${[...unexpectedlyAutoCompounded].join(
               ", "
-            )}" were unexpectedly auto-compounded for collator "${rewarded.collator
+            )}" were unexpectedly auto-compounded for collator "${
+              rewarded.collator
             }" at block ${blockNumber}`
           ).to.be.empty;
         }


### PR DESCRIPTION
### What does it do?

Fixes the following error for staking rewards `S22C500` smoke test (line 623):

```shell
📁 S22C500 rewards are given as expected
Error: Number can only safely store up to 53 bits
 - /moonbeam/node_modules/.pnpm/bn.js@5.2.1/node_modules/bn.js/lib/bn.js:6:21
 - /moonbeam/node_modules/.pnpm/bn.js@5.2.1/node_modules/bn.js/lib/bn.js:547:7
 - /suites/smoke/test-staking-rewards.ts:623:51
 - /suites/smoke/test-staking-rewards.ts:358:7
 - /suites/smoke/test-staking-rewards.ts:349:9
```
Also, smoke test configs for Alphanet and Stagenet were updated to use the proper endpoints at the moment of running smoke tests locally.
