### PR TITLE
feat: don't override fork strategy in import_queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -3000,6 +3000,7 @@ dependencies = [
  "evm",
  "evm-gasometer",
  "evm-runtime",
+ "log",
  "parity-scale-codec",
  "sp-runtime-interface",
 ]
@@ -7571,7 +7572,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -7611,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8126,7 +8127,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8146,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8165,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8184,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8541,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9253,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -9501,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9552,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9880,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9955,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -14815,7 +14816,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -18468,7 +18469,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#f32e4035c5b00083accd53f0f6b829feb9b88b1e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -7571,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8146,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9253,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -9501,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9880,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9955,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -14815,7 +14815,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -18468,7 +18468,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2407#54564227255cc8e6cd6a01fb8540459337fb43ff"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,7 +3000,6 @@ dependencies = [
  "evm",
  "evm-gasometer",
  "evm-runtime",
- "log",
  "parity-scale-codec",
  "sp-runtime-interface",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -7571,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8146,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9253,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -9501,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9880,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9955,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -14815,7 +14815,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -18468,7 +18468,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#e8b828a235c35d5c5447dad07a9f2b083475a906"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=rq/remove-nimbus-block-import#6d7c01609f7a480232feb2caae08a52b5b681647"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,23 +334,23 @@ westend-runtime = { git = "https://github.com/moonbeam-foundation/polkadot-sdk",
 xcm-simulator = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407" }
 
 # Moonkit (wasm)
