### PR TITLE
test(smoke): use parachain connection when fetching the runtime name

### DIFF
--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -191,10 +191,6 @@ export const MAX_ETH_POV_PER_TX = 3_250_000n;
 type ConstantStoreType = (typeof RUNTIME_CONSTANTS)["MOONBASE"];
 
 export function ConstantStore(context: GenericContext): ConstantStoreType {
-  const runtimeChain = context.polkadotJs().consts.system.version.specName.toUpperCase();
-  const runtime = runtimeChain
-    .split(" ")
-    .filter((v) => Object.keys(RUNTIME_CONSTANTS).includes(v))
-    .join();
+  const runtime = context.polkadotJs().consts.system.version.specName.toUpperCase();
   return RUNTIME_CONSTANTS[runtime];
 }

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -191,7 +191,7 @@ export const MAX_ETH_POV_PER_TX = 3_250_000n;
 type ConstantStoreType = (typeof RUNTIME_CONSTANTS)["MOONBASE"];
 
 export function ConstantStore(context: GenericContext): ConstantStoreType {
-  const runtimeChain = context.polkadotJs().runtimeChain.toUpperCase();
+  const runtimeChain = context.polkadotJs().consts.system.version.specName.toUpperCase();
   const runtime = runtimeChain
     .split(" ")
     .filter((v) => Object.keys(RUNTIME_CONSTANTS).includes(v))

--- a/test/suites/lazy-loading/test-runtime-upgrade.ts
+++ b/test/suites/lazy-loading/test-runtime-upgrade.ts
@@ -1,6 +1,5 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import { RUNTIME_CONSTANTS } from "../../helpers";
 import { ApiPromise } from "@polkadot/api";
 import fs from "fs/promises";
 import { u8aToHex } from "@polkadot/util";
@@ -24,12 +23,7 @@ describeSuite({
     beforeAll(async () => {
       api = context.polkadotJs();
 
-      const runtimeChain = api.consts.system.version.specName.toUpperCase();
-      const runtime = runtimeChain
-        .split(" ")
-        .filter((v) => Object.keys(RUNTIME_CONSTANTS).includes(v))
-        .join()
-        .toLowerCase();
+      const runtime = api.consts.system.version.specName.toLowerCase();
       const wasmPath = `../target/release/wbuild/${runtime}-runtime/${runtime}_runtime.compact.compressed.wasm`; // editorconfig-checker-disable-line
 
       const runtimeWasmHex = u8aToHex(await fs.readFile(wasmPath));

--- a/test/suites/lazy-loading/test-runtime-upgrade.ts
+++ b/test/suites/lazy-loading/test-runtime-upgrade.ts
@@ -24,7 +24,7 @@ describeSuite({
     beforeAll(async () => {
       api = context.polkadotJs();
 
-      const runtimeChain = api.runtimeChain.toUpperCase();
+      const runtimeChain = api.consts.system.version.specName.toUpperCase();
       const runtime = runtimeChain
         .split(" ")
         .filter((v) => Object.keys(RUNTIME_CONSTANTS).includes(v))

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -16,7 +16,6 @@ import { AnyTuple } from "@polkadot/types/types";
 import { ethers } from "ethers";
 import {
   checkTimeSliceForUpgrades,
-  ConstantStore,
   rateLimiter,
   RUNTIME_CONSTANTS,
 } from "../../helpers";

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -14,11 +14,7 @@ import {
 } from "@polkadot/types/lookup";
 import { AnyTuple } from "@polkadot/types/types";
 import { ethers } from "ethers";
-import {
-  checkTimeSliceForUpgrades,
-  rateLimiter,
-  RUNTIME_CONSTANTS,
-} from "../../helpers";
+import { checkTimeSliceForUpgrades, rateLimiter, RUNTIME_CONSTANTS } from "../../helpers";
 import Debug from "debug";
 import { DispatchInfo } from "@polkadot/types/interfaces";
 const debug = Debug("smoke:dynamic-fees");

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -304,7 +304,8 @@ describeSuite({
           log("Skipping test suite due to runtime version");
           return;
         }
-        const weightFee = ConstantStore(context).WEIGHT_FEE.get(specVersion.toNumber());
+        const runtime = paraApi.runtimeChain.toUpperCase();
+        const weightFee = RUNTIME_CONSTANTS[runtime].WEIGHT_FEE.get(specVersion.toNumber());
 
         const failures = blockData
           .map(({ blockNum, nextFeeMultiplier, baseFeePerGasInGwei }) => {

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -299,7 +299,7 @@ describeSuite({
           log("Skipping test suite due to runtime version");
           return;
         }
-        const runtime = paraApi.runtimeChain.toUpperCase();
+        const runtime = paraApi.consts.system.version.specName.toUpperCase();
         const weightFee = RUNTIME_CONSTANTS[runtime].WEIGHT_FEE.get(specVersion.toNumber());
 
         const failures = blockData


### PR DESCRIPTION
### What does it do?

For smoke tests, we have 2 polkadotJS connections, one for the parachain and another for the relay chain. This PR fixes the test, by explicitly fetching the runtime name from the parachain connection.

Before this change, the smoke test could fail if moonwall picked the `relay` connection, giving the relay runtime name, instead of the parachain one.
