### PR TITLE
Fix foreign assets smoke tests

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -125,6 +125,12 @@ export const ForeignChainsEndpoints = [
         name: "Turing",
         paraId: 2114,
       },
+      // Litmus has become a para-thread
+      {
+        name: "Litmus",
+        paraId: 2106,
+        mutedUntil: new Date("2025-01-30").getTime(),
+      },
     ],
   },
   {

--- a/test/suites/smoke/test-foreign-asset-consistency.ts
+++ b/test/suites/smoke/test-foreign-asset-consistency.ts
@@ -30,6 +30,11 @@ describeSuite({
       apiAt = await paraApi.at(await paraApi.rpc.chain.getBlockHash(atBlockNumber));
       specVersion = apiAt.consts.system.version.specVersion.toNumber();
 
+      liveForeignAssets = (await apiAt.query.assets.asset.entries()).reduce((acc, [key, value]) => {
+        acc[key.args.toString()] = (value.unwrap() as any).status.isLive;
+        return acc;
+      }, {});
+
       // Query all assets mapped by identifier
       const legacyAssets = await apiAt.query.assetManager.assetIdType.entries();
       const evmForeignAssets = await apiAt.query.evmForeignAssets.assetsById.entries();
@@ -48,6 +53,7 @@ describeSuite({
       assetsByLocation.forEach(([key, exposure]) => {
         const assetType = key.args.toString();
         const [assetId, assetStatus] = exposure.unwrap();
+        liveForeignAssets[assetType] = assetStatus.isActive;
         foreignAssetTypeId[assetType] = assetId.toString();
       });
 
@@ -60,11 +66,6 @@ describeSuite({
       log(`Foreign Xcm Supported Assets: ${xcmWeightManagerSupportedAssets}`);
       log(`Foreign AssetId -> AssetLocation: ${JSON.stringify(foreignAssetIdType)}`);
       log(`Foreign AssetLocation -> AssetId: ${JSON.stringify(foreignAssetTypeId)}`);
-
-      liveForeignAssets = (await apiAt.query.assets.asset.entries()).reduce((acc, [key, value]) => {
-        acc[key.args.toString()] = (value.unwrap() as any).status.isLive;
-        return acc;
-      }, {} as any);
     });
 
     it({


### PR DESCRIPTION
### What does it do?

Fixes the following smoke tests: `S12C100`, `S12C300` and `S25C1200`.

(`S12C100`, `S12C300`): With the new native ERC20 foreign assets, the smoke test needs to fetch assets from 2 different pallets.

`S25C1200`: Litmus has become a para-thread and the channel is idle.
