### PR TITLE
 errors in documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@
 
 To release `vX.Y.Z`:
 
-1. Create a PR with increment client version
+1. Create a PR with increment the client version
 1. Get that PR approved and merged
 1. Tag master with `vX.Y.Z` and push to github
 1. Start the github action "Publish Binary Draft" (on master branch)
@@ -40,7 +40,7 @@ To release `vX.Y.Z`:
 
 To release `runtime-XXYY`:
 
-1. Create a PR that increment spec version (like #1051)
+1. Create a PR that increment the spec version (like #1051)
 1. Get that PR approved and merged
 1. Tag master with `runtime-XXYY` and push to github
 1. Start the github action "Publish Runtime Draft"

--- a/client/rpc/debug/README.md
+++ b/client/rpc/debug/README.md
@@ -64,9 +64,9 @@ sp_api::decl_runtime_apis! {
 Substrate provides two macro attributes to do what we want: `api_version` and `changed_in`.
 
 - `api_version`: is the current version of the Api. In our case we updated it to `#[api_version(2)]`.
-- changed_in: is meant to describe for `decl_runtime_apis` macro past implementations of methods. In this case, we anotate our previous implementation with `#[changed_in(2)]`, telling the `decl_runtime_apis` macro that this is the implementation to use before version 2. In fact, this attribute will rename the method name for the trait in the client side to `METHOD_before_version_VERSION`, so `trace_transaction_before_version_2` in our example.
+- changed_in: is meant to describe for `decl_runtime_apis` macro past implementations of methods. In this case, we annotate our previous implementation with `#[changed_in(2)]`, telling the `decl_runtime_apis` macro that this is the implementation to use before version 2. In fact, this attribute will rename the method name for the trait in the client side to `METHOD_before_version_VERSION`, so `trace_transaction_before_version_2` in our example.
 
-The un-anotated method is considered the default implemetation, and holds the current `trace_transaction` signature, with the new header argument and the empty result.
+The un-annotated method is considered the default implementation, and holds the current `trace_transaction` signature, with the new header argument and the empty result.
 
 ### Using a versioned runtime api from the client
 

--- a/tools/pov/README.md
+++ b/tools/pov/README.md
@@ -1,6 +1,6 @@
 # PoV Benchmarking
 
-This scripts runs a parameterized benchmark with the given `params` and collects the result over them
+This script runs a parameterized benchmark with the given `params` and collects the result over them
 into a json file. Additionally this file may be used to visualize the following metrics as charts:
 
 - PoV Size


### PR DESCRIPTION
1. Spelling Corrections:
"annotate" is the correct spelling of the word meaning "to add notes to"
"implementation" is the correct spelling for the process of putting a plan into action
These corrections improve documentation accuracy and professionalism

2. Grammar Fixes:
Changed "scripts" to "script" to match the singular context
