### PR TITLE
Divides min gas price by 4

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -482,7 +482,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int((currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -108,7 +108,7 @@ type XcmTransactorV2PCall =
 	pallet_evm_precompile_xcm_transactor::v2::XcmTransactorPrecompileV2Call<Runtime>;
 
 // TODO: can we construct a const U256...?
-const BASE_FEE_GENISIS: u128 = 10 * GIGAWEI;
+const BASE_FEE_GENISIS: u128 = 10 * GIGAWEI / 4;
 
 #[test]
 fn xcmp_queue_controller_origin_is_root() {
@@ -1864,7 +1864,7 @@ fn initial_gas_fee_is_correct() {
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
 			(
-				10_000_000_000u128.into(),
+				2_500_000_000u128.into(),
 				Weight::from_parts(41_742_000u64, 0)
 			)
 		);
@@ -3133,11 +3133,11 @@ mod fee_tests {
 			// 1 "real" day (at 6-second blocks)
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(0), 14400),
-				U256::from(125_000_000), // lower bound enforced
+				U256::from(31_250_000), // lower bound enforced
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(25), 14400),
-				U256::from(125_000_000),
+				U256::from(31_250_000), // lower bound enforced if threshold not reached
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(50), 14400),
@@ -3145,7 +3145,8 @@ mod fee_tests {
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(100), 14400),
-				U256::from(125_000_000_000_000u128), // upper bound enforced
+				U256::from(31_250_000_000_000u128),
+				// upper bound enforced (min_gas_price * MaximumMultiplier)
 			);
 		});
 	}

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -3035,9 +3035,7 @@ mod fee_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
-				.saturating_mul_int(
-					(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128),
-				)
+				.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128))
 				.into();
 
 			assert_eq!(expected, actual);
@@ -3074,8 +3072,7 @@ mod fee_tests {
 			.unwrap()
 			.into();
 		t.execute_with(|| {
-			let weight_fee_per_gas =
-				(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
+			let weight_fee_per_gas = (currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -3036,7 +3036,7 @@ mod fee_tests {
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
 				.saturating_mul_int(
-					(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128),
+					(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128),
 				)
 				.into();
 
@@ -3075,7 +3075,7 @@ mod fee_tests {
 			.into();
 		t.execute_with(|| {
 			let weight_fee_per_gas =
-				(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128);
+				(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -470,7 +470,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int((currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2821,9 +2821,7 @@ mod fee_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
-				.saturating_mul_int(
-					(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128),
-				)
+				.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128))
 				.into();
 
 			assert_eq!(expected, actual);
@@ -2860,8 +2858,7 @@ mod fee_tests {
 			.unwrap()
 			.into();
 		t.execute_with(|| {
-			let weight_fee_per_gas =
-				(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
+			let weight_fee_per_gas = (currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2822,7 +2822,7 @@ mod fee_tests {
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
 				.saturating_mul_int(
-					(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128),
+					(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128),
 				)
 				.into();
 
@@ -2861,7 +2861,7 @@ mod fee_tests {
 			.into();
 		t.execute_with(|| {
 			let weight_fee_per_gas =
-				(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128);
+				(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -1385,7 +1385,7 @@ fn initial_gas_fee_is_correct() {
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
 			(
-				125_000_000_000u128.into(),
+				31_250_000_000u128.into(),
 				Weight::from_parts(41_742_000u64, 0)
 			)
 		);
@@ -1407,7 +1407,7 @@ fn min_gas_fee_is_correct() {
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
 			(
-				125_000_000_000u128.into(),
+				31_250_000_000u128.into(),
 				Weight::from_parts(41_742_000u64, 0)
 			)
 		);
@@ -1554,7 +1554,7 @@ fn total_issuance_after_evm_transaction_with_priority_fee() {
 				input: Vec::new(),
 				value: (1 * GLMR).into(),
 				gas_limit: 21_000u64,
-				max_fee_per_gas: U256::from(200 * GIGAWEI),
+				max_fee_per_gas: U256::from(125 * GIGAWEI),
 				max_priority_fee_per_gas: Some(U256::from(100 * GIGAWEI)),
 				nonce: Some(U256::from(0)),
 				access_list: Vec::new(),
@@ -1562,8 +1562,8 @@ fn total_issuance_after_evm_transaction_with_priority_fee() {
 			.dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::root()));
 
 			let issuance_after = <Runtime as pallet_evm::Config>::Currency::total_issuance();
-			// Fee is 100 GWEI base fee + 100 GWEI tip.
-			let fee = ((200 * GIGAWEI) * 21_000) as f64;
+			// Fee is 25 GWEI base fee + 100 GWEI tip.
+			let fee = ((125 * GIGAWEI) * 21_000) as f64;
 			// 80% was burned.
 			let expected_burn = (fee * 0.8) as u128;
 			assert_eq!(issuance_after, issuance_before - expected_burn,);
@@ -2883,55 +2883,55 @@ mod fee_tests {
 
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(0), 1),
-				U256::from(125_000_000_000u128),
+				U256::from(31_250_000_000u128), // lower bound enforced
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(25), 1),
-				U256::from(125_000_000_000u128),
+				U256::from(31_250_000_000u128),
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(50), 1),
-				U256::from(125_075_022_500u128),
+				U256::from(31_268_755_625u128), // slightly higher than lower bound
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(100), 1),
-				U256::from(125_325_422_500u128),
+				U256::from(31_331_355_625u128), // a bit higher than before
 			);
 
 			// 1 "real" hour (at 12-second blocks)
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(0), 600),
-				U256::from(125_000_000_000u128),
+				U256::from(31_250_000_000u128), // lower bound enforced
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(25), 600),
-				U256::from(125_000_000_000u128),
+				U256::from(31_250_000_000u128),
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(50), 600),
-				U256::from(179_166_172_951u128),
+				U256::from(44_791_543_237u128), // a bit higher than lower bound
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(100), 600),
-				U256::from(594_851_612_166u128),
+				U256::from(148_712_903_041u128), // a lot more
 			);
 
 			// 1 "real" day (at 12-second blocks)
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(0), 14400),
-				U256::from(125_000_000_000u128), // lower bound enforced
+				U256::from(31_250_000_000u128), // lower bound enforced
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(25), 14400),
-				U256::from(125_000_000_000u128),
+				U256::from(31_250_000_000u128),
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(50), 14400),
-				U256::from(706_665_861_883_635u128),
+				U256::from(176_666_465_470_908u128), // significantly higher
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(100), 14400),
-				U256::from(12_500_000_000_000_000u128), // upper bound enforced
+				U256::from(3_125_000_000_000_000u128), // upper bound enforced
 			);
 		});
 	}

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -472,7 +472,7 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// There's still some precision loss when the final `gas_price` (used_gas * min_gas_price)
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
-			.saturating_mul_int((currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128));
+			.saturating_mul_int((currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128));
 		(
 			min_gas_price.into(),
 			<Runtime as frame_system::Config>::DbWeight::get().reads(1),

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -1372,7 +1372,7 @@ fn initial_gas_fee_is_correct() {
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
 			(
-				12_500_000_000u128.into(),
+				3_125_000_000u128.into(),
 				Weight::from_parts(41_742_000u64, 0)
 			)
 		);
@@ -1394,7 +1394,7 @@ fn min_gas_fee_is_correct() {
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
 			(
-				1_250_000_000u128.into(),
+				312_500_000u128.into(),
 				Weight::from_parts(41_742_000u64, 0)
 			)
 		);
@@ -2779,57 +2779,58 @@ mod fee_tests {
 			// If a test fails when nothing specific to fees has changed,
 			// it may indicate an unexpected collateral effect and should be investigated
 
+
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(0), 1),
-				U256::from(1_250_000_000u128),
+				sim(100_000_000, Perbill::from_percent(0), 1),
+				U256::from(312_500_000u128), // lower bound enforced
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(25), 1),
-				U256::from(1_250_000_000u128),
+				sim(100_000_000, Perbill::from_percent(25), 1),
+				U256::from(312_500_000u128),
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(50), 1),
-				U256::from(1_250_750_225u128),
+				sim(100_000_000, Perbill::from_percent(50), 1),
+				U256::from(312_687_556u128), // slightly higher than lower bound
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(100), 1),
-				U256::from(1_253_254_225u128),
+				sim(100_000_000, Perbill::from_percent(100), 1),
+				U256::from(313_313_556u128),
 			);
 
 			// 1 "real" hour (at 6-second blocks)
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(0), 600),
-				U256::from(1_250_000_000u128),
+				sim(100_000_000, Perbill::from_percent(0), 600),
+				U256::from(312_500_000u128),
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(25), 600),
-				U256::from(1_250_000_000u128),
+				sim(100_000_000, Perbill::from_percent(25), 600),
+				U256::from(312_500_000u128),
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(50), 600),
-				U256::from(1_791_661_729u128),
+				sim(100_000_000, Perbill::from_percent(50), 600),
+				U256::from(447_915_432u128),
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(100), 600),
-				U256::from(5_948_516_121u128),
+				sim(100_000_000, Perbill::from_percent(100), 600),
+				U256::from(1_487_129_030u128),
 			);
 
 			// 1 "real" day (at 6-second blocks)
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(0), 14400),
-				U256::from(1_250_000_000u128), // lower bound enforced
+				sim(100_000_000, Perbill::from_percent(0), 14400),
+				U256::from(312_500_000u128), // lower bound enforced
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(25), 14400),
-				U256::from(1_250_000_000u128),
+				sim(100_000_000, Perbill::from_percent(25), 14400),
+				U256::from(312_500_000u128),
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(50), 14400),
-				U256::from(7_066_658_618_836u128),
+				sim(100_000_000, Perbill::from_percent(50), 14400),
+				U256::from(1_766_664_654_709u128),
 			);
 			assert_eq!(
-				sim(1_000_000_000, Perbill::from_percent(100), 14400),
-				U256::from(125_000_000_000_000u128), // upper bound enforced
+				sim(100_000_000, Perbill::from_percent(100), 14400),
+				U256::from(31_250_000_000_000u128), // upper bound enforced
 			);
 		});
 	}

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -1393,10 +1393,7 @@ fn min_gas_fee_is_correct() {
 
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
-			(
-				312_500_000u128.into(),
-				Weight::from_parts(41_742_000u64, 0)
-			)
+			(312_500_000u128.into(), Weight::from_parts(41_742_000u64, 0))
 		);
 	});
 }
