### PR TITLE
test(smoke): Correctly check egress hmrp channels

### DIFF
--- a/test/suites/smoke/test-xcm-failures.ts
+++ b/test/suites/smoke/test-xcm-failures.ts
@@ -412,7 +412,7 @@ describeSuite({
           (await relayApi.query.hrmp.hrmpIngressChannelsIndex(paraId)) as any
         ).map((a: any) => a.toNumber());
         const outChannels = (
-          (await relayApi.query.hrmp.hrmpIngressChannelsIndex(paraId)) as any
+          (await relayApi.query.hrmp.hrmpEgressChannelsIndex(paraId)) as any
         ).map((a: any) => a.toNumber());
         const channels = [...new Set([...inChannels, ...outChannels])];
 


### PR DESCRIPTION
### What does it do?

Fixes the smoke test for checking the hmrp channels. Outgoing channels were not being checked. 