### PR TITLE
Fixes wrong runtime import with native flags

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -22,10 +22,15 @@ use cumulus_primitives_core::ParaId;
 use frame_benchmarking_cli::BenchmarkCmd;
 use log::{info, warn};
 use moonbeam_cli_opt::EthApi;
-use moonbeam_service::{
-	chain_spec, frontier_database_dir, moonbase_runtime, moonbeam_runtime, moonriver_runtime,
-	HostFunctions, IdentifyVariant,
-};
+
+#[cfg(feature = "moonbase-native")]
+use moonbeam_service::moonbase_runtime;
+#[cfg(feature = "moonbeam-native")]
+use moonbeam_service::moonbeam_runtime;
+#[cfg(feature = "moonriver-native")]
+use moonbeam_service::moonriver_runtime;
+
+use moonbeam_service::{chain_spec, frontier_database_dir, HostFunctions, IdentifyVariant};
 use parity_scale_codec::Encode;
 #[cfg(feature = "westend-native")]
 use polkadot_service::WestendChainSpec;
@@ -507,11 +512,14 @@ pub fn run() -> Result<()> {
 							_ => panic!("invalid chain spec"),
 						}
 					} else if cfg!(feature = "moonbase-runtime-benchmarks") {
+						#[cfg(feature = "moonbase-native")]
 						return runner.sync_run(|config| {
 							cmd.run_with_spec::<HashingFor<moonbeam_service::moonbase_runtime::Block>, HostFunctions>(
 								Some(config.chain_spec),
 							)
 						});
+						#[cfg(not(feature = "moonbase-native"))]
+						panic!("Benchmarking wasn't enabled when building the node.");
 					} else {
 						Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -24,11 +24,10 @@ use crate::chain_spec::{derive_bip44_pairs_from_mnemonic, get_account_id_from_pa
 use crate::chain_spec::{generate_accounts, get_from_seed, Extensions};
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use moonbase_runtime::EligibilityValue;
 use moonbeam_runtime::{
 	currency::GLMR, currency::SUPPLY_FACTOR, AccountId, AuthorFilterConfig, AuthorMappingConfig,
-	Balance, BalancesConfig, CrowdloanRewardsConfig, EVMConfig, EthereumChainIdConfig,
-	EthereumConfig, GenesisAccount, InflationInfo, MaintenanceModeConfig,
+	Balance, BalancesConfig, CrowdloanRewardsConfig, EVMConfig, EligibilityValue,
+	EthereumChainIdConfig, EthereumConfig, GenesisAccount, InflationInfo, MaintenanceModeConfig,
 	OpenTechCommitteeCollectiveConfig, ParachainInfoConfig, ParachainStakingConfig,
 	PolkadotXcmConfig, Precompiles, Range, RuntimeGenesisConfig, TransactionPaymentConfig,
 	TreasuryCouncilCollectiveConfig, HOURS, WASM_BINARY,

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -24,13 +24,13 @@ use crate::chain_spec::{derive_bip44_pairs_from_mnemonic, get_account_id_from_pa
 use crate::chain_spec::{generate_accounts, get_from_seed, Extensions};
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use moonbase_runtime::EligibilityValue;
 use moonriver_runtime::{
 	currency::MOVR, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
-	CrowdloanRewardsConfig, EVMConfig, EthereumChainIdConfig, EthereumConfig, GenesisAccount,
-	InflationInfo, MaintenanceModeConfig, OpenTechCommitteeCollectiveConfig, ParachainInfoConfig,
-	ParachainStakingConfig, PolkadotXcmConfig, Precompiles, Range, RuntimeGenesisConfig,
-	TransactionPaymentConfig, TreasuryCouncilCollectiveConfig, HOURS, WASM_BINARY,
+	CrowdloanRewardsConfig, EVMConfig, EligibilityValue, EthereumChainIdConfig, EthereumConfig,
+	GenesisAccount, InflationInfo, MaintenanceModeConfig, OpenTechCommitteeCollectiveConfig,
+	ParachainInfoConfig, ParachainStakingConfig, PolkadotXcmConfig, Precompiles, Range,
+	RuntimeGenesisConfig, TransactionPaymentConfig, TreasuryCouncilCollectiveConfig, HOURS,
+	WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use pallet_transaction_payment::Multiplier;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -68,6 +68,7 @@ use moonbeam_runtime_common::{
 	timestamp::{ConsensusHookWrapperForRelayTimestamp, RelayTimestamp},
 	weights as moonbeam_weights,
 };
+pub use pallet_author_slot_filter::EligibilityValue;
 use pallet_ethereum::Call::transact;
 use pallet_ethereum::{PostLogContent, Transaction as EthereumTransaction};
 use pallet_evm::{

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -69,6 +69,7 @@ use moonbeam_runtime_common::{
 	timestamp::{ConsensusHookWrapperForRelayTimestamp, RelayTimestamp},
 	weights as moonriver_weights,
 };
+pub use pallet_author_slot_filter::EligibilityValue;
 use pallet_ethereum::Call::transact;
 use pallet_ethereum::{PostLogContent, Transaction as EthereumTransaction};
 use pallet_evm::{


### PR DESCRIPTION
Fixes inconsistent import/use of wrong runtime.

This should fix the follow aliases:
`cargo moonbase`
`cargo moonriver`
`cargo moonbeam`

There are still some warnings to investigate