@@ -2778,7 +2775,6 @@ mod fee_tests {
 			// the fee calculation are changed, and should be updated accordingly.
 			// If a test fails when nothing specific to fees has changed,
 			// it may indicate an unexpected collateral effect and should be investigated
-
 
 			assert_eq!(
 				sim(100_000_000, Perbill::from_percent(0), 1),

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -2720,7 +2720,7 @@ mod fee_tests {
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
 				.saturating_mul_int(
-					(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128),
+					(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128),
 				)
 				.into();
 
@@ -2759,7 +2759,7 @@ mod fee_tests {
 			.into();
 		t.execute_with(|| {
 			let weight_fee_per_gas =
-				(currency::WEIGHT_FEE * 4).saturating_mul(WEIGHT_PER_GAS as u128);
+				(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -2719,9 +2719,7 @@ mod fee_tests {
 			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::set(multiplier);
 			let actual = TransactionPaymentAsGasPrice::min_gas_price().0;
 			let expected: U256 = multiplier
-				.saturating_mul_int(
-					(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128),
-				)
+				.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128))
 				.into();
 
 			assert_eq!(expected, actual);
@@ -2758,8 +2756,7 @@ mod fee_tests {
 			.unwrap()
 			.into();
 		t.execute_with(|| {
-			let weight_fee_per_gas =
-				(currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
+			let weight_fee_per_gas = (currency::WEIGHT_FEE).saturating_mul(WEIGHT_PER_GAS as u128);
 			let sim = |start_gas_price: u128, fullness: Perbill, num_blocks: u64| -> U256 {
 				let start_multiplier =
 					FixedU128::from_rational(start_gas_price, weight_fee_per_gas);

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -61,62 +61,90 @@ export const PRECOMPILE_RELAY_DATA_VERIFIER_ADDRESS = "0x00000000000000000000000
 // Fees and gas limits
 export const RUNTIME_CONSTANTS = {
   MOONBASE: {
+    GENESIS_FEE_MULTIPLIER: 8_000_000_000_000_000_000n,
     MIN_FEE_MULTIPLIER: 100_000_000_000_000_000n,
     MAX_FEE_MULTIPLIER: 100_000_000_000_000_000_000_000n,
-    MIN_BASE_FEE_IN_WEI: "125000000",
-    MAX_BASE_FEE_IN_WEI: "125000000000000",
+
+    GENESIS_BASE_FEE: new RuntimeConstant({ 3400: 2_500_000_000n, 0: 10_000_000_000n }),
+    MIN_BASE_FEE: new RuntimeConstant({ 3400: 312_500_000n, 0: 1_250_000_000n }),
+    MAX_BASE_FEE: new RuntimeConstant({ 3400: 31_250_000_000_000n, 0: 125_000_000_000_000n }),
+
     TARGET_FILL_PERMILL: new RuntimeConstant({ 3000: 350_000n, 2801: 500_000n, 0: 250_000n }),
     // Deadline for block production in miliseconds
-    DEADLINE_MILISECONDS: 2000n,
-    // Caclulated as the weight per second by the deadline in seconds
-    BLOCK_WEIGHT_LIMIT: 2_000_000_000_000n,
+    DEADLINE_MILISECONDS: new RuntimeConstant({ 2800: 2000n, 0: 500n }),
+    // 2 seconds of weight
+    BLOCK_WEIGHT_LIMIT: new RuntimeConstant({ 2900: 2_000_000_000_000n, 0: 500_000_000_000n }),
     // Gas limit considering the block utilization threshold (75%)
-    GAS_LIMIT: 60_000_000n,
+    GAS_LIMIT: new RuntimeConstant({ 2900: 60_000_000n, 0: 15_000_000n }),
     // Maximum extrinsic weight is taken from the max allowed transaction weight per block (75%),
     // minus the block initialization (10%) and minus the extrinsic base cost.
-    EXTRINSIC_GAS_LIMIT: 52_000_000n,
+    EXTRINSIC_GAS_LIMIT: new RuntimeConstant({ 2900: 52_000_000n, 0: 13_000_000n }),
     // Maximum Gas to PoV ratio used in the gasometer
-    GAS_PER_POV_BYTES: 16n,
+    GAS_PER_POV_BYTES: new RuntimeConstant({ 2900: 16n, 0: 4n }),
     // Storage read/write costs
     STORAGE_READ_COST: 41_742_000n,
     // Weight to gas convertion ratio
     WEIGHT_TO_GAS_RATIO: 25_000n,
   },
   MOONRIVER: {
+    GENESIS_FEE_MULTIPLIER: 10_000_000_000_000_000_000n,
     MIN_FEE_MULTIPLIER: 1_000_000_000_000_000_000n,
     MAX_FEE_MULTIPLIER: 100_000_000_000_000_000_000_000n,
-    MIN_BASE_FEE_IN_WEI: "1250000000",
-    MAX_BASE_FEE_IN_WEI: "125000000000000",
+
+    GENESIS_BASE_FEE: new RuntimeConstant({ 3400: 3_125_000_000n, 0: 12_500_000_000n }),
+    MIN_BASE_FEE: new RuntimeConstant({ 3400: 312_500_000n, 0: 1_250_000_000n }),
+    MAX_BASE_FEE: new RuntimeConstant({ 3400: 31_250_000_000_000n, 0: 125_000_000_000_000n }),
+
     TARGET_FILL_PERMILL: new RuntimeConstant({ 3000: 350_000n, 2801: 500_000n, 0: 250_000n }),
     // Deadline for block production in miliseconds
-    DEADLINE_MILISECONDS: 2000n,
+    DEADLINE_MILISECONDS: new RuntimeConstant({ 3000: 2000n, 0: 500n }),
     // Caclulated as the weight per second by the deadline in seconds
-    BLOCK_WEIGHT_LIMIT: 2_000_000_000_000n,
+    BLOCK_WEIGHT_LIMIT: new RuntimeConstant({
+      3100: 2_000_000_000_000n,
+      3000: 1_000_000_000_000n,
+      0: 500_000_000_000n,
+    }),
     // Gas limit considering the block utilization threshold (75%)
-    GAS_LIMIT: 60_000_000n,
+    GAS_LIMIT: new RuntimeConstant({ 3100: 60_000_000n, 3000: 30_000_000n, 0: 15_000_000n }),
     // Maximum extrinsic weight is taken from the max allowed transaction weight per block (75%),
     // minus the block initialization (10%) and minus the extrinsic base cost.
-    EXTRINSIC_GAS_LIMIT: 52_000_000n,
+    EXTRINSIC_GAS_LIMIT: new RuntimeConstant({
+      3100: 52_000_000n,
+      3000: 26_000_000n,
+      0: 13_000_000n,
+    }),
     // Maximum Gas to PoV ratio used in the gasometer
-    GAS_PER_POV_BYTES: 16n,
+    GAS_PER_POV_BYTES: new RuntimeConstant({ 3100: 16n, 3000: 8n, 0: 4n }),
   },
   MOONBEAM: {
+    GENESIS_FEE_MULTIPLIER: 8_000_000_000_000_000_000n,
     MIN_FEE_MULTIPLIER: 1_000_000_000_000_000_000n,
     MAX_FEE_MULTIPLIER: 100_000_000_000_000_000_000_000n,
-    MIN_BASE_FEE_IN_WEI: "125000000000",
-    MAX_BASE_FEE_IN_WEI: "12500000000000000",
+
+    GENESIS_BASE_FEE: new RuntimeConstant({ 3400: 250_000_000_000n, 0: 1_000_000_000_000n }),
+    MIN_BASE_FEE: new RuntimeConstant({ 3400: 31_250_000_000n, 0: 125_000_000_000n }),
+    MAX_BASE_FEE: new RuntimeConstant({ 3400: 3_125_000_000_000_000n, 0: 12_500_000_000_000_000n }),
+
     TARGET_FILL_PERMILL: new RuntimeConstant({ 3000: 350_000n, 2801: 500_000n, 0: 250_000n }),
     // Deadline for block production in miliseconds
-    DEADLINE_MILISECONDS: 2000n,
+    DEADLINE_MILISECONDS: new RuntimeConstant({ 3000: 2000n, 0: 500n }),
     // Caclulated as the weight per second by the deadline in seconds
-    BLOCK_WEIGHT_LIMIT: 2_000_000_000_000n,
+    BLOCK_WEIGHT_LIMIT: new RuntimeConstant({
+      3200: 2_000_000_000_000n,
+      3100: 1_000_000_000_000n,
+      0: 500_000_000_000n,
+    }),
     // Gas limit considering the block utilization threshold (75%)
-    GAS_LIMIT: 60_000_000n,
+    GAS_LIMIT: new RuntimeConstant({ 3200: 60_000_000n, 3100: 30_000_000n, 0: 15_000_000n }),
     // Maximum extrinsic weight is taken from the max allowed transaction weight per block (75%),
     // minus the block initialization (10%) and minus the extrinsic base cost.
-    EXTRINSIC_GAS_LIMIT: 52_000_000n,
+    EXTRINSIC_GAS_LIMIT: new RuntimeConstant({
+      3200: 52_000_000n,
+      3100: 26_000_000n,
+      0: 13_000_000n,
+    }),
     // Maximum Gas to PoV ratio used in the gasometer
-    GAS_PER_POV_BYTES: 16n,
+    GAS_PER_POV_BYTES: new RuntimeConstant({ 3200: 16n, 3100: 8n, 0: 4n }),
   },
 } as const;
 

--- a/test/suites/dev/common/test-block/test-block-1.ts
+++ b/test/suites/dev/common/test-block/test-block-1.ts
@@ -8,8 +8,10 @@ describeSuite({
   title: "Block 1",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
+    let specVersion: number;
     beforeAll(async () => {
       await context.createBlock();
+      specVersion = (await context.polkadotJs().runtimeVersion.specVersion).toNumber();
     });
 
     it({
@@ -42,7 +44,7 @@ describeSuite({
           author: ALITH_ADDRESS.toLocaleLowerCase(),
           difficulty: 0n,
           extraData: "0x",
-          gasLimit: ConstantStore(context).GAS_LIMIT,
+          gasLimit: ConstantStore(context).GAS_LIMIT.get(specVersion),
           gasUsed: 0n,
           logsBloom: `0x${"0".repeat(512)}`,
           miner: ALITH_ADDRESS.toLocaleLowerCase(),

--- a/test/suites/dev/common/test-block/test-block-genesis.ts
+++ b/test/suites/dev/common/test-block/test-block-genesis.ts
@@ -7,8 +7,10 @@ describeSuite({
   title: "Block genesis",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
+    let specVersion: number;
     beforeAll(async () => {
       expect(await context.viem().getBlockNumber()).toBe(0n);
+      specVersion = (await context.polkadotJs().runtimeVersion.specVersion).toNumber();
     });
 
     it({
@@ -21,7 +23,7 @@ describeSuite({
           author: "0x0000000000000000000000000000000000000000",
           difficulty: 0n,
           extraData: "0x",
-          gasLimit: ConstantStore(context).GAS_LIMIT,
+          gasLimit: ConstantStore(context).GAS_LIMIT.get(specVersion),
           gasUsed: 0n,
           logsBloom: `0x${"0".repeat(512)}`,
           number: 0n,
@@ -50,7 +52,7 @@ describeSuite({
           author: "0x0000000000000000000000000000000000000000",
           difficulty: 0n,
           extraData: "0x",
-          gasLimit: ConstantStore(context).GAS_LIMIT,
+          gasLimit: ConstantStore(context).GAS_LIMIT.get(specVersion),
           gasUsed: 0n,
           logsBloom: `0x${"0".repeat(512)}`,
           number: 0n,

--- a/test/suites/dev/moonbase/test-balance/test-balance-existential.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-existential.ts
@@ -3,8 +3,7 @@ import { expect, describeSuite, beforeEach, TransactionTypes } from "@moonwall/c
 import { ALITH_ADDRESS, baltathar, GLMR } from "@moonwall/util";
 import { createRawTransfer } from "@moonwall/util";
 import { Wallet } from "ethers";
-
-const MIN_GAS_PRICE = 2500000000n;
+import { ConstantStore } from "../../../../helpers";
 
 describeSuite({
   id: "D010301",
@@ -14,8 +13,12 @@ describeSuite({
     // let randomAccount: PrivateKeyAccount;
     let privateKey: `0x${string}`;
     let randomWeb3Account: any;
+    let GENESIS_BASE_FEE;
 
     beforeEach(async function () {
+      const { specVersion } = await context.polkadotJs().consts.system.version;
+      GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(specVersion.toNumber());
+
       // privateKey = generatePrivateKey();
       // randomAccount = privateKeyToAccount(privateKey);
       randomWeb3Account = context.web3().eth.accounts.create();
@@ -34,13 +37,13 @@ describeSuite({
           const raw = await createRawTransfer(
             context,
             ALITH_ADDRESS,
-            10n * GLMR - 21000n * MIN_GAS_PRICE,
+            10n * GLMR - 21000n * GENESIS_BASE_FEE,
             {
               privateKey,
               type: txnType,
-              gasPrice: MIN_GAS_PRICE,
+              gasPrice: GENESIS_BASE_FEE,
               gas: 21000n,
-              maxFeePerGas: MIN_GAS_PRICE,
+              maxFeePerGas: GENESIS_BASE_FEE,
             }
           );
           const { result } = await context.createBlock(raw);
@@ -61,8 +64,8 @@ describeSuite({
         const signer = new Wallet(privateKey, context.ethers().provider);
         await signer.sendTransaction({
           to: baltathar.address,
-          value: 10n * GLMR - 21000n * MIN_GAS_PRICE - 1n,
-          gasPrice: MIN_GAS_PRICE,
+          value: 10n * GLMR - 21000n * GENESIS_BASE_FEE - 1n,
+          gasPrice: GENESIS_BASE_FEE,
           gasLimit: 21000n,
         });
 

--- a/test/suites/dev/moonbase/test-balance/test-balance-existential.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-existential.ts
@@ -1,8 +1,10 @@
 import "@moonbeam-network/api-augment";
 import { expect, describeSuite, beforeEach, TransactionTypes } from "@moonwall/cli";
-import { ALITH_ADDRESS, baltathar, GLMR, MIN_GAS_PRICE } from "@moonwall/util";
+import { ALITH_ADDRESS, baltathar, GLMR } from "@moonwall/util";
 import { createRawTransfer } from "@moonwall/util";
 import { Wallet } from "ethers";
+
+const MIN_GAS_PRICE = 2500000000n;
 
 describeSuite({
   id: "D010301",

--- a/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
@@ -49,7 +49,7 @@ describeSuite({
 
         await context.createBlock(createRawTransfer(context, randomAddress, 0n));
         expect(await context.viem().getBalance({ address: ALITH_ADDRESS })).toBe(
-          ALITH_GENESIS_TRANSFERABLE_BALANCE - 21000n * 2_500_000_000n
+          ALITH_GENESIS_TRANSFERABLE_BALANCE - 21000n * GENESIS_BASE_FEE
         );
       },
     });
@@ -133,8 +133,8 @@ describeSuite({
 
         expect(await context.viem().getBalance({ blockNumber, address: ALITH_ADDRESS })).to.equal(
           balance.data.free.toBigInt() +
-            balance.data.reserved.toBigInt() -
-            balance.data.frozen.toBigInt()
+          balance.data.reserved.toBigInt() -
+          balance.data.frozen.toBigInt()
         );
       },
     });

--- a/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
@@ -133,8 +133,8 @@ describeSuite({
 
         expect(await context.viem().getBalance({ blockNumber, address: ALITH_ADDRESS })).to.equal(
           balance.data.free.toBigInt() +
-          balance.data.reserved.toBigInt() -
-          balance.data.frozen.toBigInt()
+            balance.data.reserved.toBigInt() -
+            balance.data.frozen.toBigInt()
         );
       },
     });

--- a/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
@@ -7,7 +7,6 @@ import {
   CHARLETH_PRIVATE_KEY,
   GERALD_PRIVATE_KEY,
   GLMR,
-  MIN_GAS_PRICE,
   checkBalance,
   createViemTransaction,
   createRawTransfer,
@@ -17,6 +16,8 @@ import {
 import { ALITH_GENESIS_TRANSFERABLE_BALANCE, verifyLatestBlockFees } from "../../../../helpers";
 
 import { parseGwei } from "viem";
+
+const MIN_GAS_PRICE = 2500000000n;
 
 describeSuite({
   id: "D010306",
@@ -43,7 +44,7 @@ describeSuite({
 
         await context.createBlock(createRawTransfer(context, randomAddress, 0n));
         expect(await context.viem().getBalance({ address: ALITH_ADDRESS })).toBe(
-          ALITH_GENESIS_TRANSFERABLE_BALANCE - 21000n * 10_000_000_000n
+          ALITH_GENESIS_TRANSFERABLE_BALANCE - 21000n * 2_500_000_000n
         );
       },
     });

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
@@ -7,13 +7,12 @@ import {
   DOROTHY_ADDRESS,
   GOLIATH_ADDRESS,
   GOLIATH_PRIVATE_KEY,
-  MIN_GAS_PRICE,
   createEthersTransaction,
   createRawTransfer,
   sendRawTransaction,
 } from "@moonwall/util";
 import { parseGwei } from "viem";
-import { ALITH_GENESIS_TRANSFERABLE_BALANCE } from "../../../../helpers";
+import { ALITH_GENESIS_TRANSFERABLE_BALANCE, ConstantStore } from "../../../../helpers";
 
 describeSuite({
   id: "D011102",
@@ -101,13 +100,18 @@ describeSuite({
       id: "T04",
       title: "already known #2",
       test: async function () {
+        const { specVersion } = await context.polkadotJs().consts.system.version;
+        const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(
+          specVersion.toNumber()
+        );
+
         const nonce = await context
           .viem("public")
           .getTransactionCount({ address: GOLIATH_ADDRESS });
 
         const tx1 = await createRawTransfer(context, BALTATHAR_ADDRESS, 1, {
           nonce: nonce + 1,
-          gasPrice: MIN_GAS_PRICE,
+          gasPrice: GENESIS_BASE_FEE,
           privateKey: GOLIATH_PRIVATE_KEY,
         });
         await context.createBlock(tx1);

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
@@ -25,12 +25,12 @@ describeSuite({
             nonce: currentNonce,
             maxFeePerGas: parseGwei("10"),
           }),
-          await createRawTransfer(context, randomAddress, 2, {
+          await createRawTransfer(context, randomAddress, 3, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("20"),
           }),
         ]);
-        expect(await context.viem().getBalance({ address: randomAddress })).to.equal(2n);
+        expect(await context.viem().getBalance({ address: randomAddress })).to.be.above(2);
       },
     });
 
@@ -63,14 +63,14 @@ describeSuite({
             maxFeePerGas: parseGwei("10"),
             gas: 1048575n,
           }),
-          await createRawTransfer(context, randomAddress, 2, {
+          await createRawTransfer(context, randomAddress, 3, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("20"),
             gas: 65536n,
           }),
         ]);
 
-        expect(await context.viem().getBalance({ address: randomAddress })).to.equal(2n);
+        expect(await context.viem().getBalance({ address: randomAddress })).to.be.above(2);
       },
     });
 

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, createRawTransfer, sendRawTransaction } from "@moonwall/util";
+import { ALITH_ADDRESS, createRawTransfer, GLMR, sendRawTransaction } from "@moonwall/util";
 import { parseGwei } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
@@ -18,19 +18,22 @@ describeSuite({
 
     it({
       id: "T01",
-      title: "should allow resubmitting with higher gas",
+      title: "should allow resubmitting with higher gas (implying higher tip)",
       test: async function () {
         await context.createBlock([
           await createRawTransfer(context, randomAddress, 1, {
             nonce: currentNonce,
-            maxFeePerGas: parseGwei("10"),
+            maxFeePerGas: parseGwei("300"),
+            maxPriorityFeePerGas: parseGwei("300"),
           }),
-          await createRawTransfer(context, randomAddress, 3, {
+          await createRawTransfer(context, randomAddress, 2, {
             nonce: currentNonce,
-            maxFeePerGas: parseGwei("20"),
+            maxFeePerGas: parseGwei("400"),
+            maxPriorityFeePerGas: parseGwei("300"),
+            // same priority fee but higher max fee so higher tip
           }),
         ]);
-        expect(await context.viem().getBalance({ address: randomAddress })).to.be.above(2);
+        expect(await context.viem().getBalance({ address: randomAddress })).to.equal(2n);
       },
     });
 
@@ -54,7 +57,7 @@ describeSuite({
 
     it({
       id: "T03",
-      title: "should allow cancelling transaction",
+      title: "should allow cancelling transaction by reducing limit",
       test: async function () {
         // gas price should trump limit
         await context.createBlock([
@@ -63,41 +66,37 @@ describeSuite({
             maxFeePerGas: parseGwei("10"),
             gas: 1048575n,
           }),
-          await createRawTransfer(context, randomAddress, 3, {
+          await createRawTransfer(context, randomAddress, 2, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("20"),
             gas: 65536n,
           }),
         ]);
 
-        expect(await context.viem().getBalance({ address: randomAddress })).to.be.above(2);
+        expect(await context.viem().getBalance({ address: randomAddress })).to.equal(1n);
       },
     });
 
     it({
       id: "T04",
-      title: "should pick highest gas price from many transactions",
+      title: "should prioritize higher gas tips",
       test: async function () {
+        // GasFee are using very high value to ensure gasPrice is not impacting
+        const alithGLMR = (await context.viem().getBalance({ address: ALITH_ADDRESS })) / GLMR;
         await sendRawTransaction(
           context,
-          await createRawTransfer(context, randomAddress, 2, {
+          await createRawTransfer(context, randomAddress, 66, {
             nonce: currentNonce,
-            maxFeePerGas: parseGwei("100"),
-            maxPriorityFeePerGas: parseGwei("100"),
+            maxFeePerGas: 1n * GLMR,
+            maxPriorityFeePerGas: 1n * GLMR,
           })
         );
 
-        const testParameters = [
-          parseGwei("2"),
-          parseGwei("5"),
-          parseGwei("10"),
-          parseGwei("11"),
-          parseGwei("20"),
-        ];
+        const testParameters = [1n * GLMR, 2n * GLMR, 20n * GLMR, 4n * GLMR, 10n * GLMR];
         const txns: string[] = await Promise.all(
           testParameters.map(
             async (gasPrice) =>
-              await createRawTransfer(context, randomAddress, 1, {
+              await createRawTransfer(context, randomAddress, 77, {
                 nonce: currentNonce,
                 maxFeePerGas: gasPrice,
                 maxPriorityFeePerGas: gasPrice,
@@ -107,7 +106,30 @@ describeSuite({
 
         await context.createBlock(txns);
 
-        expect(await context.viem().getBalance({ address: randomAddress })).to.equal(2n);
+        expect((await context.viem().getBalance({ address: ALITH_ADDRESS })) / GLMR).to.equal(
+          alithGLMR - 21000n * 20n
+        );
+        expect(await context.viem().getBalance({ address: randomAddress })).to.equal(77n);
+      },
+    });
+
+    it({
+      id: "T05",
+      title: "should not allow resubmitting with higher gas (implying same tip)",
+      test: async function () {
+        await context.createBlock([
+          await createRawTransfer(context, randomAddress, 1, {
+            nonce: currentNonce,
+            maxFeePerGas: parseGwei("300"),
+            maxPriorityFeePerGas: parseGwei("10"),
+          }),
+          await createRawTransfer(context, randomAddress, 2, {
+            nonce: currentNonce,
+            maxFeePerGas: parseGwei("400"),
+            maxPriorityFeePerGas: parseGwei("10"),
+          }),
+        ]);
+        expect(await context.viem().getBalance({ address: randomAddress })).to.equal(1n);
       },
     });
   },

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
@@ -16,7 +16,7 @@ describeSuite({
         expect(initialValue).to.equal(8_000_000_000_000_000_000n);
 
         const gasPrice = await context.viem().getGasPrice();
-        expect(gasPrice).to.eq(10_000_000_000n);
+        expect(gasPrice).to.eq(2_500_000_000n); // min gas price
       },
     });
   },

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
@@ -12,7 +12,9 @@ describeSuite({
       title: "should start with genesis value",
       test: async () => {
         const { specVersion } = await context.polkadotJs().consts.system.version;
-        const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(specVersion.toNumber());
+        const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(
+          specVersion.toNumber()
+        );
         const initialValue = (
           await context.polkadotJs().query.transactionPayment.nextFeeMultiplier()
         ).toBigInt();

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-genesis.ts
@@ -1,5 +1,6 @@
 import "@moonbeam-network/api-augment/moonbase";
 import { describeSuite, expect } from "@moonwall/cli";
+import { ConstantStore } from "../../../../helpers";
 
 describeSuite({
   id: "D011601",
@@ -10,13 +11,15 @@ describeSuite({
       id: "T01",
       title: "should start with genesis value",
       test: async () => {
+        const { specVersion } = await context.polkadotJs().consts.system.version;
+        const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(specVersion.toNumber());
         const initialValue = (
           await context.polkadotJs().query.transactionPayment.nextFeeMultiplier()
         ).toBigInt();
         expect(initialValue).to.equal(8_000_000_000_000_000_000n);
 
         const gasPrice = await context.viem().getGasPrice();
-        expect(gasPrice).to.eq(2_500_000_000n); // min gas price
+        expect(gasPrice).to.eq(GENESIS_BASE_FEE);
       },
     });
   },

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
@@ -49,7 +49,7 @@ describeSuite({
         ).toBigInt();
         expect(multiplier).toBe(100_000_000_000_000_000_000_000n);
         const gasPrice = await context.viem().getGasPrice();
-        expect(gasPrice).toBe(125_000_000_000_000n);
+        expect(gasPrice).toBe(31_250_000_000_000n);
       },
     });
 
@@ -128,7 +128,7 @@ describeSuite({
         let blockNumber = (await context.polkadotJs().rpc.chain.getHeader()).number.toBigInt();
         let baseFeePerGas = (await context.viem().getBlock({ blockNumber: blockNumber }))
           .baseFeePerGas!;
-        expect(baseFeePerGas).to.equal(125_000_000_000_000n);
+        expect(baseFeePerGas).to.equal(31_250_000_000_000n);
 
         const {
           hash: createTxHash,

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
@@ -175,7 +175,7 @@ describeSuite({
         expect(withdrawEvents?.length).to.equal(1);
         const withdrawEvent = withdrawEvents![0];
         const amount = withdrawEvent.event.data.amount.toBigInt();
-        expect(amount).to.equal(11_875_042_908_039_453_764n);
+        expect(amount).to.equal(2_968_760_727_009_792_092n);
       },
     });
   },

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-max.ts
@@ -143,7 +143,7 @@ describeSuite({
         blockNumber = (await context.polkadotJs().rpc.chain.getHeader()).number.toBigInt();
         baseFeePerGas = (await context.viem().getBlock({ blockNumber: blockNumber }))
           .baseFeePerGas!;
-        expect(baseFeePerGas).to.equal(124_827_007_821_127n);
+        expect(baseFeePerGas).to.equal(31_206_751_955_281n);
 
         const rawSigned = await createEthersTransaction(context, {
           to: contractAddress,

--- a/test/suites/dev/moonbase/test-fees/test-fee-multiplier-min.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fee-multiplier-min.ts
@@ -51,7 +51,7 @@ describeSuite({
         expect(multiplier).to.equal(100_000_000_000_000_000n);
 
         const gasPrice = await context.viem().getGasPrice();
-        expect(gasPrice).to.eq(125_000_000n);
+        expect(gasPrice).to.eq(31_250_000n);
       },
     });
   },

--- a/test/suites/dev/moonbase/test-fees/test-length-fees2.ts
+++ b/test/suites/dev/moonbase/test-fees/test-length-fees2.ts
@@ -12,6 +12,7 @@ describeSuite({
       id: "T01",
       title: "should not charge length fee for precompile from Ethereum txn",
       test: async () => {
+        const { specVersion } = await context.polkadotJs().consts.system.version;
         // we use modexp here because it allows us to send large-ish transactions
         const MODEXP_PRECOMPILE_ADDRESS = "0x0000000000000000000000000000000000000005";
 
@@ -28,7 +29,7 @@ describeSuite({
 
         const tx = await createViemTransaction(context, {
           to: MODEXP_PRECOMPILE_ADDRESS,
-          gas: BigInt(ConstantStore(context).EXTRINSIC_GAS_LIMIT),
+          gas: BigInt(ConstantStore(context).EXTRINSIC_GAS_LIMIT.get(specVersion.toNumber())),
           data: ("0x0000000000000000000000000000000000000000000000000000000000000004" + // base
             "0000000000000000000000000000000000000000000000000000000000000004" + // exp
             "0000000000000000000000000000000000000000000000000000000000000004" + // mod

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -88,8 +88,6 @@ describeSuite({
       const calcTreasuryIncrease = (feeWithTip: bigint, tip?: bigint): bigint => {
         const issuanceDecrease = calcIssuanceDecrease(feeWithTip, tip);
         const treasuryIncrease = feeWithTip - issuanceDecrease;
-        console.log("issuanceDecrease", issuanceDecrease.toString());
-        console.log("treasuryIncrease", treasuryIncrease.toString());
         return treasuryIncrease;
       };
       const calcIssuanceDecrease = (feeWithTip: bigint, tip?: bigint): bigint => {
@@ -107,16 +105,6 @@ describeSuite({
           burnProportion.value(),
           t.proportion.value()
         );
-
-        console.log("burn percentage", burnPercentage);
-        console.log("treasury percentage", treasuryPercentage);
-        console.log("feeWithTipBN", feeWithTipBN.toString());
-        console.log("tipBN", tipBN.toString());
-        console.log("feeWithoutTipBN", feeWithoutTipBN.toString());
-        console.log("burnFeePart", burnFeePart.toString());
-        console.log("treasuryFeePart", _treasuryFeePart.toString());
-        console.log("burnTipPart", burnTipPart.toString());
-        console.log("treasuryTipPart", _treasuryTipPart.toString());
 
         return BigInt(burnFeePart.add(burnTipPart).toString());
       };

--- a/test/suites/dev/moonbase/test-subscription/test-subscription.ts
+++ b/test/suites/dev/moonbase/test-subscription/test-subscription.ts
@@ -50,7 +50,8 @@ describeSuite({
           miner: ALITH_ADDRESS.toLowerCase(),
           receiptsRoot: "0xf78dfb743fbd92ade140711c8bbc542b5e307f0ab7984eff35d751969fe57efa",
           sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-          transactionsRoot: "0x199e8cd01da80b37a1dc061d83f5845334ac861e0c839636f1cad280f5a9bd49",
+          transactionsRoot: "0x7d43207a75e74b916ea381c28bf65a4691d7ac3d12bd8c20a5c547d67eb92141",
+          // TransactionRoot can often change (gas price, genesis data,...)
         });
         expect(blocks[0].nonce).to.be.eq("0x0000000000000000");
       },

--- a/test/suites/dev/moonbase/test-txpool/test-txpool-pending2.ts
+++ b/test/suites/dev/moonbase/test-txpool/test-txpool-pending2.ts
@@ -1,12 +1,8 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import {
-  ALITH_ADDRESS,
-  MIN_GAS_PRICE,
-  createEthersTransaction,
-  sendRawTransaction,
-} from "@moonwall/util";
+import { ALITH_ADDRESS, createEthersTransaction, sendRawTransaction } from "@moonwall/util";
 import { encodeFunctionData, toHex } from "viem";
+import { ConstantStore } from "../../../../helpers";
 
 describeSuite({
   id: "D013908",
@@ -17,6 +13,9 @@ describeSuite({
     let txHash: `0x${string}`;
 
     beforeAll(async () => {
+      const { specVersion } = await context.polkadotJs().consts.system.version;
+      const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(specVersion.toNumber());
+
       const { contractAddress, abi } = await context.deployContract!("MultiplyBy7", {
         gas: 1048576n,
       });
@@ -31,7 +30,7 @@ describeSuite({
         to: contractAddress,
         data,
         gasLimit: 12000000n,
-        gasPrice: MIN_GAS_PRICE,
+        gasPrice: GENESIS_BASE_FEE,
       });
 
       txHash = await sendRawTransaction(context, rawTx);
@@ -49,7 +48,7 @@ describeSuite({
 
         expect(data).to.not.be.undefined;
         expect(data).to.be.equal(
-          multiplyBy7Contract.toLowerCase() + ": 0 wei + 12000000 gas x 10000000000 wei"
+          multiplyBy7Contract.toLowerCase() + ": 0 wei + 12000000 gas x 2500000000 wei"
         );
       },
     });
@@ -67,7 +66,7 @@ describeSuite({
           blockNumber: null,
           from: ALITH_ADDRESS.toLowerCase(),
           gas: "0xb71b00",
-          gasPrice: "0x2540be400",
+          gasPrice: "0x9502f900",
           hash: txHash,
           nonce: toHex(1),
           to: multiplyBy7Contract.toLowerCase(),

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -124,7 +124,7 @@ describeSuite({
       ) {
         log(
           `Runtime ${specName.toString()} version ` +
-          `${specVersion.toString()} is less than 2200, skipping test suite.`
+            `${specVersion.toString()} is less than 2200, skipping test suite.`
         );
         skipAll = true;
       }
@@ -132,7 +132,7 @@ describeSuite({
       if (specVersion.toNumber() < 2300 && specName.toString() == "moonbeam") {
         log(
           `Runtime ${specName.toString()} version ` +
-          `${specVersion.toString()} is less than 2300, skipping test suite.`
+            `${specVersion.toString()} is less than 2300, skipping test suite.`
         );
         skipAll = true;
       }
@@ -143,9 +143,9 @@ describeSuite({
 
       log(
         `Collecting ${hours} hours worth of data ` +
-        `[from #${blockNumArray[0]} ` +
-        `to #${blockNumArray[blockNumArray.length - 1]}] ` +
-        `(${blockNumArray.length} blocks, RT${specVersion.toNumber()})`
+          `[from #${blockNumArray[0]} ` +
+          `to #${blockNumArray[blockNumArray.length - 1]}] ` +
+          `(${blockNumArray.length} blocks, RT${specVersion.toNumber()})`
       );
 
       const getBlockData = async (blockNum: number) => {
@@ -195,7 +195,7 @@ describeSuite({
       if (result) {
         log(
           `Time slice of blocks intersects with upgrade ` +
-          `from RT ${onChainRt} to RT ${specVersion}, skipping tests.`
+            `from RT ${onChainRt} to RT ${specVersion}, skipping tests.`
         );
         skipAll = true;
       }
@@ -293,9 +293,9 @@ describeSuite({
         const failures = blockData.filter(({ baseFeePerGasInGwei }) => {
           return (
             ethers.parseUnits(baseFeePerGasInGwei, "gwei") <
-            RUNTIME_CONSTANTS[runtime].MIN_BASE_FEE.get(specVersion.toNumber()) ||
+              RUNTIME_CONSTANTS[runtime].MIN_BASE_FEE.get(specVersion.toNumber()) ||
             ethers.parseUnits(baseFeePerGasInGwei, "gwei") >
-            RUNTIME_CONSTANTS[runtime].MAX_BASE_FEE.get(specVersion.toNumber())
+              RUNTIME_CONSTANTS[runtime].MAX_BASE_FEE.get(specVersion.toNumber())
           );
         });
 

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -115,7 +115,7 @@ describeSuite({
       );
       const version = (await paraApi.at(endsAtBlockHash)).consts.system.version;
       specVersion = version.specVersion;
-      let specName = version.specName;
+      const specName = version.specName;
       runtime = specName.toUpperCase() as any;
 
       if (
@@ -124,7 +124,7 @@ describeSuite({
       ) {
         log(
           `Runtime ${specName.toString()} version ` +
-            `${specVersion.toString()} is less than 2200, skipping test suite.`
+          `${specVersion.toString()} is less than 2200, skipping test suite.`
         );
         skipAll = true;
       }
@@ -132,7 +132,7 @@ describeSuite({
       if (specVersion.toNumber() < 2300 && specName.toString() == "moonbeam") {
         log(
           `Runtime ${specName.toString()} version ` +
-            `${specVersion.toString()} is less than 2300, skipping test suite.`
+          `${specVersion.toString()} is less than 2300, skipping test suite.`
         );
         skipAll = true;
       }
@@ -143,9 +143,9 @@ describeSuite({
 
       log(
         `Collecting ${hours} hours worth of data ` +
-          `[from #${blockNumArray[0]} ` +
-          `to #${blockNumArray[blockNumArray.length - 1]}] ` +
-          `(${blockNumArray.length} blocks, RT${specVersion.toNumber()})`
+        `[from #${blockNumArray[0]} ` +
+        `to #${blockNumArray[blockNumArray.length - 1]}] ` +
+        `(${blockNumArray.length} blocks, RT${specVersion.toNumber()})`
       );
 
       const getBlockData = async (blockNum: number) => {
@@ -195,7 +195,7 @@ describeSuite({
       if (result) {
         log(
           `Time slice of blocks intersects with upgrade ` +
-            `from RT ${onChainRt} to RT ${specVersion}, skipping tests.`
+          `from RT ${onChainRt} to RT ${specVersion}, skipping tests.`
         );
         skipAll = true;
       }
@@ -293,9 +293,9 @@ describeSuite({
         const failures = blockData.filter(({ baseFeePerGasInGwei }) => {
           return (
             ethers.parseUnits(baseFeePerGasInGwei, "gwei") <
-              RUNTIME_CONSTANTS[runtime].MIN_BASE_FEE.get(specVersion.toNumber()) ||
+            RUNTIME_CONSTANTS[runtime].MIN_BASE_FEE.get(specVersion.toNumber()) ||
             ethers.parseUnits(baseFeePerGasInGwei, "gwei") >
-              RUNTIME_CONSTANTS[runtime].MAX_BASE_FEE.get(specVersion.toNumber())
+            RUNTIME_CONSTANTS[runtime].MAX_BASE_FEE.get(specVersion.toNumber())
           );
         });
 


### PR DESCRIPTION
Following the increase of Gas (by 4x) due to 4x more CPU time allowed for block building, we are now decreasing the min_gas_price by 4x to match the same block minimum price.