### PR TITLE
fix(smoke): use valid moonriver transaction for runtime 1605

### DIFF
--- a/test/helpers/moonriver-tracing-samples.json
+++ b/test/helpers/moonriver-tracing-samples.json
@@ -104,8 +104,8 @@
   {
     "network": "moonriver",
     "runtime": 1605,
-    "blockNumber": 2077599,
-    "txHash": "0x2cceda1436e32ae3b3a2194a8cb5bc4188259600c714789bae1fedc0bbc5125f"
+    "blockNumber": 2077600,
+    "txHash": "0x26d33099b7f8b1377c0c0cbadbfd3bc0318e21b039a48e520e3bbe1082238bd8"
   },
   {
     "network": "moonriver",


### PR DESCRIPTION
### What does it do?

Unblocks the following PR: https://github.com/moonbeam-foundation/moonbeam-smoke-tests-moonwall-config/pull/66

### What important points reviewers should know?

Transactions included in block [2077599](https://moonriver.subscan.io/block/2077599) were duplicated in block [2077600](https://moonriver.subscan.io/block/2077600), which causes the tracing of these transactions to fail.

The issue is documented here:
[Historical Updates | Moonbeam Docs](https://docs.moonbeam.network/builders/build/historical-updates/#ethereum-transactions-duplicated-in-storage)