### PR TITLE
chore: disable debug-assertions in production builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -477,9 +477,10 @@ zeroize = { opt-level = 3 }
 inherits = "release"
 
 [profile.production]
+inherits = "release"
+debug-assertions = false # Disable debug-assert! for production builds
 codegen-units = 1
 incremental = false
-inherits = "release"
 lto = true
 
 [profile.release]


### PR DESCRIPTION
### What does it do?

Disables `debug-assertions` in the production profile. Ideally debug statements should only be enabled in non optimized builds.

Relates: https://github.com/paritytech/polkadot-sdk/issues/6957