-async-backing-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-moonkit-xcm-primitives = { package = "xcm-primitives", git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-nimbus-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-async-backing = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-author-inherent = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-author-mapping = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-emergency-para-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-evm-precompile-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-maintenance-mode = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-migrations = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-randomness = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-pallet-relay-storage-roots = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
-session-keys-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+async-backing-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+moonkit-xcm-primitives = { package = "xcm-primitives", git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+nimbus-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-async-backing = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-author-inherent = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-author-mapping = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-emergency-para-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-evm-precompile-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-maintenance-mode = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-migrations = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-randomness = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+pallet-relay-storage-roots = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+session-keys-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
 
 # Moonkit (client)
-nimbus-consensus = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407" }
+nimbus-consensus = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import" }
 
 # Other (wasm)
 async-trait = { version = "0.1.42" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,23 +334,23 @@ westend-runtime = { git = "https://github.com/moonbeam-foundation/polkadot-sdk",
 xcm-simulator = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407" }
 
 # Moonkit (wasm)
-async-backing-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-moonkit-xcm-primitives = { package = "xcm-primitives", git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-nimbus-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-async-backing = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-author-inherent = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-author-mapping = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-emergency-para-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-evm-precompile-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-maintenance-mode = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-migrations = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-randomness = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-pallet-relay-storage-roots = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
-session-keys-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import", default-features = false }
+async-backing-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+moonkit-xcm-primitives = { package = "xcm-primitives", git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+nimbus-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-async-backing = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-author-inherent = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-author-mapping = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-emergency-para-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-evm-precompile-xcm = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-maintenance-mode = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-migrations = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-randomness = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+pallet-relay-storage-roots = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
+session-keys-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407", default-features = false }
 
 # Moonkit (client)
-nimbus-consensus = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "rq/remove-nimbus-block-import" }
+nimbus-consensus = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "moonbeam-polkadot-stable2407" }
 
 # Other (wasm)
 async-trait = { version = "0.1.42" }
@@ -377,8 +377,7 @@ slices = "0.2.0"
 strum = { version = "0.26.3", default-features = false, features = ["derive"] }
 strum_macros = "0.24"
 smallvec = "1.11.0"
-p256 = { version = "0.13.2", default-features = false, features = [
-    "ecdsa"] }
+p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
 ansi_term = "0.12.1"
 
 # Other (client)

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -142,10 +142,10 @@ pub struct RunCmd {
 	#[clap(long)]
 	pub dev_service: bool,
 
-	/// Enable old nimbus block import pipeline
+	/// Enable the new block import strategy
 	/// Deprecated in: https://github.com/Moonsong-Labs/moonkit/pull/43
 	#[clap(long)]
-	pub use_deprecated_fork_strategy: bool,
+	pub experimental_block_import_strategy: bool,
 
 	#[cfg(feature = "lazy-loading")]
 	#[clap(long)]

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -142,6 +142,11 @@ pub struct RunCmd {
 	#[clap(long)]
 	pub dev_service: bool,
 
+	/// Enable old nimbus block import pipeline
+	/// Deprecated in: https://github.com/Moonsong-Labs/moonkit/pull/43
+	#[clap(long)]
+	pub use_deprecated_fork_strategy: bool,
+
 	#[cfg(feature = "lazy-loading")]
 	#[clap(long)]
 	pub fork_chain_from_rpc: Option<String>,

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -268,8 +268,11 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			let rpc_config = cli.run.new_rpc_config();
 			runner.async_run(|mut config| {
-				let (client, _, import_queue, task_manager) =
-					moonbeam_service::new_chain_ops(&mut config, &rpc_config)?;
+				let (client, _, import_queue, task_manager) = moonbeam_service::new_chain_ops(
+					&mut config,
+					&rpc_config,
+					cli.run.use_deprecated_fork_strategy,
+				)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		}
@@ -277,8 +280,11 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			let rpc_config = cli.run.new_rpc_config();
 			runner.async_run(|mut config| {
-				let (client, _, _, task_manager) =
-					moonbeam_service::new_chain_ops(&mut config, &rpc_config)?;
+				let (client, _, _, task_manager) = moonbeam_service::new_chain_ops(
+					&mut config,
+					&rpc_config,
+					cli.run.use_deprecated_fork_strategy,
+				)?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
 		}
@@ -286,8 +292,11 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			let rpc_config = cli.run.new_rpc_config();
 			runner.async_run(|mut config| {
-				let (client, _, _, task_manager) =
-					moonbeam_service::new_chain_ops(&mut config, &rpc_config)?;
+				let (client, _, _, task_manager) = moonbeam_service::new_chain_ops(
+					&mut config,
+					&rpc_config,
+					cli.run.use_deprecated_fork_strategy,
+				)?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
 		}
@@ -295,8 +304,11 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			let rpc_config = cli.run.new_rpc_config();
 			runner.async_run(|mut config| {
-				let (client, _, import_queue, task_manager) =
-					moonbeam_service::new_chain_ops(&mut config, &rpc_config)?;
+				let (client, _, import_queue, task_manager) = moonbeam_service::new_chain_ops(
+					&mut config,
+					&rpc_config,
+					cli.run.use_deprecated_fork_strategy,
+				)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		}
@@ -356,7 +368,12 @@ pub fn run() -> Result<()> {
 					let params = moonbeam_service::new_partial::<
 						moonbeam_service::moonriver_runtime::RuntimeApi,
 						moonbeam_service::MoonriverCustomizations,
-					>(&mut config, &rpc_config, false)?;
+					>(
+						&mut config,
+						&rpc_config,
+						false,
+						cli.run.use_deprecated_fork_strategy,
+					)?;
 
 					Ok((
 						cmd.run(params.client, params.backend, None),
@@ -368,7 +385,12 @@ pub fn run() -> Result<()> {
 					let params = moonbeam_service::new_partial::<
 						moonbeam_service::moonbeam_runtime::RuntimeApi,
 						moonbeam_service::MoonbeamCustomizations,
-					>(&mut config, &rpc_config, false)?;
+					>(
+						&mut config,
+						&rpc_config,
+						false,
+						cli.run.use_deprecated_fork_strategy,
+					)?;
 
 					Ok((
 						cmd.run(params.client, params.backend, None),
@@ -380,7 +402,12 @@ pub fn run() -> Result<()> {
 					let params = moonbeam_service::new_partial::<
 						moonbeam_service::moonbase_runtime::RuntimeApi,
 						moonbeam_service::MoonbaseCustomizations,
-					>(&mut config, &rpc_config, false)?;
+					>(
+						&mut config,
+						&rpc_config,
+						false,
+						cli.run.use_deprecated_fork_strategy,
+					)?;
 
 					Ok((
 						cmd.run(params.client, params.backend, None),
@@ -536,7 +563,12 @@ pub fn run() -> Result<()> {
 								let params = moonbeam_service::new_partial::<
 									moonbeam_service::moonriver_runtime::RuntimeApi,
 									moonbeam_service::MoonriverCustomizations,
-								>(&mut config, &rpc_config, false)?;
+								>(
+									&mut config,
+									&rpc_config,
+									false,
+									cli.run.use_deprecated_fork_strategy,
+								)?;
 
 								cmd.run(params.client)
 							})
@@ -547,7 +579,12 @@ pub fn run() -> Result<()> {
 								let params = moonbeam_service::new_partial::<
 									moonbeam_service::moonbeam_runtime::RuntimeApi,
 									moonbeam_service::MoonbeamCustomizations,
-								>(&mut config, &rpc_config, false)?;
+								>(
+									&mut config,
+									&rpc_config,
+									false,
+									cli.run.use_deprecated_fork_strategy,
+								)?;
 
 								cmd.run(params.client)
 							})
@@ -558,7 +595,12 @@ pub fn run() -> Result<()> {
 								let params = moonbeam_service::new_partial::<
 									moonbeam_service::moonbase_runtime::RuntimeApi,
 									moonbeam_service::MoonbaseCustomizations,
-								>(&mut config, &rpc_config, false)?;
+								>(
+									&mut config,
+									&rpc_config,
+									false,
+									cli.run.use_deprecated_fork_strategy,
+								)?;
 
 								cmd.run(params.client)
 							})
@@ -654,7 +696,12 @@ pub fn run() -> Result<()> {
 					} = moonbeam_service::new_partial::<
 						moonbeam_service::moonriver_runtime::RuntimeApi,
 						moonbeam_service::MoonriverCustomizations,
-					>(&mut config, &rpc_config, false)?;
+					>(
+						&mut config,
+						&rpc_config,
+						false,
+						cli.run.use_deprecated_fork_strategy,
+					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
 				}
@@ -667,7 +714,12 @@ pub fn run() -> Result<()> {
 					} = moonbeam_service::new_partial::<
 						moonbeam_service::moonbeam_runtime::RuntimeApi,
 						moonbeam_service::MoonbeamCustomizations,
-					>(&mut config, &rpc_config, false)?;
+					>(
+						&mut config,
+						&rpc_config,
+						false,
+						cli.run.use_deprecated_fork_strategy,
+					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
 				}
@@ -680,7 +732,12 @@ pub fn run() -> Result<()> {
 					} = moonbeam_service::new_partial::<
 						moonbeam_service::moonbase_runtime::RuntimeApi,
 						moonbeam_service::MoonbaseCustomizations,
-					>(&mut config, &rpc_config, false)?;
+					>(
+						&mut config,
+						&rpc_config,
+						false,
+						cli.run.use_deprecated_fork_strategy,
+					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
 				}
@@ -863,6 +920,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
+						cli.run.use_deprecated_fork_strategy,
 					)
 					.await
 					.map(|r| r.0)
@@ -880,6 +938,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
+						cli.run.use_deprecated_fork_strategy,
 					)
 					.await
 					.map(|r| r.0)
@@ -897,6 +956,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
+						cli.run.use_deprecated_fork_strategy,
 					)
 					.await
 					.map(|r| r.0)

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -625,7 +625,12 @@ pub fn run() -> Result<()> {
 								let params = moonbeam_service::new_partial::<
 									moonbeam_service::moonriver_runtime::RuntimeApi,
 									moonbeam_service::MoonriverCustomizations,
-								>(&mut config, &rpc_config, false)?;
+								>(
+									&mut config,
+									&rpc_config,
+									false,
+									cli.run.use_deprecated_fork_strategy,
+								)?;
 
 								let db = params.backend.expose_db();
 								let storage = params.backend.expose_storage();
@@ -639,7 +644,12 @@ pub fn run() -> Result<()> {
 								let params = moonbeam_service::new_partial::<
 									moonbeam_service::moonbeam_runtime::RuntimeApi,
 									moonbeam_service::MoonbeamCustomizations,
-								>(&mut config, &rpc_config, false)?;
+								>(
+									&mut config,
+									&rpc_config,
+									false,
+									cli.run.use_deprecated_fork_strategy,
+								)?;
 
 								let db = params.backend.expose_db();
 								let storage = params.backend.expose_storage();
@@ -653,7 +663,12 @@ pub fn run() -> Result<()> {
 								let params = moonbeam_service::new_partial::<
 									moonbeam_service::moonbase_runtime::RuntimeApi,
 									moonbeam_service::MoonbaseCustomizations,
-								>(&mut config, &rpc_config, false)?;
+								>(
+									&mut config,
+									&rpc_config,
+									false,
+									cli.run.use_deprecated_fork_strategy,
+								)?;
 
 								let db = params.backend.expose_db();
 								let storage = params.backend.expose_storage();

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -271,7 +271,7 @@ pub fn run() -> Result<()> {
 				let (client, _, import_queue, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.use_deprecated_fork_strategy,
+					cli.run.experimental_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
@@ -283,7 +283,7 @@ pub fn run() -> Result<()> {
 				let (client, _, _, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.use_deprecated_fork_strategy,
+					cli.run.experimental_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
@@ -295,7 +295,7 @@ pub fn run() -> Result<()> {
 				let (client, _, _, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.use_deprecated_fork_strategy,
+					cli.run.experimental_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
@@ -307,7 +307,7 @@ pub fn run() -> Result<()> {
 				let (client, _, import_queue, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.use_deprecated_fork_strategy,
+					cli.run.experimental_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
@@ -372,7 +372,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)?;
 
 					Ok((
@@ -389,7 +389,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)?;
 
 					Ok((
@@ -406,7 +406,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)?;
 
 					Ok((
@@ -567,7 +567,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.use_deprecated_fork_strategy,
+									cli.run.experimental_block_import_strategy,
 								)?;
 
 								cmd.run(params.client)
@@ -583,7 +583,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.use_deprecated_fork_strategy,
+									cli.run.experimental_block_import_strategy,
 								)?;
 
 								cmd.run(params.client)
@@ -599,7 +599,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.use_deprecated_fork_strategy,
+									cli.run.experimental_block_import_strategy,
 								)?;
 
 								cmd.run(params.client)
@@ -629,7 +629,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.use_deprecated_fork_strategy,
+									cli.run.experimental_block_import_strategy,
 								)?;
 
 								let db = params.backend.expose_db();
@@ -648,7 +648,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.use_deprecated_fork_strategy,
+									cli.run.experimental_block_import_strategy,
 								)?;
 
 								let db = params.backend.expose_db();
@@ -667,7 +667,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.use_deprecated_fork_strategy,
+									cli.run.experimental_block_import_strategy,
 								)?;
 
 								let db = params.backend.expose_db();
@@ -715,7 +715,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
@@ -733,7 +733,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
@@ -751,7 +751,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
@@ -935,7 +935,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)
 					.await
 					.map(|r| r.0)
@@ -953,7 +953,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)
 					.await
 					.map(|r| r.0)
@@ -971,7 +971,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
-						cli.run.use_deprecated_fork_strategy,
+						cli.run.experimental_block_import_strategy,
 					)
 					.await
 					.map(|r| r.0)

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -340,6 +340,7 @@ where
 		create_inherent_data_providers,
 		&task_manager.spawn_essential_handle(),
 		config.prometheus_registry(),
+		None,
 	)?;
 	let block_import = BlockImportPipeline::Dev(frontier_block_import);
 

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -339,7 +339,7 @@ where
 		frontier_block_import.clone(),
 		create_inherent_data_providers,
 		&task_manager.spawn_essential_handle(),
-		config.prometheus_registry()
+		config.prometheus_registry(),
 	)?;
 	let block_import = BlockImportPipeline::Dev(frontier_block_import);
 

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -339,8 +339,7 @@ where
 		frontier_block_import.clone(),
 		create_inherent_data_providers,
 		&task_manager.spawn_essential_handle(),
-		config.prometheus_registry(),
-		false,
+		config.prometheus_registry()
 	)?;
 	let block_import = BlockImportPipeline::Dev(frontier_block_import);
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1209,7 +1209,7 @@ where
 				frontier_backend,
 				fee_history_cache,
 			),
-	} = new_partial::<RuntimeApi, Customizations>(&mut config, &rpc_config, true, false)?;
+	} = new_partial::<RuntimeApi, Customizations>(&mut config, &rpc_config, true, true)?;
 
 	let block_import = if let BlockImportPipeline::Dev(block_import) = block_import_pipeline {
 		block_import

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -567,10 +567,7 @@ where
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
 				config.prometheus_registry(),
-				match use_deprecated_fork_strategy {
-					true => Some(!dev_service),
-					false => None,
-				},
+				use_deprecated_fork_strategy.then(|| !dev_service),
 			)?,
 			BlockImportPipeline::Dev(frontier_block_import),
 		)
@@ -584,10 +581,7 @@ where
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
 				config.prometheus_registry(),
-				match use_deprecated_fork_strategy {
-					true => Some(!dev_service),
-					false => None,
-				},
+				use_deprecated_fork_strategy.then(|| !dev_service),
 			)?,
 			BlockImportPipeline::Parachain(parachain_block_import),
 		)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -561,10 +561,8 @@ where
 			BlockImportPipeline::Dev(frontier_block_import),
 		)
 	} else {
-		let parachain_block_import = ParachainBlockImport::new_with_delayed_best_block(
-			frontier_block_import,
-			backend.clone(),
-		);
+		let parachain_block_import =
+			ParachainBlockImport::new(frontier_block_import, backend.clone());
 		(
 			nimbus_consensus::import_queue(
 				client.clone(),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -556,7 +556,7 @@ where
 				frontier_block_import.clone(),
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
-				config.prometheus_registry()
+				config.prometheus_registry(),
 			)?,
 			BlockImportPipeline::Dev(frontier_block_import),
 		)
@@ -571,7 +571,7 @@ where
 				parachain_block_import.clone(),
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
-				config.prometheus_registry()
+				config.prometheus_registry(),
 			)?,
 			BlockImportPipeline::Parachain(parachain_block_import),
 		)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -556,8 +556,7 @@ where
 				frontier_block_import.clone(),
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
-				config.prometheus_registry(),
-				!dev_service,
+				config.prometheus_registry()
 			)?,
 			BlockImportPipeline::Dev(frontier_block_import),
 		)
@@ -572,8 +571,7 @@ where
 				parachain_block_import.clone(),
 				create_inherent_data_providers,
 				&task_manager.spawn_essential_handle(),
-				config.prometheus_registry(),
-				!dev_service,
+				config.prometheus_registry()
 			)?,
 			BlockImportPipeline::Parachain(parachain_block_import),
 		)


### PR DESCRIPTION
### What does it do?

Supersedes https://github.com/moonbeam-foundation/moonbeam/pull/2794

Historically aura was overcharging fork strategy for parachain at block import, but seems no longer necessary.

This PR updates nimbus to [remove the NimbusBlockImport type](https://github.com/Moonsong-Labs/moonkit/pull/43), a wrapper that impl BlockImport only to override the fork strategy.

### What important points reviewers should know?
