### PR TITLE
Use ParachainBlockImport::new_with_delayed_best_block when experimental_block_import_strategy is disabled

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -578,12 +578,12 @@ where
 		)
 	} else {
 		let parachain_block_import = if experimental_block_import_strategy {
-			ParachainBlockImport::new(frontier_block_import, backend.clone());
+			ParachainBlockImport::new(frontier_block_import, backend.clone())
 		} else {
 			ParachainBlockImport::new_with_delayed_best_block(
 				frontier_block_import,
 				backend.clone(),
-			);
+			)
 		};
 		(
 			nimbus_consensus::import_queue(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -577,8 +577,14 @@ where
 			BlockImportPipeline::Dev(frontier_block_import),
 		)
 	} else {
-		let parachain_block_import =
+		let parachain_block_import = if experimental_block_import_strategy {
 			ParachainBlockImport::new(frontier_block_import, backend.clone());
+		} else {
+			ParachainBlockImport::new_with_delayed_best_block(
+				frontier_block_import,
+				backend.clone(),
+			);
+		};
 		(
 			nimbus_consensus::import_queue(
 				client.clone(),

--- a/test/configs/localZombie.json
+++ b/test/configs/localZombie.json
@@ -48,7 +48,7 @@
       "collator": {
         "name": "alith",
         "ws_port": 33345,
-        "command": "tmp/moonbeam_rt",
+        "command": "../target/release/moonbeam",
         "args": [
           "--no-hardware-benchmarks",
           "--force-authoring",

--- a/test/configs/zombieAlphanet.json
+++ b/test/configs/zombieAlphanet.json
@@ -49,7 +49,7 @@
       "collator": {
         "name": "alith",
         "ws_port": 33345,
-        "command": "tmp/moonbeam_rt",
+        "command": "../target/release/moonbeam",
         "args": [
           "--no-hardware-benchmarks",
           "--force-authoring",

--- a/test/configs/zombieAlphanetRpc.json
+++ b/test/configs/zombieAlphanetRpc.json
@@ -49,7 +49,7 @@
         {
           "name": "alith",
           "ws_port": 33345,
-          "command": "tmp/moonbeam_rt",
+          "command": "../target/release/moonbeam",
           "args": [
             "--no-hardware-benchmarks",
             "--force-authoring",

--- a/test/configs/zombieMoonbeam.json
+++ b/test/configs/zombieMoonbeam.json
@@ -46,7 +46,7 @@
       "chain_spec_path": "tmp/moonbeam-modified-raw-spec.json",
       "collator": {
         "name": "alith",
-        "command": "tmp/moonbeam_rt",
+        "command": "../target/release/moonbeam",
         "ws_port": 33345,
         "args": [
           "--no-hardware-benchmarks",

--- a/test/configs/zombieMoonbeamRpc.json
+++ b/test/configs/zombieMoonbeamRpc.json
@@ -48,7 +48,7 @@
       "collators": [
         {
           "name": "alith",
-          "command": "tmp/moonbeam_rt",
+          "command": "../target/release/moonbeam",
           "ws_port": 33345,
           "args": [
             "--no-hardware-benchmarks",


### PR DESCRIPTION
### What does it do?

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
