### PR TITLE
Allow dist folder of api-augment to be included in the npm package

### DIFF
--- a/typescript-api/.npmignore
+++ b/typescript-api/.npmignore
@@ -1,0 +1,34 @@
+metadata-*.json
+build
+# dist # Commented out to allow the dist directory to be included in the package
+*.tgz
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Dependency directories
+node_modules/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache


### PR DESCRIPTION
This pull request adds the `.npmignore` file in the `typescript-api` directory to prevent npm to use the `.gitignore` file which also include the `dist` folder which must be published in the package