### PR TITLE
Send priority fees to collators

### DIFF
--- a/runtime/common/src/deal_with_fees.rs
+++ b/runtime/common/src/deal_with_fees.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2024 Moonbeam foundation
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/deal_with_fees.rs
+++ b/runtime/common/src/deal_with_fees.rs
@@ -1,3 +1,19 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
 use frame_support::__private::Get;
 use frame_support::pallet_prelude::TypedGet;
 use frame_support::traits::fungible::Credit;

--- a/runtime/common/src/deal_with_fees.rs
+++ b/runtime/common/src/deal_with_fees.rs
@@ -1,0 +1,98 @@
+use frame_support::__private::Get;
+use frame_support::pallet_prelude::TypedGet;
+use frame_support::traits::fungible::Credit;
+use frame_support::traits::tokens::imbalance::ResolveTo;
+use frame_support::traits::Imbalance;
+use frame_support::traits::OnUnbalanced;
+use pallet_treasury::TreasuryAccountId;
+use sp_runtime::Perbill;
+
+/// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
+pub struct DealWithSubstrateFeesAndTip<R, FeesTreasuryProportion>(
+	sp_std::marker::PhantomData<(R, FeesTreasuryProportion)>,
+);
+impl<R, FeesTreasuryProportion> DealWithSubstrateFeesAndTip<R, FeesTreasuryProportion>
+where
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+	FeesTreasuryProportion: Get<Perbill>,
+{
+	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// Balances pallet automatically burns dropped Credits by decreasing
+		// total_supply accordingly
+		let treasury_proportion = FeesTreasuryProportion::get();
+		let treasury_part = treasury_proportion.deconstruct();
+		let burn_part = Perbill::one().deconstruct() - treasury_part;
+		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
+		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+
+	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
+	}
+}
+
+impl<R, FeesTreasuryProportion> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithSubstrateFeesAndTip<R, FeesTreasuryProportion>
+where
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+	FeesTreasuryProportion: Get<Perbill>,
+{
+	fn on_unbalanceds(
+		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
+	) {
+		if let Some(fees) = fees_then_tips.next() {
+			Self::deal_with_fees(fees);
+			if let Some(tip) = fees_then_tips.next() {
+				Self::deal_with_tip(tip);
+			}
+		}
+	}
+}
+
+/// Deal with ethereum based fees. To handle tips/priority fees, use DealWithEthereumPriorityFees.
+pub struct DealWithEthereumBaseFees<R, FeesTreasuryProportion>(
+	sp_std::marker::PhantomData<(R, FeesTreasuryProportion)>,
+);
+impl<R, FeesTreasuryProportion> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithEthereumBaseFees<R, FeesTreasuryProportion>
+where
+	R: pallet_balances::Config + pallet_treasury::Config,
+	FeesTreasuryProportion: Get<Perbill>,
+{
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// Balances pallet automatically burns dropped Credits by decreasing
+		// total_supply accordingly
+		let treasury_proportion = FeesTreasuryProportion::get();
+		let treasury_part = treasury_proportion.deconstruct();
+		let burn_part = Perbill::one().deconstruct() - treasury_part;
+		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
+		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+}
+
+pub struct BlockAuthorAccountId<R>(sp_std::marker::PhantomData<R>);
+impl<R> TypedGet for BlockAuthorAccountId<R>
+where
+	R: frame_system::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+{
+	type Type = R::AccountId;
+	fn get() -> Self::Type {
+		<pallet_author_inherent::Pallet<R> as Get<R::AccountId>>::get()
+	}
+}
+
+/// Deal with ethereum based priority fees/tips. See DealWithEthereumBaseFees for base fees.
+pub struct DealWithEthereumPriorityFees<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithEthereumPriorityFees<R>
+where
+	R: pallet_balances::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+{
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
+	}
+}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -19,6 +19,7 @@
 mod apis;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
+pub mod deal_with_fees;
 mod impl_moonbeam_xcm_call;
 mod impl_moonbeam_xcm_call_tracing;
 mod impl_on_charge_evm_transaction;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -60,7 +60,7 @@ use frame_support::{
 	construct_runtime,
 	dispatch::{DispatchClass, GetDispatchInfo, PostDispatchInfo},
 	ensure,
-	pallet_prelude::{DispatchResult},
+	pallet_prelude::DispatchResult,
 	parameter_types,
 	traits::{
 		fungible::{Balanced, Credit, HoldConsideration, Inspect},
@@ -89,7 +89,6 @@ use pallet_evm::{
 	OnChargeEVMTransaction as OnChargeEVMTransactionT, Runner,
 };
 use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
-use pallet_treasury::TreasuryAccountId;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use runtime_params::*;
 use scale_info::TypeInfo;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -343,7 +343,8 @@ impl pallet_balances::Config for Runtime {
 pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
 impl<R> DealWithSubstrateFeesAndTip<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config,
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
 {
 	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
 		// Balances pallet automatically burns dropped Credits by decreasing
@@ -362,9 +363,10 @@ where
 }
 
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithSubstrateFeesAndTip<R>
+for DealWithSubstrateFeesAndTip<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config,
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
 {
 	fn on_unbalanceds(
 		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -363,7 +363,7 @@ where
 }
 
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-for DealWithSubstrateFeesAndTip<R>
+	for DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
 	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -341,12 +341,11 @@ impl pallet_balances::Config for Runtime {
 
 /// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
 pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithSubstrateFeesAndTip<R>
+impl<R> DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
 {
-	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
 		// Balances pallet automatically burns dropped Credits by decreasing
 		// total_supply accordingly
 		let treasury_proportion =
@@ -355,6 +354,28 @@ where
 		let burn_part = Perbill::one().deconstruct() - treasury_part;
 		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
 		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+
+	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// same as fees
+		Self::deal_with_fees(amount)
+	}
+}
+
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithSubstrateFeesAndTip<R>
+where
+	R: pallet_balances::Config + pallet_treasury::Config,
+{
+	fn on_unbalanceds(
+		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
+	) {
+		if let Some(fees) = fees_then_tips.next() {
+			Self::deal_with_fees(fees);
+			if let Some(tip) = fees_then_tips.next() {
+				Self::deal_with_tip(tip);
+			}
+		}
 	}
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -60,14 +60,13 @@ use frame_support::{
 	construct_runtime,
 	dispatch::{DispatchClass, GetDispatchInfo, PostDispatchInfo},
 	ensure,
-	pallet_prelude::{DispatchResult, PhantomData},
+	pallet_prelude::{DispatchResult},
 	parameter_types,
 	traits::{
 		fungible::{Balanced, Credit, HoldConsideration, Inspect},
-		tokens::imbalance::ResolveTo,
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
 		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
-		EqualPrivilegeOnly, FindAuthor, Imbalance, InstanceFilter, LinearStoragePrice, OnFinalize,
+		EqualPrivilegeOnly, FindAuthor, InstanceFilter, LinearStoragePrice, OnFinalize,
 		OnUnbalanced,
 	},
 	weights::{
@@ -125,7 +124,6 @@ use xcm_runtime_apis::{
 use smallvec::smallvec;
 use sp_runtime::serde::{Deserialize, Serialize};
 
-use sp_runtime::traits::TypedGet;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -357,8 +357,7 @@ where
 	}
 
 	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		// same as fees
-		Self::deal_with_fees(amount)
+		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
 	}
 }
 

--- a/runtime/moonbase/src/runtime_params.rs
+++ b/runtime/moonbase/src/runtime_params.rs
@@ -55,7 +55,7 @@ impl Default for RuntimeParameters {
 		RuntimeParameters::RuntimeConfig(
 			dynamic_params::runtime_config::Parameters::FeesTreasuryProportion(
 				dynamic_params::runtime_config::FeesTreasuryProportion,
-				Some(Perbill::from_percent(5)),
+				Some(Perbill::from_percent(20)),
 			),
 		)
 	}

--- a/runtime/moonbase/src/runtime_params.rs
+++ b/runtime/moonbase/src/runtime_params.rs
@@ -55,7 +55,7 @@ impl Default for RuntimeParameters {
 		RuntimeParameters::RuntimeConfig(
 			dynamic_params::runtime_config::Parameters::FeesTreasuryProportion(
 				dynamic_params::runtime_config::FeesTreasuryProportion,
-				Some(Perbill::from_percent(20)),
+				Some(Perbill::from_percent(5)),
 			),
 		)
 	}

--- a/runtime/moonbase/src/runtime_params.rs
+++ b/runtime/moonbase/src/runtime_params.rs
@@ -30,7 +30,7 @@ pub mod dynamic_params {
 	pub mod runtime_config {
 		// for fees, 80% are burned, 20% to the treasury
 		#[codec(index = 0)]
-		pub static FeesTreasuryProportion: Perbill = Perbill::from_percent(20);
+		pub static FeesTreasuryProportion: Perbill = Perbill::from_percent(5);
 	}
 
 	#[dynamic_pallet_params]

--- a/runtime/moonbase/src/runtime_params.rs
+++ b/runtime/moonbase/src/runtime_params.rs
@@ -30,7 +30,7 @@ pub mod dynamic_params {
 	pub mod runtime_config {
 		// for fees, 80% are burned, 20% to the treasury
 		#[codec(index = 0)]
-		pub static FeesTreasuryProportion: Perbill = Perbill::from_percent(5);
+		pub static FeesTreasuryProportion: Perbill = Perbill::from_percent(20);
 	}
 
 	#[dynamic_pallet_params]

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -364,6 +364,9 @@ pub fn set_parachain_inherent_data() {
 	use cumulus_primitives_core::PersistedValidationData;
 	use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 
+	let author = AccountId::from(<pallet_evm::Pallet<Runtime>>::find_author());
+	pallet_author_inherent::Author::<Runtime>::put(author);
+
 	let mut relay_sproof = RelayStateSproofBuilder::default();
 	relay_sproof.para_id = 100u32.into();
 	relay_sproof.included_para_head = Some(HeadData(vec![1, 2, 3]));

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2797,12 +2797,12 @@ fn substrate_based_fees_zero_txn_costs_only_base_extrinsic() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonriver_runtime::{DealWithSubstrateFeesAndTip, Treasury};
+	use moonbase_runtime::{DealWithSubstrateFeesAndTip, Treasury};
 
 	ExtBuilder::default().build().execute_with(|| {
 		set_parachain_inherent_data();
 		// This test validates the functionality of the `DealWithSubstrateFeesAndTip` trait implementation
-		// in the Moonriver runtime. It verifies that:
+		// in the Moonbeam runtime. It verifies that:
 		// - The correct proportion of the fee is sent to the treasury.
 		// - The remaining fee is burned (removed from the total supply).
 		// - The entire tip is sent to the block author.

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2780,10 +2780,10 @@ fn substrate_based_fees_zero_txn_costs_only_base_extrinsic() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonbase_runtime::{DealWithFees, Treasury};
+	use moonbase_runtime::{DealWithSubstrateFeesAndTip, Treasury};
 
 	ExtBuilder::default().build().execute_with(|| {
-		// This test checks the functionality of the `DealWithFees` trait implementation in the runtime.
+		// This test checks the functionality of the `DealWithSubstrateFeesAndTip` trait implementation in the runtime.
 		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
 		// treasury receives the correct amount (20% of the total), and the rest is burned (80%).
 		//
@@ -2791,7 +2791,7 @@ fn deal_with_fees_handles_tip() {
 		// 1. It issues a fee of 100 and a tip of 1000.
 		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
 		// 3. It checks that the treasury's balance is initially 0.
-		// 4. It calls `DealWithFees::on_unbalanceds` with the fee and tip.
+		// 4. It calls `DealWithSubstrateFeesAndTip::on_unbalanceds` with the fee and tip.
 		// 5. It checks that the treasury's balance is now 220 (20% of the fee and tip).
 		// 6. It checks that the total supply has decreased by 880 (80% of the fee and tip), indicating
 		//    that this amount was burned.
@@ -2806,7 +2806,7 @@ fn deal_with_fees_handles_tip() {
 		assert_eq!(total_supply_before, 1_100);
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
-		DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
+		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
 
 		// treasury should have received 20%
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -77,17 +77,17 @@ use moonkit_xcm_primitives::AccountIdAssetIdConversion;
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
 //use pallet_evm_precompileset_assets_erc20::{SELECTOR_LOG_APPROVAL, SELECTOR_LOG_TRANSFER};
+use moonbase_runtime::runtime_params::dynamic_params;
 use pallet_moonbeam_foreign_assets::AssetStatus;
 use pallet_transaction_payment::Multiplier;
 use pallet_xcm_transactor::{Currency, CurrencyPayment, HrmpOperation, TransactWeights};
 use parity_scale_codec::Encode;
 use sha3::{Digest, Keccak256};
-use sp_core::{crypto::UncheckedFrom, ByteArray, Pair, H160, H256, U256, Get};
+use sp_core::{crypto::UncheckedFrom, ByteArray, Get, Pair, H160, H256, U256};
 use sp_runtime::{bounded_vec, DispatchError, ModuleError};
 use std::cell::Cell;
 use std::rc::Rc;
 use xcm::{latest::prelude::*, VersionedAssets, VersionedLocation};
-use moonbase_runtime::runtime_params::dynamic_params;
 
 type AuthorMappingPCall =
 	pallet_evm_precompile_author_mapping::AuthorMappingPrecompileCall<Runtime>;
@@ -2833,11 +2833,17 @@ fn deal_with_fees_handles_tip() {
 		let burnt_tip_part: Balance = 1000 - treasury_tip_part;
 
 		// treasury should have received FeesTreasuryProportion
-		assert_eq!(Balances::free_balance(&Treasury::account_id()), treasury_fee_part + treasury_tip_part);
+		assert_eq!(
+			Balances::free_balance(&Treasury::account_id()),
+			treasury_fee_part + treasury_tip_part
+		);
 
 		// verify the rest is burned
 		let total_supply_after = Balances::total_issuance();
-		assert_eq!(total_supply_before - total_supply_after, burnt_fee_part + burnt_tip_part);
+		assert_eq!(
+			total_supply_before - total_supply_after,
+			burnt_fee_part + burnt_tip_part
+		);
 	});
 }
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2797,7 +2797,8 @@ fn substrate_based_fees_zero_txn_costs_only_base_extrinsic() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonbase_runtime::{DealWithSubstrateFeesAndTip, Treasury};
+	use moonbase_runtime::Treasury;
+	use moonbeam_runtime_common::deal_with_fees::DealWithSubstrateFeesAndTip;
 
 	ExtBuilder::default().build().execute_with(|| {
 		set_parachain_inherent_data();
@@ -2832,7 +2833,10 @@ fn deal_with_fees_handles_tip() {
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
 		// Step 3: Execute the fees handling logic.
-		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
+		DealWithSubstrateFeesAndTip::<
+			Runtime,
+			dynamic_params::runtime_config::FeesTreasuryProportion,
+		>::on_unbalanceds(vec![fee, tip].into_iter());
 
 		// Step 4: Compute the split between treasury and burned fees based on FeesTreasuryProportion (20%).
 		let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();

--- a/runtime/moonbase/tests/runtime_apis.rs
+++ b/runtime/moonbase/tests/runtime_apis.rs
@@ -216,6 +216,8 @@ fn ethereum_runtime_rpc_api_current_transaction_statuses() {
 		)])
 		.build()
 		.execute_with(|| {
+			set_parachain_inherent_data();
+
 			let _result = Executive::apply_extrinsic(unchecked_eth_tx(VALID_ETH_TX));
 			rpc_run_to_block(2);
 			let statuses =
@@ -273,6 +275,7 @@ fn ethereum_runtime_rpc_api_current_receipts() {
 		)])
 		.build()
 		.execute_with(|| {
+			set_parachain_inherent_data();
 			let _result = Executive::apply_extrinsic(unchecked_eth_tx(VALID_ETH_TX));
 			rpc_run_to_block(2);
 			let receipts = Runtime::current_receipts().expect("Receipts result.");

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -357,7 +357,7 @@ where
 }
 
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-for DealWithSubstrateFeesAndTip<R>
+	for DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
 {
@@ -536,9 +536,7 @@ pub type SlowAdjustingFeeUpdate<R> = TargetedFeeAdjustment<
 	MaximumMultiplier,
 >;
 
-use frame_support::traits::tokens::imbalance::TryMerge;
 use frame_support::traits::FindAuthor;
-use pallet_balances::Pallet;
 //TODO It feels like this shold be able to work for any T: H160, but I tried for
 // embarassingly long and couldn't figure that out.
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -37,7 +37,7 @@ use fp_rpc::TransactionStatus;
 use cumulus_primitives_core::{relay_chain, AggregateMessageOrigin};
 #[cfg(feature = "std")]
 pub use fp_evm::GenesisAccount;
-use frame_support::pallet_prelude::{TypedGet, PhantomData};
+use frame_support::pallet_prelude::{PhantomData, TypedGet};
 pub use frame_support::traits::Get;
 use frame_support::{
 	construct_runtime,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -48,8 +48,7 @@ use frame_support::{
 		fungible::{Balanced, Credit, HoldConsideration, Inspect},
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
 		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
-		EqualPrivilegeOnly, InstanceFilter, LinearStoragePrice, OnFinalize,
-		OnUnbalanced,
+		EqualPrivilegeOnly, InstanceFilter, LinearStoragePrice, OnFinalize, OnUnbalanced,
 	},
 	weights::{
 		constants::WEIGHT_REF_TIME_PER_SECOND, ConstantMultiplier, Weight, WeightToFeeCoefficient,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -333,91 +333,6 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = moonbeam_weights::pallet_balances::WeightInfo<Runtime>;
 }
 
-/// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
-pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
-impl<R> DealWithSubstrateFeesAndTip<R>
-where
-	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		// Balances pallet automatically burns dropped Credits by decreasing
-		// total_supply accordingly
-		let treasury_proportion =
-			runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
-		let treasury_part = treasury_proportion.deconstruct();
-		let burn_part = Perbill::one().deconstruct() - treasury_part;
-		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
-		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
-	}
-
-	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
-	}
-}
-
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithSubstrateFeesAndTip<R>
-where
-	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	fn on_unbalanceds(
-		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
-	) {
-		if let Some(fees) = fees_then_tips.next() {
-			Self::deal_with_fees(fees);
-			if let Some(tip) = fees_then_tips.next() {
-				Self::deal_with_tip(tip);
-			}
-		}
-	}
-}
-
-/// Deal with ethereum based fees. To handle tips/priority fees, use DealWithEthereumPriorityFees.
-pub struct DealWithEthereumBaseFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithEthereumBaseFees<R>
-where
-	R: pallet_balances::Config + pallet_treasury::Config,
-{
-	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		// Balances pallet automatically burns dropped Credits by decreasing
-		// total_supply accordingly
-		let treasury_proportion =
-			runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
-		let treasury_part = treasury_proportion.deconstruct();
-		let burn_part = Perbill::one().deconstruct() - treasury_part;
-		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
-		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
-	}
-}
-
-pub struct BlockAuthorAccountId<R>(PhantomData<R>);
-impl<R> TypedGet for BlockAuthorAccountId<R>
-where
-	R: frame_system::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	type Type = R::AccountId;
-	fn get() -> Self::Type {
-		<pallet_author_inherent::Pallet<R> as Get<R::AccountId>>::get()
-	}
-}
-
-/// Deal with ethereum based priority fees/tips. See DealWithEthereumBaseFees for base fees.
-pub struct DealWithEthereumPriorityFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithEthereumPriorityFees<R>
-where
-	R: pallet_balances::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
-	}
-}
-
 pub struct LengthToFee;
 impl WeightToFeePolynomial for LengthToFee {
 	type Balance = Balance;
@@ -442,7 +357,13 @@ impl WeightToFeePolynomial for LengthToFee {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = FungibleAdapter<Balances, DealWithSubstrateFeesAndTip<Runtime>>;
+	type OnChargeTransaction = FungibleAdapter<
+		Balances,
+		DealWithSubstrateFeesAndTip<
+			Runtime,
+			dynamic_params::runtime_config::FeesTreasuryProportion,
+		>,
+	>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ currency::WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;
@@ -574,7 +495,7 @@ impl pallet_evm::Config for Runtime {
 	type PrecompilesValue = PrecompilesValue;
 	type ChainId = EthereumChainId;
 	type OnChargeTransaction = OnChargeEVMTransaction<
-		DealWithEthereumBaseFees<Runtime>,
+		DealWithEthereumBaseFees<Runtime, dynamic_params::runtime_config::FeesTreasuryProportion>,
 		DealWithEthereumPriorityFees<Runtime>,
 	>;
 	type BlockGasLimit = BlockGasLimit;
@@ -1534,6 +1455,10 @@ construct_runtime! {
 
 #[cfg(feature = "runtime-benchmarks")]
 use moonbeam_runtime_common::benchmarking::BenchmarkHelper;
+use moonbeam_runtime_common::deal_with_fees::{
+	DealWithEthereumBaseFees, DealWithEthereumPriorityFees, DealWithSubstrateFeesAndTip,
+};
+
 #[cfg(feature = "runtime-benchmarks")]
 mod benches {
 	frame_support::parameter_types! {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -37,6 +37,7 @@ use fp_rpc::TransactionStatus;
 use cumulus_primitives_core::{relay_chain, AggregateMessageOrigin};
 #[cfg(feature = "std")]
 pub use fp_evm::GenesisAccount;
+use frame_support::pallet_prelude::{TypedGet, PhantomData};
 pub use frame_support::traits::Get;
 use frame_support::{
 	construct_runtime,
@@ -332,40 +333,13 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = moonbeam_weights::pallet_balances::WeightInfo<Runtime>;
 }
 
-pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>> for DealWithFees<R>
+/// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
+pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
 {
-	// this seems to be called for substrate-based transactions
-	fn on_unbalanceds(
-		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
-	) {
-		if let Some(fees) = fees_then_tips.next() {
-			let treasury_proportion =
-				runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
-			let treasury_part = treasury_proportion.deconstruct();
-			let burn_part = Perbill::one().deconstruct() - treasury_part;
-			let (_, to_treasury) = fees.ration(burn_part, treasury_part);
-			// Balances pallet automatically burns dropped Credits by decreasing
-			// total_supply accordingly
-			ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
-				to_treasury,
-			);
-
-			// handle tip if there is one
-			if let Some(tip) = fees_then_tips.next() {
-				// for now we use the same burn/treasury strategy used for regular fees
-				let (_, to_treasury) = tip.ration(burn_part, treasury_part);
-				ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
-					to_treasury,
-				);
-			}
-		}
-	}
-
-	// this is called from pallet_evm for Ethereum-based transactions
-	// (technically, it calls on_unbalanced, which calls this when non-zero)
 	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
 		// Balances pallet automatically burns dropped Credits by decreasing
 		// total_supply accordingly
@@ -375,6 +349,50 @@ where
 		let burn_part = Perbill::one().deconstruct() - treasury_part;
 		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
 		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+}
+
+/// Deal with ethereum based fees. To handle tips/priority fees, use DealWithEthereumPriorityFees.
+pub struct DealWithEthereumBaseFees<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithEthereumBaseFees<R>
+where
+	R: pallet_balances::Config + pallet_treasury::Config,
+{
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// Balances pallet automatically burns dropped Credits by decreasing
+		// total_supply accordingly
+		let treasury_proportion =
+			runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
+		let treasury_part = treasury_proportion.deconstruct();
+		let burn_part = Perbill::one().deconstruct() - treasury_part;
+		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
+		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+}
+
+pub struct BlockAuthorAccountId<R>(PhantomData<R>);
+impl<R> TypedGet for BlockAuthorAccountId<R>
+where
+	R: frame_system::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+{
+	type Type = R::AccountId;
+	fn get() -> Self::Type {
+		<pallet_author_inherent::Pallet<R> as Get<R::AccountId>>::get()
+	}
+}
+
+/// Deal with ethereum based priority fees/tips. See DealWithEthereumBaseFees for base fees.
+pub struct DealWithEthereumPriorityFees<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithEthereumPriorityFees<R>
+where
+	R: pallet_balances::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+{
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
 	}
 }
 
@@ -402,7 +420,7 @@ impl WeightToFeePolynomial for LengthToFee {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees<Runtime>>;
+	type OnChargeTransaction = FungibleAdapter<Balances, DealWithSubstrateFeesAndTip<Runtime>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ currency::WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;
@@ -533,7 +551,10 @@ impl pallet_evm::Config for Runtime {
 	type PrecompilesType = MoonbeamPrecompiles<Self>;
 	type PrecompilesValue = PrecompilesValue;
 	type ChainId = EthereumChainId;
-	type OnChargeTransaction = OnChargeEVMTransaction<DealWithFees<Runtime>>;
+	type OnChargeTransaction = OnChargeEVMTransaction<
+		DealWithEthereumBaseFees<Runtime>,
+		DealWithEthereumPriorityFees<Runtime>,
+	>;
 	type BlockGasLimit = BlockGasLimit;
 	type FindAuthor = FindAuthorAdapter<AuthorInherent>;
 	type OnCreate = ();

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -351,8 +351,7 @@ where
 	}
 
 	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		// same as fees
-		Self::deal_with_fees(amount)
+		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
 	}
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -337,7 +337,8 @@ impl pallet_balances::Config for Runtime {
 pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
 impl<R> DealWithSubstrateFeesAndTip<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config,
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
 {
 	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
 		// Balances pallet automatically burns dropped Credits by decreasing
@@ -358,7 +359,8 @@ where
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
 	for DealWithSubstrateFeesAndTip<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config,
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
 {
 	fn on_unbalanceds(
 		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -335,7 +335,6 @@ impl pallet_balances::Config for Runtime {
 
 /// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
 pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
-
 impl<R> DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
@@ -358,7 +357,7 @@ where
 }
 
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithSubstrateFeesAndTip<R>
+for DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
 {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -37,7 +37,6 @@ use fp_rpc::TransactionStatus;
 use cumulus_primitives_core::{relay_chain, AggregateMessageOrigin};
 #[cfg(feature = "std")]
 pub use fp_evm::GenesisAccount;
-use frame_support::pallet_prelude::{PhantomData, TypedGet};
 pub use frame_support::traits::Get;
 use frame_support::{
 	construct_runtime,
@@ -47,10 +46,9 @@ use frame_support::{
 	parameter_types,
 	traits::{
 		fungible::{Balanced, Credit, HoldConsideration, Inspect},
-		tokens::imbalance::ResolveTo,
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
 		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
-		EqualPrivilegeOnly, Imbalance, InstanceFilter, LinearStoragePrice, OnFinalize,
+		EqualPrivilegeOnly, InstanceFilter, LinearStoragePrice, OnFinalize,
 		OnUnbalanced,
 	},
 	weights::{
@@ -76,7 +74,6 @@ use pallet_evm::{
 };
 pub use pallet_parachain_staking::{weights::WeightInfo, InflationInfo, Range};
 use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
-use pallet_treasury::TreasuryAccountId;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -335,12 +335,12 @@ impl pallet_balances::Config for Runtime {
 
 /// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
 pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithSubstrateFeesAndTip<R>
+
+impl<R> DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
 {
-	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
 		// Balances pallet automatically burns dropped Credits by decreasing
 		// total_supply accordingly
 		let treasury_proportion =
@@ -349,6 +349,28 @@ where
 		let burn_part = Perbill::one().deconstruct() - treasury_part;
 		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
 		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+
+	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// same as fees
+		Self::deal_with_fees(amount)
+	}
+}
+
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithSubstrateFeesAndTip<R>
+where
+	R: pallet_balances::Config + pallet_treasury::Config,
+{
+	fn on_unbalanceds(
+		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
+	) {
+		if let Some(fees) = fees_then_tips.next() {
+			Self::deal_with_fees(fees);
+			if let Some(tip) = fees_then_tips.next() {
+				Self::deal_with_tip(tip);
+			}
+		}
 	}
 }
 
@@ -515,7 +537,9 @@ pub type SlowAdjustingFeeUpdate<R> = TargetedFeeAdjustment<
 	MaximumMultiplier,
 >;
 
+use frame_support::traits::tokens::imbalance::TryMerge;
 use frame_support::traits::FindAuthor;
+use pallet_balances::Pallet;
 //TODO It feels like this shold be able to work for any T: H160, but I tried for
 // embarassingly long and couldn't figure that out.
 

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -345,6 +345,9 @@ pub fn set_parachain_inherent_data() {
 	use cumulus_primitives_core::PersistedValidationData;
 	use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 
+	let author = AccountId::from(<pallet_evm::Pallet<Runtime>>::find_author());
+	pallet_author_inherent::Author::<Runtime>::put(author);
+
 	let mut relay_sproof = RelayStateSproofBuilder::default();
 	relay_sproof.para_id = 100u32.into();
 	relay_sproof.included_para_head = Some(HeadData(vec![1, 2, 3]));

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -1445,6 +1445,7 @@ fn transfer_ed_0_evm() {
 		])
 		.build()
 		.execute_with(|| {
+			set_parachain_inherent_data();
 			// EVM transfer
 			assert_ok!(RuntimeCall::EVM(pallet_evm::Call::<Runtime>::call {
 				source: H160::from(ALICE),

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -1537,6 +1537,7 @@ fn author_does_receive_priority_fee() {
 
 #[test]
 fn total_issuance_after_evm_transaction_with_priority_fee() {
+	use fp_evm::FeeCalculator;
 	ExtBuilder::default()
 		.with_balances(vec![
 			(
@@ -1569,7 +1570,9 @@ fn total_issuance_after_evm_transaction_with_priority_fee() {
 
 			let issuance_after = <Runtime as pallet_evm::Config>::Currency::total_issuance();
 
-			let base_fee: Balance = 125 * GIGAWEI * 21_000;
+			let base_fee = TransactionPaymentAsGasPrice::min_gas_price().0.as_u128();
+
+			let base_fee: Balance = base_fee * 21_000;
 
 			let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();
 
@@ -1616,11 +1619,10 @@ fn total_issuance_after_evm_transaction_without_priority_fee() {
 			.dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::root()));
 
 			let issuance_after = <Runtime as pallet_evm::Config>::Currency::total_issuance();
-			// Fee is 1 GWEI base fee.
-			let base_fee = TransactionPaymentAsGasPrice::min_gas_price().0;
-			assert_eq!(base_fee.as_u128(), BASE_FEE_GENESIS); // hint in case following asserts fail
 
-			let base_fee: Balance = BASE_FEE_GENESIS * 21_000;
+			let base_fee = TransactionPaymentAsGasPrice::min_gas_price().0.as_u128();
+
+			let base_fee: Balance = base_fee * 21_000;
 
 			let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();
 

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2618,7 +2618,8 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonbeam_runtime::{DealWithSubstrateFeesAndTip, Treasury};
+	use moonbeam_runtime::Treasury;
+	use moonbeam_runtime_common::deal_with_fees::DealWithSubstrateFeesAndTip;
 
 	ExtBuilder::default().build().execute_with(|| {
 		set_parachain_inherent_data();
@@ -2653,7 +2654,10 @@ fn deal_with_fees_handles_tip() {
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
 		// Step 3: Execute the fees handling logic.
-		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
+		DealWithSubstrateFeesAndTip::<
+			Runtime,
+			dynamic_params::runtime_config::FeesTreasuryProportion,
+		>::on_unbalanceds(vec![fee, tip].into_iter());
 
 		// Step 4: Compute the split between treasury and burned fees based on FeesTreasuryProportion (20%).
 		let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2618,12 +2618,12 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonriver_runtime::{DealWithSubstrateFeesAndTip, Treasury};
+	use moonbeam_runtime::{DealWithSubstrateFeesAndTip, Treasury};
 
 	ExtBuilder::default().build().execute_with(|| {
 		set_parachain_inherent_data();
 		// This test validates the functionality of the `DealWithSubstrateFeesAndTip` trait implementation
-		// in the Moonriver runtime. It verifies that:
+		// in the Moonbeam runtime. It verifies that:
 		// - The correct proportion of the fee is sent to the treasury.
 		// - The remaining fee is burned (removed from the total supply).
 		// - The entire tip is sent to the block author.

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2618,21 +2618,26 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonbeam_runtime::{DealWithSubstrateFeesAndTip, Treasury};
+	use moonriver_runtime::{DealWithSubstrateFeesAndTip, Treasury};
 
 	ExtBuilder::default().build().execute_with(|| {
-		// This test checks the functionality of the `DealWithSubstrateFeesAndTip` trait implementation in the runtime.
-		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
-		// treasury receives the correct amount (set by FeesTreasuryProportion), and the rest is burned.
-		//
-		// The test follows these steps: (Assuming FeesTreasuryProportion is set to 20%)
-		// 1. It issues a fee of 100 and a tip of 1000.
-		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
-		// 3. It checks that the treasury's balance is initially 0.
-		// 4. It calls `DealWithSubstrateFeesAndTip::on_unbalanceds` with the fee and tip.
-		// 5. It checks that the treasury's balance is now 220 (20% of the fee and tip).
-		// 6. It checks that the total supply has decreased by 880 (80% of the fee and tip), indicating
-		//    that this amount was burned.
+		set_parachain_inherent_data();
+		// This test validates the functionality of the `DealWithSubstrateFeesAndTip` trait implementation
+		// in the Moonriver runtime. It verifies that:
+		// - The correct proportion of the fee is sent to the treasury.
+		// - The remaining fee is burned (removed from the total supply).
+		// - The entire tip is sent to the block author.
+
+		// The test details:
+		// 1. Simulate issuing a `fee` of 100 and a `tip` of 1000.
+		// 2. Confirm the initial total supply is 1,100 (equal to the sum of the issued fee and tip).
+		// 3. Confirm the treasury's balance is initially 0.
+		// 4. Execute the `DealWithSubstrateFeesAndTip::on_unbalanceds` function with the `fee` and `tip`.
+		// 5. Validate that the treasury's balance has increased by 20% of the fee (based on FeesTreasuryProportion).
+		// 6. Validate that 80% of the fee is burned, and the total supply decreases accordingly.
+		// 7. Validate that the entire tip (100%) is sent to the block author (collator).
+
+		// Step 1: Issue the fee and tip amounts.
 		let fee = <pallet_balances::Pallet<Runtime> as frame_support::traits::fungible::Balanced<
 			AccountId,
 		>>::issue(100);
@@ -2640,30 +2645,37 @@ fn deal_with_fees_handles_tip() {
 			AccountId,
 		>>::issue(1000);
 
+		// Step 2: Validate the initial supply and balances.
 		let total_supply_before = Balances::total_issuance();
+		let block_author = pallet_author_inherent::Pallet::<Runtime>::get();
+		let block_author_balance_before = Balances::free_balance(&block_author);
 		assert_eq!(total_supply_before, 1_100);
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
+		// Step 3: Execute the fees handling logic.
 		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
 
+		// Step 4: Compute the split between treasury and burned fees based on FeesTreasuryProportion (20%).
 		let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();
 
 		let treasury_fee_part: Balance = treasury_proportion.mul_floor(100);
 		let burnt_fee_part: Balance = 100 - treasury_fee_part;
-		let treasury_tip_part: Balance = treasury_proportion.mul_floor(1000);
-		let burnt_tip_part: Balance = 1000 - treasury_tip_part;
 
-		// treasury should have received 20%
+		// Step 5: Validate the treasury received 20% of the fee.
 		assert_eq!(
 			Balances::free_balance(&Treasury::account_id()),
-			treasury_fee_part + treasury_tip_part
+			treasury_fee_part,
 		);
 
-		// verify 80% burned
+		// Step 6: Verify that 80% of the fee was burned (removed from the total supply).
 		let total_supply_after = Balances::total_issuance();
+		assert_eq!(total_supply_before - total_supply_after, burnt_fee_part,);
+
+		// Step 7: Validate that the block author (collator) received 100% of the tip.
+		let block_author_balance_after = Balances::free_balance(&block_author);
 		assert_eq!(
-			total_supply_before - total_supply_after,
-			burnt_fee_part + burnt_tip_part
+			block_author_balance_after - block_author_balance_before,
+			1000,
 		);
 	});
 }

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -1585,6 +1585,7 @@ fn total_issuance_after_evm_transaction_with_priority_fee() {
 
 #[test]
 fn total_issuance_after_evm_transaction_without_priority_fee() {
+	use fp_evm::FeeCalculator;
 	ExtBuilder::default()
 		.with_balances(vec![
 			(

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -1629,7 +1629,7 @@ fn total_issuance_after_evm_transaction_without_priority_fee() {
 
 			assert_eq!(issuance_after, issuance_before - burnt_base_fee_part);
 
-			assert_eq!(moonbase_runtime::Treasury::pot(), treasury_base_fee_part);
+			assert_eq!(moonbeam_runtime::Treasury::pot(), treasury_base_fee_part);
 		});
 }
 

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -33,6 +33,7 @@ use frame_support::{
 	StorageHasher, Twox128,
 };
 use moonbeam_runtime::currency::{GIGAWEI, WEI};
+use moonbeam_runtime::runtime_params::dynamic_params;
 use moonbeam_runtime::{
 	asset_config::ForeignAssetInstance,
 	currency::GLMR,
@@ -57,7 +58,7 @@ use precompile_utils::{
 	testing::*,
 };
 use sha3::{Digest, Keccak256};
-use sp_core::{ByteArray, Pair, H160, U256, Get};
+use sp_core::{ByteArray, Get, Pair, H160, U256};
 use sp_runtime::{
 	traits::{Convert, Dispatchable},
 	BuildStorage, DispatchError, ModuleError,
@@ -66,7 +67,6 @@ use std::str::from_utf8;
 use xcm::{latest::prelude::*, VersionedAssets, VersionedLocation};
 use xcm_builder::{ParentIsPreset, SiblingParachainConvertsVia};
 use xcm_executor::traits::ConvertLocation;
-use moonbeam_runtime::runtime_params::dynamic_params;
 use xcm_primitives::split_location_into_chain_part_and_beneficiary;
 
 type BatchPCall = pallet_evm_precompile_batch::BatchPrecompileCall<Runtime>;
@@ -2651,11 +2651,17 @@ fn deal_with_fees_handles_tip() {
 		let burnt_tip_part: Balance = 1000 - treasury_tip_part;
 
 		// treasury should have received 20%
-		assert_eq!(Balances::free_balance(&Treasury::account_id()), treasury_fee_part + treasury_tip_part);
+		assert_eq!(
+			Balances::free_balance(&Treasury::account_id()),
+			treasury_fee_part + treasury_tip_part
+		);
 
 		// verify 80% burned
 		let total_supply_after = Balances::total_issuance();
-		assert_eq!(total_supply_before - total_supply_after, burnt_fee_part + burnt_tip_part);
+		assert_eq!(
+			total_supply_before - total_supply_after,
+			burnt_fee_part + burnt_tip_part
+		);
 	});
 }
 

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2595,18 +2595,19 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonbeam_runtime::{DealWithFees, Treasury};
+	use moonbeam_runtime::{DealWithSubstrateFeesAndTip, Treasury};
 
 	ExtBuilder::default().build().execute_with(|| {
-		// This test checks the functionality of the `DealWithFees` trait implementation in the runtime.
-		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
-		// treasury receives the correct amount (20% of the total), and the rest is burned (80%).
+		// This test checks the functionality of the `DealWithSubstrateFeesAndTip` trait
+		// implementation in the runtime. It simulates a scenario where a fee and a tip are issued
+		// to an account and ensures that the treasury receives the correct amount (20% of the
+		// total), and the rest is burned (80%).
 		//
 		// The test follows these steps:
 		// 1. It issues a fee of 100 and a tip of 1000.
 		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
 		// 3. It checks that the treasury's balance is initially 0.
-		// 4. It calls `DealWithFees::on_unbalanceds` with the fee and tip.
+		// 4. It calls `DealWithSubstrateFeesAndTip::on_unbalanceds` with the fee and tip.
 		// 5. It checks that the treasury's balance is now 220 (20% of the fee and tip).
 		// 6. It checks that the total supply has decreased by 880 (80% of the fee and tip), indicating
 		//    that this amount was burned.
@@ -2621,7 +2622,7 @@ fn deal_with_fees_handles_tip() {
 		assert_eq!(total_supply_before, 1_100);
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
-		DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
+		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
 
 		// treasury should have received 20%
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -38,7 +38,6 @@ use fp_rpc::TransactionStatus;
 use cumulus_primitives_core::{relay_chain, AggregateMessageOrigin};
 #[cfg(feature = "std")]
 pub use fp_evm::GenesisAccount;
-use frame_support::pallet_prelude::{PhantomData, TypedGet};
 pub use frame_support::traits::Get;
 use frame_support::{
 	construct_runtime,
@@ -48,10 +47,9 @@ use frame_support::{
 	parameter_types,
 	traits::{
 		fungible::{Balanced, Credit, HoldConsideration, Inspect},
-		tokens::imbalance::ResolveTo,
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
 		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
-		EqualPrivilegeOnly, Imbalance, InstanceFilter, LinearStoragePrice, OnFinalize,
+		EqualPrivilegeOnly, InstanceFilter, LinearStoragePrice, OnFinalize,
 		OnUnbalanced,
 	},
 	weights::{
@@ -80,7 +78,6 @@ use pallet_evm::{
 };
 pub use pallet_parachain_staking::{weights::WeightInfo, InflationInfo, Range};
 use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
-use pallet_treasury::TreasuryAccountId;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -339,7 +339,8 @@ impl pallet_balances::Config for Runtime {
 pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
 impl<R> DealWithSubstrateFeesAndTip<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config,
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
 {
 	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
 		// Balances pallet automatically burns dropped Credits by decreasing
@@ -358,9 +359,10 @@ where
 }
 
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithSubstrateFeesAndTip<R>
+for DealWithSubstrateFeesAndTip<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config,
+	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
 {
 	fn on_unbalanceds(
 		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -38,6 +38,7 @@ use fp_rpc::TransactionStatus;
 use cumulus_primitives_core::{relay_chain, AggregateMessageOrigin};
 #[cfg(feature = "std")]
 pub use fp_evm::GenesisAccount;
+use frame_support::pallet_prelude::{PhantomData, TypedGet};
 pub use frame_support::traits::Get;
 use frame_support::{
 	construct_runtime,
@@ -334,40 +335,13 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = moonriver_weights::pallet_balances::WeightInfo<Runtime>;
 }
 
-pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>> for DealWithFees<R>
+/// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
+pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
 {
-	// this seems to be called for substrate-based transactions
-	fn on_unbalanceds(
-		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
-	) {
-		if let Some(fees) = fees_then_tips.next() {
-			let treasury_proportion =
-				runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
-			let treasury_part = treasury_proportion.deconstruct();
-			let burn_part = Perbill::one().deconstruct() - treasury_part;
-			let (_, to_treasury) = fees.ration(burn_part, treasury_part);
-			// Balances pallet automatically burns dropped Credits by decreasing
-			// total_supply accordingly
-			ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
-				to_treasury,
-			);
-
-			// handle tip if there is one
-			if let Some(tip) = fees_then_tips.next() {
-				// for now we use the same burn/treasury strategy used for regular fees
-				let (_, to_treasury) = tip.ration(burn_part, treasury_part);
-				ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(
-					to_treasury,
-				);
-			}
-		}
-	}
-
-	// this is called from pallet_evm for Ethereum-based transactions
-	// (technically, it calls on_unbalanced, which calls this when non-zero)
 	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
 		// Balances pallet automatically burns dropped Credits by decreasing
 		// total_supply accordingly
@@ -377,6 +351,50 @@ where
 		let burn_part = Perbill::one().deconstruct() - treasury_part;
 		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
 		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+}
+
+/// Deal with ethereum based fees. To handle tips/priority fees, use DealWithEthereumPriorityFees.
+pub struct DealWithEthereumBaseFees<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithEthereumBaseFees<R>
+where
+	R: pallet_balances::Config + pallet_treasury::Config,
+{
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		// Balances pallet automatically burns dropped Credits by decreasing
+		// total_supply accordingly
+		let treasury_proportion =
+			runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
+		let treasury_part = treasury_proportion.deconstruct();
+		let burn_part = Perbill::one().deconstruct() - treasury_part;
+		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
+		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
+	}
+}
+
+pub struct BlockAuthorAccountId<R>(PhantomData<R>);
+impl<R> TypedGet for BlockAuthorAccountId<R>
+where
+	R: frame_system::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+{
+	type Type = R::AccountId;
+	fn get() -> Self::Type {
+		<pallet_author_inherent::Pallet<R> as Get<R::AccountId>>::get()
+	}
+}
+
+/// Deal with ethereum based priority fees/tips. See DealWithEthereumBaseFees for base fees.
+pub struct DealWithEthereumPriorityFees<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
+	for DealWithEthereumPriorityFees<R>
+where
+	R: pallet_balances::Config + pallet_author_inherent::Config,
+	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
+{
+	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
+		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
 	}
 }
 
@@ -404,7 +422,7 @@ impl WeightToFeePolynomial for LengthToFee {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees<Runtime>>;
+	type OnChargeTransaction = FungibleAdapter<Balances, DealWithSubstrateFeesAndTip<Runtime>>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ currency::WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;
@@ -535,7 +553,10 @@ impl pallet_evm::Config for Runtime {
 	type PrecompilesType = MoonriverPrecompiles<Self>;
 	type PrecompilesValue = PrecompilesValue;
 	type ChainId = EthereumChainId;
-	type OnChargeTransaction = OnChargeEVMTransaction<DealWithFees<Runtime>>;
+	type OnChargeTransaction = OnChargeEVMTransaction<
+		DealWithEthereumBaseFees<Runtime>,
+		DealWithEthereumPriorityFees<Runtime>,
+	>;
 	type BlockGasLimit = BlockGasLimit;
 	type FindAuthor = FindAuthorAdapter<AuthorInherent>;
 	type OnCreate = ();

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -353,8 +353,7 @@ where
 	}
 
 	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		// same as fees
-		Self::deal_with_fees(amount)
+		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
 	}
 }
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -49,8 +49,7 @@ use frame_support::{
 		fungible::{Balanced, Credit, HoldConsideration, Inspect},
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
 		ConstBool, ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse,
-		EqualPrivilegeOnly, InstanceFilter, LinearStoragePrice, OnFinalize,
-		OnUnbalanced,
+		EqualPrivilegeOnly, InstanceFilter, LinearStoragePrice, OnFinalize, OnUnbalanced,
 	},
 	weights::{
 		constants::WEIGHT_REF_TIME_PER_SECOND, ConstantMultiplier, Weight, WeightToFeeCoefficient,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -66,6 +66,9 @@ pub use moonbeam_core_primitives::{
 	Index, Signature,
 };
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
+use moonbeam_runtime_common::deal_with_fees::{
+	DealWithEthereumBaseFees, DealWithEthereumPriorityFees, DealWithSubstrateFeesAndTip,
+};
 use moonbeam_runtime_common::timestamp::{ConsensusHookWrapperForRelayTimestamp, RelayTimestamp};
 pub use pallet_author_slot_filter::EligibilityValue;
 use pallet_ethereum::Call::transact;
@@ -335,91 +338,6 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = moonriver_weights::pallet_balances::WeightInfo<Runtime>;
 }
 
-/// Deal with substrate based fees and tip. This should be used with pallet_transaction_payment.
-pub struct DealWithSubstrateFeesAndTip<R>(sp_std::marker::PhantomData<R>);
-impl<R> DealWithSubstrateFeesAndTip<R>
-where
-	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	fn deal_with_fees(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		// Balances pallet automatically burns dropped Credits by decreasing
-		// total_supply accordingly
-		let treasury_proportion =
-			runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
-		let treasury_part = treasury_proportion.deconstruct();
-		let burn_part = Perbill::one().deconstruct() - treasury_part;
-		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
-		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
-	}
-
-	fn deal_with_tip(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
-	}
-}
-
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithSubstrateFeesAndTip<R>
-where
-	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	fn on_unbalanceds(
-		mut fees_then_tips: impl Iterator<Item = Credit<R::AccountId, pallet_balances::Pallet<R>>>,
-	) {
-		if let Some(fees) = fees_then_tips.next() {
-			Self::deal_with_fees(fees);
-			if let Some(tip) = fees_then_tips.next() {
-				Self::deal_with_tip(tip);
-			}
-		}
-	}
-}
-
-/// Deal with ethereum based fees. To handle tips/priority fees, use DealWithEthereumPriorityFees.
-pub struct DealWithEthereumBaseFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithEthereumBaseFees<R>
-where
-	R: pallet_balances::Config + pallet_treasury::Config,
-{
-	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		// Balances pallet automatically burns dropped Credits by decreasing
-		// total_supply accordingly
-		let treasury_proportion =
-			runtime_params::dynamic_params::runtime_config::FeesTreasuryProportion::get();
-		let treasury_part = treasury_proportion.deconstruct();
-		let burn_part = Perbill::one().deconstruct() - treasury_part;
-		let (_, to_treasury) = amount.ration(burn_part, treasury_part);
-		ResolveTo::<TreasuryAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(to_treasury);
-	}
-}
-
-pub struct BlockAuthorAccountId<R>(PhantomData<R>);
-impl<R> TypedGet for BlockAuthorAccountId<R>
-where
-	R: frame_system::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	type Type = R::AccountId;
-	fn get() -> Self::Type {
-		<pallet_author_inherent::Pallet<R> as Get<R::AccountId>>::get()
-	}
-}
-
-/// Deal with ethereum based priority fees/tips. See DealWithEthereumBaseFees for base fees.
-pub struct DealWithEthereumPriorityFees<R>(sp_std::marker::PhantomData<R>);
-impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-	for DealWithEthereumPriorityFees<R>
-where
-	R: pallet_balances::Config + pallet_author_inherent::Config,
-	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,
-{
-	fn on_nonzero_unbalanced(amount: Credit<R::AccountId, pallet_balances::Pallet<R>>) {
-		ResolveTo::<BlockAuthorAccountId<R>, pallet_balances::Pallet<R>>::on_unbalanced(amount);
-	}
-}
-
 pub struct LengthToFee;
 impl WeightToFeePolynomial for LengthToFee {
 	type Balance = Balance;
@@ -444,7 +362,13 @@ impl WeightToFeePolynomial for LengthToFee {
 
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = FungibleAdapter<Balances, DealWithSubstrateFeesAndTip<Runtime>>;
+	type OnChargeTransaction = FungibleAdapter<
+		Balances,
+		DealWithSubstrateFeesAndTip<
+			Runtime,
+			dynamic_params::runtime_config::FeesTreasuryProportion,
+		>,
+	>;
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = ConstantMultiplier<Balance, ConstU128<{ currency::WEIGHT_FEE }>>;
 	type LengthToFee = LengthToFee;
@@ -576,7 +500,7 @@ impl pallet_evm::Config for Runtime {
 	type PrecompilesValue = PrecompilesValue;
 	type ChainId = EthereumChainId;
 	type OnChargeTransaction = OnChargeEVMTransaction<
-		DealWithEthereumBaseFees<Runtime>,
+		DealWithEthereumBaseFees<Runtime, dynamic_params::runtime_config::FeesTreasuryProportion>,
 		DealWithEthereumPriorityFees<Runtime>,
 	>;
 	type BlockGasLimit = BlockGasLimit;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -359,7 +359,7 @@ where
 }
 
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-for DealWithSubstrateFeesAndTip<R>
+	for DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config + pallet_author_inherent::Config,
 	pallet_author_inherent::Pallet<R>: Get<R::AccountId>,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -359,7 +359,7 @@ where
 }
 
 impl<R> OnUnbalanced<Credit<R::AccountId, pallet_balances::Pallet<R>>>
-for DealWithSubstrateFeesAndTip<R>
+	for DealWithSubstrateFeesAndTip<R>
 where
 	R: pallet_balances::Config + pallet_treasury::Config,
 {

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -352,6 +352,9 @@ pub fn set_parachain_inherent_data() {
 	use cumulus_primitives_core::PersistedValidationData;
 	use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 
+	let author = AccountId::from(<pallet_evm::Pallet<Runtime>>::find_author());
+	pallet_author_inherent::Author::<Runtime>::put(author);
+
 	let mut relay_sproof = RelayStateSproofBuilder::default();
 	relay_sproof.para_id = 100u32.into();
 	relay_sproof.included_para_head = Some(HeadData(vec![1, 2, 3]));

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -2517,7 +2517,8 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonriver_runtime::{DealWithSubstrateFeesAndTip, Treasury};
+	use moonbeam_runtime_common::deal_with_fees::DealWithSubstrateFeesAndTip;
+	use moonriver_runtime::Treasury;
 
 	ExtBuilder::default().build().execute_with(|| {
 		set_parachain_inherent_data();
@@ -2552,7 +2553,10 @@ fn deal_with_fees_handles_tip() {
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
 		// Step 3: Execute the fees handling logic.
-		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
+		DealWithSubstrateFeesAndTip::<
+			Runtime,
+			dynamic_params::runtime_config::FeesTreasuryProportion,
+		>::on_unbalanceds(vec![fee, tip].into_iter());
 
 		// Step 4: Compute the split between treasury and burned fees based on FeesTreasuryProportion (20%).
 		let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -36,9 +36,10 @@ use moonriver_runtime::currency::{GIGAWEI, WEI};
 use moonriver_runtime::{
 	asset_config::ForeignAssetInstance,
 	xcm_config::{CurrencyId, SelfReserve},
-	AssetId, Balances, CrowdloanRewards, Executive, OpenTechCommitteeCollective, PolkadotXcm,
-	Precompiles, RuntimeBlockWeights, TransactionPayment, TransactionPaymentAsGasPrice,
-	TreasuryCouncilCollective, XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, WEEKS,
+	AssetId, Balances, CrowdloanRewards, DealWithSubstrateFeesAndTip, Executive,
+	OpenTechCommitteeCollective, PolkadotXcm, Precompiles, RuntimeBlockWeights, TransactionPayment,
+	TransactionPaymentAsGasPrice, TreasuryCouncilCollective, XcmTransactor,
+	FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, WEEKS,
 };
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
@@ -2493,10 +2494,10 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonriver_runtime::{DealWithFees, Treasury};
+	use moonriver_runtime::{DealWithSubstrateFeesAndTip, Treasury};
 
 	ExtBuilder::default().build().execute_with(|| {
-		// This test checks the functionality of the `DealWithFees` trait implementation in the runtime.
+		// This test checks the functionality of the `DealWithSubstrateFeesAndTip` trait implementation in the runtime.
 		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
 		// treasury receives the correct amount (20% of the total), and the rest is burned (80%).
 		//
@@ -2504,7 +2505,7 @@ fn deal_with_fees_handles_tip() {
 		// 1. It issues a fee of 100 and a tip of 1000.
 		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
 		// 3. It checks that the treasury's balance is initially 0.
-		// 4. It calls `DealWithFees::on_unbalanceds` with the fee and tip.
+		// 4. It calls `DealWithSubstrateFeesAndTip::on_unbalanceds` with the fee and tip.
 		// 5. It checks that the treasury's balance is now 220 (20% of the fee and tip).
 		// 6. It checks that the total supply has decreased by 880 (80% of the fee and tip), indicating
 		//    that this amount was burned.
@@ -2519,7 +2520,7 @@ fn deal_with_fees_handles_tip() {
 		assert_eq!(total_supply_before, 1_100);
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
-		DealWithFees::on_unbalanceds(vec![fee, tip].into_iter());
+		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
 
 		// treasury should have received 20%
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -36,7 +36,7 @@ use moonriver_runtime::currency::{GIGAWEI, WEI};
 use moonriver_runtime::{
 	asset_config::ForeignAssetInstance,
 	xcm_config::{CurrencyId, SelfReserve},
-	AssetId, Balances, CrowdloanRewards, DealWithSubstrateFeesAndTip, Executive,
+	AssetId, Balances, CrowdloanRewards, Executive,
 	OpenTechCommitteeCollective, PolkadotXcm, Precompiles, RuntimeBlockWeights, TransactionPayment,
 	TransactionPaymentAsGasPrice, TreasuryCouncilCollective, XcmTransactor,
 	FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, WEEKS,
@@ -55,7 +55,7 @@ use precompile_utils::{
 };
 use sha3::{Digest, Keccak256};
 use sp_core::{ByteArray, Pair, H160, U256, Get};
-use sp_runtime::{traits::{Convert, Dispatchable}, BuildStorage, DispatchError, ModuleError, Perbill, Saturating};
+use sp_runtime::{traits::{Convert, Dispatchable}, BuildStorage, DispatchError, ModuleError};
 use std::str::from_utf8;
 use xcm::latest::prelude::*;
 use xcm::{VersionedAssets, VersionedLocation};

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -33,13 +33,13 @@ use frame_support::{
 use moonbeam_xcm_benchmarks::weights::XcmWeight;
 use moonkit_xcm_primitives::AccountIdAssetIdConversion;
 use moonriver_runtime::currency::{GIGAWEI, WEI};
+use moonriver_runtime::runtime_params::dynamic_params;
 use moonriver_runtime::{
 	asset_config::ForeignAssetInstance,
 	xcm_config::{CurrencyId, SelfReserve},
-	AssetId, Balances, CrowdloanRewards, Executive,
-	OpenTechCommitteeCollective, PolkadotXcm, Precompiles, RuntimeBlockWeights, TransactionPayment,
-	TransactionPaymentAsGasPrice, TreasuryCouncilCollective, XcmTransactor,
-	FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, WEEKS,
+	AssetId, Balances, CrowdloanRewards, Executive, OpenTechCommitteeCollective, PolkadotXcm,
+	Precompiles, RuntimeBlockWeights, TransactionPayment, TransactionPaymentAsGasPrice,
+	TreasuryCouncilCollective, XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, WEEKS,
 };
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
@@ -54,14 +54,16 @@ use precompile_utils::{
 	testing::*,
 };
 use sha3::{Digest, Keccak256};
-use sp_core::{ByteArray, Pair, H160, U256, Get};
-use sp_runtime::{traits::{Convert, Dispatchable}, BuildStorage, DispatchError, ModuleError};
+use sp_core::{ByteArray, Get, Pair, H160, U256};
+use sp_runtime::{
+	traits::{Convert, Dispatchable},
+	BuildStorage, DispatchError, ModuleError,
+};
 use std::str::from_utf8;
 use xcm::latest::prelude::*;
 use xcm::{VersionedAssets, VersionedLocation};
 use xcm_builder::{ParentIsPreset, SiblingParachainConvertsVia};
 use xcm_executor::traits::ConvertLocation;
-use moonriver_runtime::runtime_params::dynamic_params;
 use xcm_primitives::split_location_into_chain_part_and_beneficiary;
 
 type BatchPCall = pallet_evm_precompile_batch::BatchPrecompileCall<Runtime>;
@@ -2539,11 +2541,17 @@ fn deal_with_fees_handles_tip() {
 		let burnt_tip_part: Balance = 1000 - treasury_tip_part;
 
 		// treasury should have received 20%
-		assert_eq!(Balances::free_balance(&Treasury::account_id()), treasury_fee_part + treasury_tip_part);
+		assert_eq!(
+			Balances::free_balance(&Treasury::account_id()),
+			treasury_fee_part + treasury_tip_part
+		);
 
 		// verify 80% burned
 		let total_supply_after = Balances::total_issuance();
-		assert_eq!(total_supply_before - total_supply_after, burnt_fee_part + burnt_tip_part);
+		assert_eq!(
+			total_supply_before - total_supply_after,
+			burnt_fee_part + burnt_tip_part
+		);
 	});
 }
 

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -54,16 +54,14 @@ use precompile_utils::{
 	testing::*,
 };
 use sha3::{Digest, Keccak256};
-use sp_core::{ByteArray, Pair, H160, U256};
-use sp_runtime::{
-	traits::{Convert, Dispatchable},
-	BuildStorage, DispatchError, ModuleError,
-};
+use sp_core::{ByteArray, Pair, H160, U256, Get};
+use sp_runtime::{traits::{Convert, Dispatchable}, BuildStorage, DispatchError, ModuleError, Perbill, Saturating};
 use std::str::from_utf8;
 use xcm::latest::prelude::*;
 use xcm::{VersionedAssets, VersionedLocation};
 use xcm_builder::{ParentIsPreset, SiblingParachainConvertsVia};
 use xcm_executor::traits::ConvertLocation;
+use moonriver_runtime::runtime_params::dynamic_params;
 use xcm_primitives::split_location_into_chain_part_and_beneficiary;
 
 type BatchPCall = pallet_evm_precompile_batch::BatchPrecompileCall<Runtime>;
@@ -1429,6 +1427,7 @@ fn transfer_ed_0_evm() {
 		])
 		.build()
 		.execute_with(|| {
+			set_parachain_inherent_data();
 			// EVM transfer
 			assert_ok!(RuntimeCall::EVM(pallet_evm::Call::<Runtime>::call {
 				source: H160::from(ALICE),
@@ -1481,7 +1480,7 @@ fn refund_ed_0_evm() {
 }
 
 #[test]
-fn author_does_not_receive_priority_fee() {
+fn author_does_receive_priority_fee() {
 	ExtBuilder::default()
 		.with_balances(vec![(
 			AccountId::from(BOB),
@@ -1491,6 +1490,7 @@ fn author_does_not_receive_priority_fee() {
 		.execute_with(|| {
 			// Some block author as seen by pallet-evm.
 			let author = AccountId::from(<pallet_evm::Pallet<Runtime>>::find_author());
+			pallet_author_inherent::Author::<Runtime>::put(author);
 			// Currently the default impl of the evm uses `deposit_into_existing`.
 			// If we were to use this implementation, and for an author to receive eventual tips,
 			// the account needs to be somehow initialized, otherwise the deposit would fail.
@@ -1509,8 +1509,10 @@ fn author_does_not_receive_priority_fee() {
 				access_list: Vec::new(),
 			})
 			.dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::root()));
-			// Author free balance didn't change.
-			assert_eq!(Balances::free_balance(author), 100 * MOVR,);
+
+			let priority_fee = 200 * GIGAWEI * 21_000;
+			// Author free balance increased by priority fee.
+			assert_eq!(Balances::free_balance(author), 100 * MOVR + priority_fee,);
 		});
 }
 
@@ -1530,6 +1532,8 @@ fn total_issuance_after_evm_transaction_with_priority_fee() {
 		.build()
 		.execute_with(|| {
 			let issuance_before = <Runtime as pallet_evm::Config>::Currency::total_issuance();
+			let author = AccountId::from(<pallet_evm::Pallet<Runtime>>::find_author());
+			pallet_author_inherent::Author::<Runtime>::put(author);
 			// EVM transfer.
 			assert_ok!(RuntimeCall::EVM(pallet_evm::Call::<Runtime>::call {
 				source: H160::from(BOB),
@@ -2499,9 +2503,9 @@ fn deal_with_fees_handles_tip() {
 	ExtBuilder::default().build().execute_with(|| {
 		// This test checks the functionality of the `DealWithSubstrateFeesAndTip` trait implementation in the runtime.
 		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
-		// treasury receives the correct amount (20% of the total), and the rest is burned (80%).
+		// treasury receives the correct amount (set by FeesTreasuryProportion), and the rest is burned.
 		//
-		// The test follows these steps:
+		// The test follows these steps: (Assuming FeesTreasuryProportion is set to 20%)
 		// 1. It issues a fee of 100 and a tip of 1000.
 		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
 		// 3. It checks that the treasury's balance is initially 0.
@@ -2522,12 +2526,19 @@ fn deal_with_fees_handles_tip() {
 
 		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
 
+		let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();
+
+		let treasury_fee_part: Balance = treasury_proportion.mul_floor(100);
+		let burnt_fee_part: Balance = 100 - treasury_fee_part;
+		let treasury_tip_part: Balance = treasury_proportion.mul_floor(1000);
+		let burnt_tip_part: Balance = 1000 - treasury_tip_part;
+
 		// treasury should have received 20%
-		assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+		assert_eq!(Balances::free_balance(&Treasury::account_id()), treasury_fee_part + treasury_tip_part);
 
 		// verify 80% burned
 		let total_supply_after = Balances::total_issuance();
-		assert_eq!(total_supply_before - total_supply_after, 880);
+		assert_eq!(total_supply_before - total_supply_after, burnt_fee_part + burnt_tip_part);
 	});
 }
 

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -2520,18 +2520,23 @@ fn deal_with_fees_handles_tip() {
 	use moonriver_runtime::{DealWithSubstrateFeesAndTip, Treasury};
 
 	ExtBuilder::default().build().execute_with(|| {
-		// This test checks the functionality of the `DealWithSubstrateFeesAndTip` trait implementation in the runtime.
-		// It simulates a scenario where a fee and a tip are issued to an account and ensures that the
-		// treasury receives the correct amount (set by FeesTreasuryProportion), and the rest is burned.
-		//
-		// The test follows these steps: (Assuming FeesTreasuryProportion is set to 20%)
-		// 1. It issues a fee of 100 and a tip of 1000.
-		// 2. It checks the total supply before the fee and tip are dealt with, which should be 1_100.
-		// 3. It checks that the treasury's balance is initially 0.
-		// 4. It calls `DealWithSubstrateFeesAndTip::on_unbalanceds` with the fee and tip.
-		// 5. It checks that the treasury's balance is now 220 (20% of the fee and tip).
-		// 6. It checks that the total supply has decreased by 880 (80% of the fee and tip), indicating
-		//    that this amount was burned.
+		set_parachain_inherent_data();
+		// This test validates the functionality of the `DealWithSubstrateFeesAndTip` trait implementation
+		// in the Moonriver runtime. It verifies that:
+		// - The correct proportion of the fee is sent to the treasury.
+		// - The remaining fee is burned (removed from the total supply).
+		// - The entire tip is sent to the block author.
+
+		// The test details:
+		// 1. Simulate issuing a `fee` of 100 and a `tip` of 1000.
+		// 2. Confirm the initial total supply is 1,100 (equal to the sum of the issued fee and tip).
+		// 3. Confirm the treasury's balance is initially 0.
+		// 4. Execute the `DealWithSubstrateFeesAndTip::on_unbalanceds` function with the `fee` and `tip`.
+		// 5. Validate that the treasury's balance has increased by 20% of the fee (based on FeesTreasuryProportion).
+		// 6. Validate that 80% of the fee is burned, and the total supply decreases accordingly.
+		// 7. Validate that the entire tip (100%) is sent to the block author (collator).
+
+		// Step 1: Issue the fee and tip amounts.
 		let fee = <pallet_balances::Pallet<Runtime> as frame_support::traits::fungible::Balanced<
 			AccountId,
 		>>::issue(100);
@@ -2539,30 +2544,37 @@ fn deal_with_fees_handles_tip() {
 			AccountId,
 		>>::issue(1000);
 
+		// Step 2: Validate the initial supply and balances.
 		let total_supply_before = Balances::total_issuance();
+		let block_author = pallet_author_inherent::Pallet::<Runtime>::get();
+		let block_author_balance_before = Balances::free_balance(&block_author);
 		assert_eq!(total_supply_before, 1_100);
 		assert_eq!(Balances::free_balance(&Treasury::account_id()), 0);
 
+		// Step 3: Execute the fees handling logic.
 		DealWithSubstrateFeesAndTip::on_unbalanceds(vec![fee, tip].into_iter());
 
+		// Step 4: Compute the split between treasury and burned fees based on FeesTreasuryProportion (20%).
 		let treasury_proportion = dynamic_params::runtime_config::FeesTreasuryProportion::get();
 
 		let treasury_fee_part: Balance = treasury_proportion.mul_floor(100);
 		let burnt_fee_part: Balance = 100 - treasury_fee_part;
-		let treasury_tip_part: Balance = treasury_proportion.mul_floor(1000);
-		let burnt_tip_part: Balance = 1000 - treasury_tip_part;
 
-		// treasury should have received 20%
+		// Step 5: Validate the treasury received 20% of the fee.
 		assert_eq!(
 			Balances::free_balance(&Treasury::account_id()),
-			treasury_fee_part + treasury_tip_part
+			treasury_fee_part,
 		);
 
-		// verify 80% burned
+		// Step 6: Verify that 80% of the fee was burned (removed from the total supply).
 		let total_supply_after = Balances::total_issuance();
+		assert_eq!(total_supply_before - total_supply_after, burnt_fee_part,);
+
+		// Step 7: Validate that the block author (collator) received 100% of the tip.
+		let block_author_balance_after = Balances::free_balance(&block_author);
 		assert_eq!(
-			total_supply_before - total_supply_after,
-			burnt_fee_part + burnt_tip_part
+			block_author_balance_after - block_author_balance_before,
+			1000,
 		);
 	});
 }

--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -215,7 +215,7 @@ export const verifyBlockFees = async (
                 );
                 const tipPortions = calculateFeePortions(
                   feesTreasuryProportion,
-                extrinsic.tip.toBigInt(),
+                  extrinsic.tip.toBigInt()
                 );
                 txFees += fee.partialFee.toBigInt() + extrinsic.tip.toBigInt();
                 txBurnt += feePortions.burnt + tipPortions.burnt;
@@ -249,11 +249,12 @@ export const verifyBlockFees = async (
                   })) as any
                 ).toBigInt();
 
-                // const tip = extrinsic.tip.toBigInt();
+                const tip = extrinsic.tip.toBigInt();
                 const expectedPartialFee = lengthFee + weightFee + baseFee;
 
-                // Verify the computed fees are equal to the actual fees
-                expect(expectedPartialFee).to.eq((paymentEvent!.data[1] as u128).toBigInt());
+                // Verify the computed fees are equal to the actual fees + tip
+                expect(expectedPartialFee + tip).to.eq((paymentEvent!.data[1] as u128).toBigInt());
+                expect(tip).to.eq((paymentEvent!.data[2] as u128).toBigInt());
 
                 // Verify the computed fees are equal to the rpc computed fees
                 expect(expectedPartialFee).to.eq(fee.partialFee.toBigInt());

--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -197,12 +197,14 @@ export const verifyBlockFees = async (
                 const baseFeesPaid = gasUsed * baseFeePerGas;
                 const tipAsFeesPaid = gasUsed * effectiveTipPerGas;
 
+                // TODO: [calculateFeePortions] needs to be updated.
                 const baseFeePortions = calculateFeePortions(baseFeesPaid);
-                const tipFeePortions = calculateFeePortions(tipAsFeesPaid);
+                // we send tips to collator
+                // const tipFeePortions = calculateFeePortions(tipAsFeesPaid);
 
                 txFees += baseFeesPaid + tipAsFeesPaid;
                 txBurnt += baseFeePortions.burnt;
-                txBurnt += tipFeePortions.burnt;
+                // txBurnt += tipFeePortions.burnt;
               } else {
                 // For a regular substrate tx, we use the partialFee
                 const feePortions = calculateFeePortions(fee.partialFee.toBigInt());

--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -214,8 +214,8 @@ export const verifyBlockFees = async (
                   fee.partialFee.toBigInt()
                 );
                 const tipPortions = calculateFeePortions(
-                  extrinsic.tip.toBigInt(),
-                  feesTreasuryProportion
+                  feesTreasuryProportion,
+                extrinsic.tip.toBigInt(),
                 );
                 txFees += fee.partialFee.toBigInt() + extrinsic.tip.toBigInt();
                 txBurnt += feePortions.burnt + tipPortions.burnt;

--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -216,12 +216,9 @@ export const verifyBlockFees = async (
                   feesTreasuryProportion,
                   fee.partialFee.toBigInt()
                 );
-                const tipPortions = calculateFeePortions(
-                  feesTreasuryProportion,
-                  extrinsic.tip.toBigInt()
-                );
+
                 txFees += fee.partialFee.toBigInt() + extrinsic.tip.toBigInt();
-                txBurnt += feePortions.burnt + tipPortions.burnt;
+                txBurnt += feePortions.burnt;
 
                 // verify entire substrate txn fee
                 const apiAt = await context.polkadotJs().at(previousBlockHash);

--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -179,8 +179,6 @@ export const verifyBlockFees = async (
                   await context.viem().getBlock({ blockNumber: BigInt(number - 1) })
                 ).baseFeePerGas!;
 
-                console.log("baseFeePerGas", baseFeePerGas);
-
                 let priorityFee;
                 let gasFee;
                 // Transaction is an enum now with as many variants as supported transaction types.
@@ -195,31 +193,21 @@ export const verifyBlockFees = async (
                   gasFee = ethTxWrapper.asEip1559.maxFeePerGas.toBigInt();
                 }
 
-                console.log("priorityFee", priorityFee);
-                console.log("gasFee", gasFee);
-
                 let effectiveTipPerGas = gasFee - baseFeePerGas;
                 if (effectiveTipPerGas > priorityFee) {
                   effectiveTipPerGas = priorityFee;
                 }
-
-                console.log("effectiveTipPerGas", effectiveTipPerGas);
 
                 // Calculate the fees paid for the base fee and tip fee independently.
                 // Only the base fee is subject to the split between burn and treasury.
                 const baseFeesPaid = gasUsed * baseFeePerGas;
                 const tipAsFeesPaid = gasUsed * effectiveTipPerGas;
 
-                console.log("baseFeesPaid", baseFeesPaid);
-                console.log("tipAsFeesPaid", tipAsFeesPaid);
-
                 const { burnt: baseFeePortionsBurnt } = calculateFeePortions(
                   feesTreasuryProportion,
                   baseFeesPaid
                 );
 
-                console.log("baseFeesPaid", baseFeesPaid);
-                console.log("tipAsFeesPaid", tipAsFeesPaid);
                 txFees += baseFeesPaid + tipAsFeesPaid;
                 txBurnt += baseFeePortionsBurnt;
               } else {
@@ -289,11 +277,6 @@ export const verifyBlockFees = async (
               const toBalance = (await (
                 await api.at(blockDetails.block.hash)
               ).query.system.account(origin)) as any;
-
-              console.log("origin", origin);
-              console.log("txFees", txFees);
-              console.log("diff", (((fromBalance.data.free.toBigInt() as any) -
-                toBalance.data.free.toBigInt()) as any) - expectedBalanceDiff);
 
               expect(txFees.toString()).to.eq(
                 (

--- a/test/helpers/fees.ts
+++ b/test/helpers/fees.ts
@@ -1,0 +1,31 @@
+import { BN } from "@polkadot/util";
+
+/// Recreation of fees.ration(burn_part, treasury_part)
+export const split = (value: BN, part1: BN, part2: BN): [BN, BN] => {
+  const total = part1.add(part2);
+  if (total.eq(new BN(0)) || value.eq(new BN(0))) {
+    return [new BN(0), new BN(0)];
+  }
+  const part1BN = value.mul(part1).div(total);
+  const part2BN = value.sub(part1BN);
+  return [part1BN, part2BN];
+};
+
+export const calculateFeePortions = (
+  feesTreasuryProportion: bigint,
+  fees: bigint
+): {
+  burnt: bigint;
+  treasury: bigint;
+} => {
+  const feesBN = new BN(fees.toString());
+  const treasuryPartBN = new BN(feesTreasuryProportion.toString());
+  const burntPartBN = new BN(1e9).sub(treasuryPartBN);
+
+  const [burntBN, treasuryBN] = split(feesBN, burntPartBN, treasuryPartBN);
+
+  return {
+    burnt: BigInt(burntBN.toString()),
+    treasury: BigInt(treasuryBN.toString()),
+  };
+};

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -24,3 +24,5 @@ export * from "./voting";
 export * from "./wormhole";
 export * from "./xcm";
 export * from "./tracingFns";
+export * from "./fees.ts";
+export * from "./parameters.ts";

--- a/test/helpers/parameters.ts
+++ b/test/helpers/parameters.ts
@@ -6,7 +6,7 @@ export const getFeesTreasuryProportion = async (context: DevModeContext): Promis
   });
 
   // 20% default value
-  let feesTreasuryProportion = 50_000_000n;
+  let feesTreasuryProportion = 200_000_000n;
   if (parameter.isSome) {
     feesTreasuryProportion = parameter.value.asRuntimeConfig.asFeesTreasuryProportion.toBigInt();
   }

--- a/test/helpers/parameters.ts
+++ b/test/helpers/parameters.ts
@@ -1,0 +1,14 @@
+import type { DevModeContext } from "@moonwall/cli";
+
+export const getFeesTreasuryProportion = async (context: DevModeContext): Promise<bigint> => {
+  const parameter = await context.polkadotJs().query.parameters.parameters({
+    RuntimeConfig: "FeesTreasuryProportion",
+  });
+
+  // 20% default value
+  let feesTreasuryProportion = 200_000_000n;
+  if (parameter.isSome) {
+    feesTreasuryProportion = parameter.value.asRuntimeConfig.asFeesTreasuryProportion.toBigInt();
+  }
+  return feesTreasuryProportion;
+};

--- a/test/helpers/parameters.ts
+++ b/test/helpers/parameters.ts
@@ -6,7 +6,7 @@ export const getFeesTreasuryProportion = async (context: DevModeContext): Promis
   });
 
   // 20% default value
-  let feesTreasuryProportion = 200_000_000n;
+  let feesTreasuryProportion = 50_000_000n;
   if (parameter.isSome) {
     feesTreasuryProportion = parameter.value.asRuntimeConfig.asFeesTreasuryProportion.toBigInt();
   }

--- a/test/scripts/update-local-types.ts
+++ b/test/scripts/update-local-types.ts
@@ -60,6 +60,7 @@ const startNode = (network: string, rpcPort: string, port: string) => {
       "--wasm-execution=interpreted-i-know-what-i-do",
       "--no-telemetry",
       "--no-prometheus",
+      "--rpc-cors=all",
       "--tmp",
     ],
     {
@@ -107,7 +108,7 @@ const executeUpdateAPIScript = async () => {
   // Bundle types
   await executeScript("../../moonbeam-types-bundle", "pnpm i");
   await executeScript("../../moonbeam-types-bundle", "pnpm build");
-  await executeScript("../../moonbeam-types-bundle", "pnpm fmt:fix");
+  await executeScript("../../moonbeam-types-bundle", "pnpm check:fix");
 
   // Generate types
   console.log("Extracting metadata for all runtimes...");

--- a/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
+++ b/test/suites/dev/moonbase/test-balance/test-balance-transfer.ts
@@ -2,6 +2,7 @@ import "@moonbeam-network/api-augment";
 import { beforeEach, describeSuite, expect } from "@moonwall/cli";
 import {
   ALITH_ADDRESS,
+  CHARLETH_ADDRESS,
   BALTATHAR_ADDRESS,
   BALTATHAR_PRIVATE_KEY,
   CHARLETH_PRIVATE_KEY,
@@ -77,16 +78,17 @@ describeSuite({
       id: "T03",
       title: "should decrease from account",
       test: async function () {
-        const balanceBefore = await context.viem().getBalance({ address: ALITH_ADDRESS });
+        const balanceBefore = await context.viem().getBalance({ address: CHARLETH_ADDRESS });
         const fees = 21000n * GENESIS_BASE_FEE;
         await context.createBlock(
           await createRawTransfer(context, randomAddress, 512n, {
             gas: 21000n,
             gasPrice: GENESIS_BASE_FEE,
             txnType: "legacy",
+            privateKey: CHARLETH_PRIVATE_KEY,
           })
         );
-        const balanceAfter = await context.viem().getBalance({ address: ALITH_ADDRESS });
+        const balanceAfter = await context.viem().getBalance({ address: CHARLETH_ADDRESS });
         expect(balanceBefore - balanceAfter - fees).toBe(512n);
       },
     });
@@ -190,7 +192,7 @@ describeSuite({
       id: "T08",
       title: "should handle max_fee_per_gas",
       test: async function () {
-        const balanceBefore = await checkBalance(context);
+        const balanceBefore = await checkBalance(context, CHARLETH_ADDRESS);
         await context.createBlock(
           await createRawTransfer(context, randomAddress, 1n * GLMR, {
             gas: 21000n,
@@ -198,9 +200,10 @@ describeSuite({
             maxPriorityFeePerGas: parseGwei("0.2"),
             gasPrice: GENESIS_BASE_FEE,
             type: "eip1559",
+            privateKey: CHARLETH_PRIVATE_KEY,
           })
         );
-        const balanceAfter = await checkBalance(context);
+        const balanceAfter = await checkBalance(context, CHARLETH_ADDRESS);
         const fee = 21000n * GENESIS_BASE_FEE;
 
         expect(balanceAfter + fee + 1n * GLMR).toBe(balanceBefore);

--- a/test/suites/dev/moonbase/test-contract/test-contract-error.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-error.ts
@@ -6,7 +6,12 @@ import {
   describeSuite,
   expect,
 } from "@moonwall/cli";
-import { CHARLETH_PRIVATE_KEY, CHARLETH_ADDRESS, createEthersTransaction } from "@moonwall/util";
+import {
+  CHARLETH_PRIVATE_KEY,
+  CHARLETH_ADDRESS,
+  createEthersTransaction,
+  ALITH_ADDRESS,
+} from "@moonwall/util";
 import { encodeFunctionData, type Abi } from "viem";
 import { verifyLatestBlockFees } from "../../../../helpers";
 
@@ -20,9 +25,7 @@ describeSuite({
     let looperAbi: Abi;
 
     beforeAll(async () => {
-      const { contractAddress, abi } = await deployCreateCompiledContract(context, "Looper", {
-        privateKey: CHARLETH_PRIVATE_KEY,
-      });
+      const { contractAddress, abi } = await deployCreateCompiledContract(context, "Looper");
 
       looperAddress = contractAddress;
       looperAbi = abi;
@@ -33,7 +36,7 @@ describeSuite({
         id: `T0${TransactionTypes.indexOf(txnType) + 1}`,
         title: `"should return OutOfGas on inifinite loop ${txnType} call`,
         test: async function () {
-          expect(
+          await expect(
             async () =>
               await context.viem().call({
                 account: CHARLETH_ADDRESS,
@@ -47,17 +50,25 @@ describeSuite({
       });
 
       it({
-        id: `T0${TransactionTypes.indexOf(txnType) * 2 + 1}`,
+        id: `T0${TransactionTypes.indexOf(txnType) + 1 + TransactionTypes.length}`,
         title: `should fail with OutOfGas on infinite loop ${txnType} transaction`,
         test: async function () {
+          const nonce = await context.viem().getTransactionCount({ address: CHARLETH_ADDRESS });
+
           const rawSigned = await createEthersTransaction(context, {
-            privateKey: CHARLETH_PRIVATE_KEY,
             to: looperAddress,
             data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
             txnType,
+            nonce,
+            privateKey: CHARLETH_PRIVATE_KEY,
           });
 
-          const { result } = await context.createBlock(rawSigned);
+          const { result } = await context.createBlock(rawSigned, {
+            signer: { type: "ethereum", privateKey: CHARLETH_PRIVATE_KEY },
+          });
+
+          expect(result.successful).to.be.true;
+
           const receipt = await context
             .viem("public")
             .getTransactionReceipt({ hash: result!.hash as `0x${string}` });
@@ -66,17 +77,24 @@ describeSuite({
       });
 
       it({
-        id: `T0${TransactionTypes.indexOf(txnType) * 3 + 1}`,
+        id: `T0${TransactionTypes.indexOf(txnType) + 1 + TransactionTypes.length * 2}`,
         title: `should fail with OutOfGas on infinite loop ${txnType} transaction - check fees`,
         test: async function () {
+          const nonce = await context.viem().getTransactionCount({ address: CHARLETH_ADDRESS });
+
           const rawSigned = await createEthersTransaction(context, {
-            privateKey: CHARLETH_PRIVATE_KEY,
             to: looperAddress,
             data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
             txnType,
+            nonce,
+            privateKey: CHARLETH_PRIVATE_KEY,
           });
 
-          await context.createBlock(rawSigned);
+          const { result } = await context.createBlock(rawSigned, {
+            signer: { type: "ethereum", privateKey: CHARLETH_PRIVATE_KEY },
+          });
+
+          expect(result.successful).to.be.true;
           await verifyLatestBlockFees(context);
         },
       });

--- a/test/suites/dev/moonbase/test-contract/test-contract-error.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-error.ts
@@ -6,24 +6,23 @@ import {
   describeSuite,
   expect,
 } from "@moonwall/cli";
-import {CHARLETH_PRIVATE_KEY, CHARLETH_ADDRESS, createEthersTransaction} from "@moonwall/util";
-import {encodeFunctionData, type Abi} from "viem";
-import {verifyLatestBlockFees} from "../../../../helpers";
+import { CHARLETH_PRIVATE_KEY, CHARLETH_ADDRESS, createEthersTransaction } from "@moonwall/util";
+import { encodeFunctionData, type Abi } from "viem";
+import { verifyLatestBlockFees } from "../../../../helpers";
 
 // TODO: expand these tests to do multiple txn types when added to viem
 describeSuite({
   id: "D010603",
   title: "Contract loop error",
   foundationMethods: "dev",
-  testCases: ({context, it, log}) => {
+  testCases: ({ context, it, log }) => {
     let looperAddress: `0x${string}`;
     let looperAbi: Abi;
 
     beforeAll(async () => {
-      const {
-        contractAddress,
-        abi
-      } = await deployCreateCompiledContract(context, "Looper", {privateKey: CHARLETH_PRIVATE_KEY});
+      const { contractAddress, abi } = await deployCreateCompiledContract(context, "Looper", {
+        privateKey: CHARLETH_PRIVATE_KEY,
+      });
 
       looperAddress = contractAddress;
       looperAbi = abi;
@@ -39,7 +38,7 @@ describeSuite({
               await context.viem().call({
                 account: CHARLETH_ADDRESS,
                 to: looperAddress,
-                data: encodeFunctionData({abi: looperAbi, functionName: "infinite", args: []}),
+                data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
                 gas: 12_000_000n,
               }),
             "Execution succeeded but should have failed"
@@ -54,14 +53,14 @@ describeSuite({
           const rawSigned = await createEthersTransaction(context, {
             privateKey: CHARLETH_PRIVATE_KEY,
             to: looperAddress,
-            data: encodeFunctionData({abi: looperAbi, functionName: "infinite", args: []}),
+            data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
             txnType,
           });
 
-          const {result} = await context.createBlock(rawSigned);
+          const { result } = await context.createBlock(rawSigned);
           const receipt = await context
             .viem("public")
-            .getTransactionReceipt({hash: result!.hash as `0x${string}`});
+            .getTransactionReceipt({ hash: result!.hash as `0x${string}` });
           expect(receipt.status).toBe("reverted");
         },
       });
@@ -73,7 +72,7 @@ describeSuite({
           const rawSigned = await createEthersTransaction(context, {
             privateKey: CHARLETH_PRIVATE_KEY,
             to: looperAddress,
-            data: encodeFunctionData({abi: looperAbi, functionName: "infinite", args: []}),
+            data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
             txnType,
           });
 

--- a/test/suites/dev/moonbase/test-contract/test-contract-error.ts
+++ b/test/suites/dev/moonbase/test-contract/test-contract-error.ts
@@ -6,21 +6,24 @@ import {
   describeSuite,
   expect,
 } from "@moonwall/cli";
-import { ALITH_ADDRESS, createEthersTransaction } from "@moonwall/util";
-import { encodeFunctionData, type Abi } from "viem";
-import { verifyLatestBlockFees } from "../../../../helpers";
+import {CHARLETH_PRIVATE_KEY, CHARLETH_ADDRESS, createEthersTransaction} from "@moonwall/util";
+import {encodeFunctionData, type Abi} from "viem";
+import {verifyLatestBlockFees} from "../../../../helpers";
 
 // TODO: expand these tests to do multiple txn types when added to viem
 describeSuite({
   id: "D010603",
   title: "Contract loop error",
   foundationMethods: "dev",
-  testCases: ({ context, it, log }) => {
+  testCases: ({context, it, log}) => {
     let looperAddress: `0x${string}`;
     let looperAbi: Abi;
 
     beforeAll(async () => {
-      const { contractAddress, abi } = await deployCreateCompiledContract(context, "Looper");
+      const {
+        contractAddress,
+        abi
+      } = await deployCreateCompiledContract(context, "Looper", {privateKey: CHARLETH_PRIVATE_KEY});
 
       looperAddress = contractAddress;
       looperAbi = abi;
@@ -34,9 +37,9 @@ describeSuite({
           expect(
             async () =>
               await context.viem().call({
-                account: ALITH_ADDRESS,
+                account: CHARLETH_ADDRESS,
                 to: looperAddress,
-                data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
+                data: encodeFunctionData({abi: looperAbi, functionName: "infinite", args: []}),
                 gas: 12_000_000n,
               }),
             "Execution succeeded but should have failed"
@@ -49,15 +52,16 @@ describeSuite({
         title: `should fail with OutOfGas on infinite loop ${txnType} transaction`,
         test: async function () {
           const rawSigned = await createEthersTransaction(context, {
+            privateKey: CHARLETH_PRIVATE_KEY,
             to: looperAddress,
-            data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
+            data: encodeFunctionData({abi: looperAbi, functionName: "infinite", args: []}),
             txnType,
           });
 
-          const { result } = await context.createBlock(rawSigned);
+          const {result} = await context.createBlock(rawSigned);
           const receipt = await context
             .viem("public")
-            .getTransactionReceipt({ hash: result!.hash as `0x${string}` });
+            .getTransactionReceipt({hash: result!.hash as `0x${string}`});
           expect(receipt.status).toBe("reverted");
         },
       });
@@ -67,8 +71,9 @@ describeSuite({
         title: `should fail with OutOfGas on infinite loop ${txnType} transaction - check fees`,
         test: async function () {
           const rawSigned = await createEthersTransaction(context, {
+            privateKey: CHARLETH_PRIVATE_KEY,
             to: looperAddress,
-            data: encodeFunctionData({ abi: looperAbi, functionName: "infinite", args: [] }),
+            data: encodeFunctionData({abi: looperAbi, functionName: "infinite", args: []}),
             txnType,
           });
 

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeAll, customDevRpcRequest, describeSuite, expect} from "@moonwall/cli";
+import { afterEach, beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
 import {
   ALITH_ADDRESS,
   BALTATHAR_ADDRESS,
@@ -11,15 +11,15 @@ import {
   createRawTransfer,
   sendRawTransaction,
 } from "@moonwall/util";
-import {parseGwei} from "viem";
-import {ALITH_GENESIS_TRANSFERABLE_BALANCE, ConstantStore} from "../../../../helpers";
-import {UNIT} from "../test-parameters/test-parameters";
+import { parseGwei } from "viem";
+import { ALITH_GENESIS_TRANSFERABLE_BALANCE, ConstantStore } from "../../../../helpers";
+import { UNIT } from "../test-parameters/test-parameters";
 
 describeSuite({
   id: "D011102",
   title: "Ethereum Rpc pool errors",
   foundationMethods: "dev",
-  testCases: ({context, it, log}) => {
+  testCases: ({ context, it, log }) => {
     beforeAll(async () => {
       await context.createBlock(await createRawTransfer(context, BALTATHAR_ADDRESS, 3n));
     });
@@ -45,7 +45,7 @@ describeSuite({
       id: "T02",
       title: "replacement transaction underpriced",
       test: async function () {
-        const nonce = await context.viem().getTransactionCount({address: ALITH_ADDRESS});
+        const nonce = await context.viem().getTransactionCount({ address: ALITH_ADDRESS });
 
         const tx1 = await createEthersTransaction(context, {
           to: CHARLETH_ADDRESS,
@@ -75,7 +75,7 @@ describeSuite({
       id: "T03",
       title: "nonce too low",
       test: async function () {
-        const nonce = await context.viem().getTransactionCount({address: CHARLETH_ADDRESS});
+        const nonce = await context.viem().getTransactionCount({ address: CHARLETH_ADDRESS });
         const tx1 = await context.createTxn!({
           to: BALTATHAR_ADDRESS,
           value: 1n,
@@ -101,14 +101,14 @@ describeSuite({
       id: "T04",
       title: "already known #2",
       test: async function () {
-        const {specVersion} = await context.polkadotJs().consts.system.version;
+        const { specVersion } = await context.polkadotJs().consts.system.version;
         const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(
           specVersion.toNumber()
         );
 
         const nonce = await context
           .viem("public")
-          .getTransactionCount({address: GOLIATH_ADDRESS});
+          .getTransactionCount({ address: GOLIATH_ADDRESS });
 
         const tx1 = await createRawTransfer(context, BALTATHAR_ADDRESS, 1, {
           nonce: nonce + 1,
@@ -156,7 +156,8 @@ describeSuite({
       id: "T07",
       title: "insufficient funds for gas * price + value",
       test: async function () {
-        const CHARLETH_GENESIS_TRANSFERABLE_BALANCE = ALITH_GENESIS_TRANSFERABLE_BALANCE + 1000n * UNIT + 10n * 100_000_000_000_000n;
+        const CHARLETH_GENESIS_TRANSFERABLE_BALANCE =
+          ALITH_GENESIS_TRANSFERABLE_BALANCE + 1000n * UNIT + 10n * 100_000_000_000_000n;
         const amount = CHARLETH_GENESIS_TRANSFERABLE_BALANCE - 21000n * 10_000_000_000n + 1n;
         const tx = await createRawTransfer(context, BALTATHAR_ADDRESS, amount, {
           privateKey: CHARLETH_PRIVATE_KEY,

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-error.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
+import {afterEach, beforeAll, customDevRpcRequest, describeSuite, expect} from "@moonwall/cli";
 import {
   ALITH_ADDRESS,
   BALTATHAR_ADDRESS,
@@ -11,14 +11,15 @@ import {
   createRawTransfer,
   sendRawTransaction,
 } from "@moonwall/util";
-import { parseGwei } from "viem";
-import { ALITH_GENESIS_TRANSFERABLE_BALANCE, ConstantStore } from "../../../../helpers";
+import {parseGwei} from "viem";
+import {ALITH_GENESIS_TRANSFERABLE_BALANCE, ConstantStore} from "../../../../helpers";
+import {UNIT} from "../test-parameters/test-parameters";
 
 describeSuite({
   id: "D011102",
   title: "Ethereum Rpc pool errors",
   foundationMethods: "dev",
-  testCases: ({ context, it, log }) => {
+  testCases: ({context, it, log}) => {
     beforeAll(async () => {
       await context.createBlock(await createRawTransfer(context, BALTATHAR_ADDRESS, 3n));
     });
@@ -44,7 +45,7 @@ describeSuite({
       id: "T02",
       title: "replacement transaction underpriced",
       test: async function () {
-        const nonce = await context.viem().getTransactionCount({ address: ALITH_ADDRESS });
+        const nonce = await context.viem().getTransactionCount({address: ALITH_ADDRESS});
 
         const tx1 = await createEthersTransaction(context, {
           to: CHARLETH_ADDRESS,
@@ -74,7 +75,7 @@ describeSuite({
       id: "T03",
       title: "nonce too low",
       test: async function () {
-        const nonce = await context.viem().getTransactionCount({ address: CHARLETH_ADDRESS });
+        const nonce = await context.viem().getTransactionCount({address: CHARLETH_ADDRESS});
         const tx1 = await context.createTxn!({
           to: BALTATHAR_ADDRESS,
           value: 1n,
@@ -100,14 +101,14 @@ describeSuite({
       id: "T04",
       title: "already known #2",
       test: async function () {
-        const { specVersion } = await context.polkadotJs().consts.system.version;
+        const {specVersion} = await context.polkadotJs().consts.system.version;
         const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(
           specVersion.toNumber()
         );
 
         const nonce = await context
           .viem("public")
-          .getTransactionCount({ address: GOLIATH_ADDRESS });
+          .getTransactionCount({address: GOLIATH_ADDRESS});
 
         const tx1 = await createRawTransfer(context, BALTATHAR_ADDRESS, 1, {
           nonce: nonce + 1,
@@ -155,8 +156,11 @@ describeSuite({
       id: "T07",
       title: "insufficient funds for gas * price + value",
       test: async function () {
-        const amount = ALITH_GENESIS_TRANSFERABLE_BALANCE - 21000n * 10_000_000_000n + 1n;
-        const tx = await createRawTransfer(context, BALTATHAR_ADDRESS, amount);
+        const CHARLETH_GENESIS_TRANSFERABLE_BALANCE = ALITH_GENESIS_TRANSFERABLE_BALANCE + 1000n * UNIT + 10n * 100_000_000_000_000n;
+        const amount = CHARLETH_GENESIS_TRANSFERABLE_BALANCE - 21000n * 10_000_000_000n + 1n;
+        const tx = await createRawTransfer(context, BALTATHAR_ADDRESS, amount, {
+          privateKey: CHARLETH_PRIVATE_KEY,
+        });
 
         expect(
           async () => await customDevRpcRequest("eth_sendRawTransaction", [tx])

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, createRawTransfer, GLMR, sendRawTransaction } from "@moonwall/util";
+import {
+  CHARLETH_ADDRESS,
+  CHARLETH_PRIVATE_KEY,
+  createRawTransfer,
+  GLMR,
+  sendRawTransaction
+} from "@moonwall/util";
 import { parseGwei } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
@@ -10,10 +16,14 @@ describeSuite({
   testCases: ({ context, it, log }) => {
     let randomAddress: `0x${string}`;
     let currentNonce: number;
+    let actorPrivateKey: `0x${string}`;
+    let actorAddress: `0x${string}`;
 
     beforeEach(async function () {
+      actorPrivateKey = CHARLETH_PRIVATE_KEY;
+      actorAddress = CHARLETH_ADDRESS;
       randomAddress = privateKeyToAccount(generatePrivateKey()).address;
-      currentNonce = await context.viem().getTransactionCount({ address: ALITH_ADDRESS });
+      currentNonce = await context.viem().getTransactionCount({ address: actorAddress });
     });
 
     it({
@@ -25,11 +35,13 @@ describeSuite({
             nonce: currentNonce,
             maxFeePerGas: parseGwei("300"),
             maxPriorityFeePerGas: parseGwei("300"),
+            privateKey: actorPrivateKey,
           }),
           await createRawTransfer(context, randomAddress, 2, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("400"),
             maxPriorityFeePerGas: parseGwei("300"),
+            privateKey: actorPrivateKey,
             // same priority fee but higher max fee so higher tip
           }),
         ]);
@@ -45,10 +57,12 @@ describeSuite({
           await createRawTransfer(context, randomAddress, 1, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("20"),
+            privateKey: actorPrivateKey,
           }),
           await createRawTransfer(context, randomAddress, 2, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("10"),
+            privateKey: actorPrivateKey,
           }),
         ]);
         expect(await context.viem().getBalance({ address: randomAddress })).to.equal(1n);
@@ -65,11 +79,13 @@ describeSuite({
             nonce: currentNonce,
             maxFeePerGas: parseGwei("10"),
             gas: 1048575n,
+            privateKey: actorPrivateKey,
           }),
           await createRawTransfer(context, randomAddress, 2, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("20"),
             gas: 65536n,
+            privateKey: actorPrivateKey,
           }),
         ]);
 
@@ -82,14 +98,15 @@ describeSuite({
       title: "should prioritize higher gas tips",
       test: async function () {
         // GasFee are using very high value to ensure gasPrice is not impacting
-        const alithGLMR = (await context.viem().getBalance({ address: ALITH_ADDRESS })) / GLMR;
+        const addressGLMR = (await context.viem().getBalance({ address: actorAddress })) / GLMR;
         await sendRawTransaction(
           context,
           await createRawTransfer(context, randomAddress, 66, {
             nonce: currentNonce,
             maxFeePerGas: 1n * GLMR,
             maxPriorityFeePerGas: 1n * GLMR,
-          })
+            privateKey: actorPrivateKey,
+          }),
         );
 
         const testParameters = [1n * GLMR, 2n * GLMR, 20n * GLMR, 4n * GLMR, 10n * GLMR];
@@ -100,14 +117,15 @@ describeSuite({
                 nonce: currentNonce,
                 maxFeePerGas: gasPrice,
                 maxPriorityFeePerGas: gasPrice,
+                privateKey: actorPrivateKey,
               })
           )
         );
 
         await context.createBlock(txns);
 
-        expect((await context.viem().getBalance({ address: ALITH_ADDRESS })) / GLMR).to.equal(
-          alithGLMR - 21000n * 20n
+        expect((await context.viem().getBalance({ address: actorAddress })) / GLMR).to.equal(
+          addressGLMR - 21000n * 20n
         );
         expect(await context.viem().getBalance({ address: randomAddress })).to.equal(77n);
       },
@@ -122,11 +140,13 @@ describeSuite({
             nonce: currentNonce,
             maxFeePerGas: parseGwei("300"),
             maxPriorityFeePerGas: parseGwei("10"),
+            privateKey: actorPrivateKey,
           }),
           await createRawTransfer(context, randomAddress, 2, {
             nonce: currentNonce,
             maxFeePerGas: parseGwei("400"),
             maxPriorityFeePerGas: parseGwei("10"),
+            privateKey: actorPrivateKey,
           }),
         ]);
         expect(await context.viem().getBalance({ address: randomAddress })).to.equal(1n);

--- a/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
+++ b/test/suites/dev/moonbase/test-eth-pool/test-eth-pool-resubmit-txn.ts
@@ -4,7 +4,7 @@ import {
   CHARLETH_PRIVATE_KEY,
   createRawTransfer,
   GLMR,
-  sendRawTransaction
+  sendRawTransaction,
 } from "@moonwall/util";
 import { parseGwei } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
@@ -106,7 +106,7 @@ describeSuite({
             maxFeePerGas: 1n * GLMR,
             maxPriorityFeePerGas: 1n * GLMR,
             privateKey: actorPrivateKey,
-          }),
+          })
         );
 
         const testParameters = [1n * GLMR, 2n * GLMR, 20n * GLMR, 4n * GLMR, 10n * GLMR];

--- a/test/suites/dev/moonbase/test-fees/test-fees-repartition.ts
+++ b/test/suites/dev/moonbase/test-fees/test-fees-repartition.ts
@@ -2,6 +2,7 @@ import "@moonbeam-network/api-augment";
 import { TransactionTypes, describeSuite, expect } from "@moonwall/cli";
 import { BALTATHAR_ADDRESS, TREASURY_ACCOUNT, createRawTransfer, extractFee } from "@moonwall/util";
 
+// These tests are checking the default value of FeesTreasuryProportion which is set to 20%
 describeSuite({
   id: "D011605",
   title: "Fees - Transaction",

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -92,21 +92,13 @@ describeSuite({
       };
       const calcIssuanceDecrease = (feeWithTip: bigint, tip?: bigint): bigint => {
         const feeWithTipBN = new BN(feeWithTip.toString());
-        const tipBN = new BN(tip?.toString() || "0");
-        const feeWithoutTipBN = feeWithTipBN.sub(tipBN);
-
-        const [burnFeePart, _treasuryFeePart] = split(
-          feeWithoutTipBN,
-          burnProportion.value(),
-          t.proportion.value()
-        );
-        const [burnTipPart, _treasuryTipPart] = split(
-          tipBN,
+        const [burnFeeWithTipPart, _treasuryFeeWithTipPart] = split(
+          feeWithTipBN,
           burnProportion.value(),
           t.proportion.value()
         );
 
-        return BigInt(burnFeePart.add(burnTipPart).toString());
+        return BigInt(burnFeeWithTipPart.toString());
       };
 
       for (const txnType of TransactionTypes) {

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -199,6 +199,8 @@ describeSuite({
             expect(issuanceDecrease, `${burnPercentage}% of the fees should be burned`).to.equal(
               calcIssuanceDecrease(fee, withTip ? t.tipAmount : undefined)
             );
+
+            await verifyLatestBlockFees(context, t.transfer_amount);
           },
         });
       }

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -79,11 +79,13 @@ describeSuite({
         const treasuryIncrease = feeWithTip - issuanceDecrease;
         return treasuryIncrease;
       };
-      const calcIssuanceDecrease = (feeWithTip: bigint, tip?: bigint): bigint => {
-        const feeWithTipBN = new BN(feeWithTip.toString());
-        const { burnt } = calculateFeePortions(treasuryPerbill, feeWithTipBN);
+      const calcIssuanceDecrease = (feeWithTip: bigint, maybeTip?: bigint): bigint => {
+        const tip = maybeTip ?? 0n;
+        const feeWithoutTip = feeWithTip - tip;
+        const { burnt: feeBurnt } = calculateFeePortions(treasuryPerbill, feeWithoutTip);
+        const { burnt: tipBurnt } = calculateFeePortions(treasuryPerbill, tip);
 
-        return BigInt(burnt.toString());
+        return feeBurnt + tipBurnt;
       };
 
       for (const txnType of TransactionTypes) {

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -1,71 +1,87 @@
-import { describeSuite, expect, TransactionTypes } from "@moonwall/cli";
+import {describeSuite, expect, extractInfo, TransactionTypes} from "@moonwall/cli";
 import {
   alith,
+  ALITH_ADDRESS,
   baltathar,
-  BALTATHAR_ADDRESS,
+  BALTATHAR_ADDRESS, BALTATHAR_PRIVATE_KEY, CHARLETH_ADDRESS,
   createRawTransfer,
   extractFee,
   Perbill,
   TREASURY_ACCOUNT,
+  WEIGHT_PER_GAS,
 } from "@moonwall/util";
-import { parameterType, UNIT } from "./test-parameters";
-import { BN } from "@polkadot/util";
-import { calculateFeePortions, verifyLatestBlockFees } from "../../../../helpers";
+import {parameterType, UNIT} from "./test-parameters";
+import {BN} from "@polkadot/util";
+import {calculateFeePortions, ConstantStore, verifyLatestBlockFees} from "../../../../helpers";
+import {parseGwei, parseWei} from "viem";
 
 interface TestCase {
   proportion: Perbill;
 
   transfer_amount: bigint;
   tipAmount: bigint;
+  priorityFeePerGas: bigint;
 }
 
 describeSuite({
   id: "DTemp03",
   title: "Parameters - RuntimeConfig",
   foundationMethods: "dev",
-  testCases: ({ it, context, log }) => {
+  testCases: ({it, context, log}) => {
     let testCounter = 0;
+    const collatorAddress = ALITH_ADDRESS;
+    const senderPrivateKey = BALTATHAR_PRIVATE_KEY;
+    const senderKeyPair = baltathar;
+    const receiver = CHARLETH_ADDRESS;
 
     const testCases: TestCase[] = [
       {
         proportion: new Perbill(0),
         transfer_amount: 10n * UNIT,
         tipAmount: 1n * UNIT,
+        priorityFeePerGas: parseGwei('1'),
       },
       {
         proportion: new Perbill(1, 100),
         transfer_amount: 1000n,
         tipAmount: 100n,
+        priorityFeePerGas: 100n,
       },
       {
         proportion: new Perbill(355, 1000),
         transfer_amount: 5n * UNIT,
         tipAmount: 111112n,
+        priorityFeePerGas: 111112n,
       },
       {
         proportion: new Perbill(400, 1000),
         transfer_amount: 10n * UNIT,
-        tipAmount: 1n * UNIT,
+        tipAmount: 2n * UNIT,
+        priorityFeePerGas: parseGwei('2'),
       },
       {
         proportion: new Perbill(500, 1000),
         transfer_amount: 10n * UNIT,
         tipAmount: 1n * UNIT,
+        priorityFeePerGas: parseGwei('1'),
       },
       {
         proportion: new Perbill(963, 1000),
         transfer_amount: 10n * UNIT,
         tipAmount: 128n,
+        priorityFeePerGas: 128,
       },
       {
         proportion: new Perbill(99, 100),
         transfer_amount: 10n * UNIT,
         tipAmount: 3n,
+        priorityFeePerGas: 3n,
       },
       {
         proportion: new Perbill(1, 1),
         transfer_amount: 10n * UNIT,
         tipAmount: 32n,
+        priorityFeePerGas: 32n,
       },
     ];
 
@@ -82,74 +98,127 @@ describeSuite({
       const calcIssuanceDecrease = (feeWithTip: bigint, maybeTip?: bigint): bigint => {
         const tip = maybeTip ?? 0n;
         const feeWithoutTip = feeWithTip - tip;
-        const { burnt: feeBurnt } = calculateFeePortions(treasuryPerbill, feeWithoutTip);
-        const { burnt: tipBurnt } = calculateFeePortions(treasuryPerbill, tip);
+        const {burnt: feeBurnt} = calculateFeePortions(treasuryPerbill, feeWithoutTip);
+        const {burnt: tipBurnt} = calculateFeePortions(treasuryPerbill, tip);
 
         return feeBurnt + tipBurnt;
       };
 
       for (const txnType of TransactionTypes) {
-        it({
-          id: `T${++testCounter}`,
-          title:
-            `Changing FeesTreasuryProportion to ${treasuryPercentage}% for Ethereum ` +
-            `${txnType} transfers`,
-          test: async () => {
-            const param = parameterType(
-              context,
-              "RuntimeConfig",
-              "FeesTreasuryProportion",
-              t.proportion.value()
-            );
-            await context.createBlock(
-              context
-                .polkadotJs()
-                .tx.sudo.sudo(context.polkadotJs().tx.parameters.setParameter(param.toU8a()))
-                .signAsync(alith),
-              { allowFailures: false }
-            );
+        for (const withTip of txnType === "eip1559" ? [false, true] : [false]) {
+          testCounter++;
+          it({
+            id: `T${testCounter}x`,
+            title:
+              `Changing FeesTreasuryProportion to ${treasuryPercentage}% for Ethereum ` +
+              `${txnType} transfers with ${withTip ? "" : "no "}tip`,
+            test: async () => {
+              const {specVersion} = context.polkadotJs().consts.system.version;
+              const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(
+                specVersion.toNumber()
+              );
+              const WEIGHT_FEE = ConstantStore(context).WEIGHT_FEE.get(
+                specVersion.toNumber()
+              );
 
-            const balBefore = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
-            const issuanceBefore = (
-              await context.polkadotJs().query.balances.totalIssuance()
-            ).toBigInt();
-            const { result } = await context.createBlock(
-              await createRawTransfer(context, BALTATHAR_ADDRESS, t.transfer_amount, {
-                type: txnType,
-              })
-            );
+              const param = parameterType(
+                context,
+                "RuntimeConfig",
+                "FeesTreasuryProportion",
+                t.proportion.value()
+              );
+              await context.createBlock(
+                context
+                  .polkadotJs()
+                  .tx.sudo.sudo(context.polkadotJs().tx.parameters.setParameter(param.toU8a()))
+                  .signAsync(alith),
+                {allowFailures: false}
+              );
 
-            const balAfter = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
-            const issuanceAfter = (
-              await context.polkadotJs().query.balances.totalIssuance()
-            ).toBigInt();
+              const balBefore = await context.viem().getBalance({address: TREASURY_ACCOUNT});
+              const collatorBalBefore = await context.viem().getBalance({address: collatorAddress});
+              const issuanceBefore = (
+                await context.polkadotJs().query.balances.totalIssuance()
+              ).toBigInt();
 
-            const treasuryIncrease = balAfter - balBefore;
-            const issuanceDecrease = issuanceBefore - issuanceAfter;
-            const fee = extractFee(result?.events)!.amount.toBigInt();
+              const nextFeeMultiplier = (await context.polkadotJs().query.transactionPayment.nextFeeMultiplier()).toBigInt();
+              const baseFee = nextFeeMultiplier * (WEIGHT_FEE * WEIGHT_PER_GAS) / 1_000_000_000_000_000_000n;
 
-            expect(
-              treasuryIncrease + issuanceDecrease,
-              `Sum of TreasuryIncrease and IssuanceDecrease should be equal to the fees`
-            ).to.equal(fee);
+              console.log("baseFee:", baseFee);
 
-            expect(
-              treasuryIncrease,
-              `${treasuryPercentage}% of the fees should go to treasury`
-            ).to.equal(calcTreasuryIncrease(fee));
+              const {result} = await context.createBlock(
+                await createRawTransfer(context, receiver, t.transfer_amount, {
+                  privateKey: senderPrivateKey,
+                  type: txnType,
+                  maxFeePerGas: withTip ? GENESIS_BASE_FEE : undefined,
+                  maxPriorityFeePerGas: withTip ? t.priorityFeePerGas : undefined,
+                })
+              );
 
-            expect(issuanceDecrease, `${burnPercentage}% of the fees should be burned`).to.equal(
-              calcIssuanceDecrease(fee)
-            );
+              const receipt = await context
+                .viem("public")
+                .getTransactionReceipt({hash: result!.hash as `0x${string}`});
 
-            await verifyLatestBlockFees(context, t.transfer_amount);
-          },
-        });
+              console.log("receipt:", receipt);
+
+              const balAfter = await context.viem().getBalance({address: TREASURY_ACCOUNT});
+              const collatorBalAfter = await context.viem().getBalance({address: collatorAddress});
+              const issuanceAfter = (
+                await context.polkadotJs().query.balances.totalIssuance()
+              ).toBigInt();
+
+              const treasuryIncrease = balAfter - balBefore;
+              const issuanceDecrease = issuanceBefore - issuanceAfter;
+              const collatorIncrease = collatorBalAfter - collatorBalBefore;
+              const tipPaid = withTip ? (() => {
+                let priorityPerGas = (GENESIS_BASE_FEE - baseFee);
+                if (priorityPerGas > t.priorityFeePerGas) {
+                  priorityPerGas = t.priorityFeePerGas;
+                }
+                return BigInt(priorityPerGas) * BigInt(receipt!.gasUsed);
+              })() : 0n;
+              const fee = extractFee(result?.events)!.amount.toBigInt();
+              const feeWithoutTip = fee - tipPaid;
+
+              console.log("treasuryIncrease:", treasuryIncrease);
+              console.log("issuanceDecrease:", issuanceDecrease);
+              console.log("collatorIncrease:", collatorIncrease);
+              console.log("total fees      :", fee);
+              console.log("feeWithoutTip   :", feeWithoutTip);
+              console.log("tipPaid         :", tipPaid);
+
+              expect(
+                treasuryIncrease + issuanceDecrease,
+                `Sum of TreasuryIncrease and IssuanceDecrease should be equal to the fees without tip`
+              ).to.equal(feeWithoutTip);
+
+              expect(
+                treasuryIncrease,
+                `${treasuryPercentage}% of the fees should go to treasury`
+              ).to.equal(calcTreasuryIncrease(feeWithoutTip));
+
+              expect(issuanceDecrease, `${burnPercentage}% of the fees should be burned`).to.equal(
+                calcIssuanceDecrease(feeWithoutTip)
+              );
+
+              if (withTip) {
+                expect(collatorIncrease, "100% of the tip should go to the collator").to.equal(
+                  tipPaid
+                );
+              } else {
+                expect(collatorIncrease, "No tip should be paid to the collator").to.equal(0n);
+              }
+
+              await verifyLatestBlockFees(context, t.transfer_amount);
+            },
+          });
+        }
       }
 
       for (const withTip of [false, true]) {
+        testCounter++;
         it({
-          id: `T${++testCounter}`,
+          id: `T${testCounter}x`,
           title:
             `Changing FeesTreasuryProportion to ${treasuryPercentage}% for Substrate based ` +
             `transactions with ${withTip ? "" : "no "}tip`,
@@ -165,23 +234,23 @@ describeSuite({
                 .polkadotJs()
                 .tx.sudo.sudo(context.polkadotJs().tx.parameters.setParameter(param.toU8a()))
                 .signAsync(alith),
-              { allowFailures: false }
+              {allowFailures: false}
             );
 
-            const balanceBefore = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
+            const balanceBefore = await context.viem().getBalance({address: TREASURY_ACCOUNT});
             const issuanceBefore = (
               await context.polkadotJs().query.balances.totalIssuance()
             ).toBigInt();
 
-            const { result } = await context.createBlock(
+            const {result} = await context.createBlock(
               context
                 .polkadotJs()
-                .tx.balances.transferKeepAlive(alith.address, t.transfer_amount)
-                .signAsync(baltathar, { tip: withTip ? t.tipAmount : 0n }),
-              { allowFailures: false }
+                .tx.balances.transferKeepAlive(receiver, t.transfer_amount)
+                .signAsync(senderKeyPair, {tip: withTip ? t.tipAmount : 0n}),
+              {allowFailures: false}
             );
 
-            const balanceAfter = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
+            const balanceAfter = await context.viem().getBalance({address: TREASURY_ACCOUNT});
             const issuanceAfter = (
               await context.polkadotJs().query.balances.totalIssuance()
             ).toBigInt();

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -10,7 +10,7 @@ import {
 } from "@moonwall/util";
 import { parameterType, UNIT } from "./test-parameters";
 import { BN } from "@polkadot/util";
-import { calculateFeePortions } from "../../../../helpers";
+import { calculateFeePortions, verifyLatestBlockFees } from "../../../../helpers";
 
 interface TestCase {
   proportion: Perbill;
@@ -70,7 +70,7 @@ describeSuite({
     ];
 
     for (const t of testCases) {
-      const treasuryPerbill = new BN(1e9).sub(t.proportion.value());
+      const treasuryPerbill = new BN(t.proportion.value());
       const treasuryPercentage = t.proportion.value().toNumber() / 1e7;
       const burnPercentage = 100 - treasuryPercentage;
 
@@ -147,7 +147,7 @@ describeSuite({
         it({
           id: `T${++testCounter}`,
           title:
-            `Changing FeesTreasuryProportion to ${treasuryPercentage}% for Substrate based` +
+            `Changing FeesTreasuryProportion to ${treasuryPercentage}% for Substrate based ` +
             `transactions with ${withTip ? "" : "no "}tip`,
           test: async () => {
             const param = parameterType(

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -1,19 +1,20 @@
-import {describeSuite, expect, extractInfo, TransactionTypes} from "@moonwall/cli";
+import { describeSuite, expect, extractInfo, TransactionTypes } from "@moonwall/cli";
 import {
   alith,
   ALITH_ADDRESS,
   baltathar,
-  BALTATHAR_ADDRESS, BALTATHAR_PRIVATE_KEY, CHARLETH_ADDRESS,
+  BALTATHAR_PRIVATE_KEY,
+  CHARLETH_ADDRESS,
   createRawTransfer,
   extractFee,
   Perbill,
   TREASURY_ACCOUNT,
   WEIGHT_PER_GAS,
 } from "@moonwall/util";
-import {parameterType, UNIT} from "./test-parameters";
-import {BN} from "@polkadot/util";
-import {calculateFeePortions, ConstantStore, verifyLatestBlockFees} from "../../../../helpers";
-import {parseGwei, parseWei} from "viem";
+import { parameterType, UNIT } from "./test-parameters";
+import { BN } from "@polkadot/util";
+import { calculateFeePortions, ConstantStore, verifyLatestBlockFees } from "../../../../helpers";
+import { parseGwei } from "viem";
 
 interface TestCase {
   proportion: Perbill;
@@ -27,7 +28,7 @@ describeSuite({
   id: "DTemp03",
   title: "Parameters - RuntimeConfig",
   foundationMethods: "dev",
-  testCases: ({it, context, log}) => {
+  testCases: ({ it, context, log }) => {
     let testCounter = 0;
     const collatorAddress = ALITH_ADDRESS;
     const senderPrivateKey = BALTATHAR_PRIVATE_KEY;
@@ -39,7 +40,7 @@ describeSuite({
         proportion: new Perbill(0),
         transfer_amount: 10n * UNIT,
         tipAmount: 1n * UNIT,
-        priorityFeePerGas: parseGwei('1'),
+        priorityFeePerGas: parseGwei("1"),
       },
       {
         proportion: new Perbill(1, 100),
@@ -57,13 +58,13 @@ describeSuite({
         proportion: new Perbill(400, 1000),
         transfer_amount: 10n * UNIT,
         tipAmount: 2n * UNIT,
-        priorityFeePerGas: parseGwei('2'),
+        priorityFeePerGas: parseGwei("2"),
       },
       {
         proportion: new Perbill(500, 1000),
         transfer_amount: 10n * UNIT,
         tipAmount: 1n * UNIT,
-        priorityFeePerGas: parseGwei('1'),
+        priorityFeePerGas: parseGwei("1"),
       },
       {
         proportion: new Perbill(963, 1000),
@@ -98,8 +99,8 @@ describeSuite({
       const calcIssuanceDecrease = (feeWithTip: bigint, maybeTip?: bigint): bigint => {
         const tip = maybeTip ?? 0n;
         const feeWithoutTip = feeWithTip - tip;
-        const {burnt: feeBurnt} = calculateFeePortions(treasuryPerbill, feeWithoutTip);
-        const {burnt: tipBurnt} = calculateFeePortions(treasuryPerbill, tip);
+        const { burnt: feeBurnt } = calculateFeePortions(treasuryPerbill, feeWithoutTip);
+        const { burnt: tipBurnt } = calculateFeePortions(treasuryPerbill, tip);
 
         return feeBurnt + tipBurnt;
       };
@@ -113,13 +114,11 @@ describeSuite({
               `Changing FeesTreasuryProportion to ${treasuryPercentage}% for Ethereum ` +
               `${txnType} transfers with ${withTip ? "" : "no "}tip`,
             test: async () => {
-              const {specVersion} = context.polkadotJs().consts.system.version;
+              const { specVersion } = context.polkadotJs().consts.system.version;
               const GENESIS_BASE_FEE = ConstantStore(context).GENESIS_BASE_FEE.get(
                 specVersion.toNumber()
               );
-              const WEIGHT_FEE = ConstantStore(context).WEIGHT_FEE.get(
-                specVersion.toNumber()
-              );
+              const WEIGHT_FEE = ConstantStore(context).WEIGHT_FEE.get(specVersion.toNumber());
 
               const param = parameterType(
                 context,
@@ -132,21 +131,24 @@ describeSuite({
                   .polkadotJs()
                   .tx.sudo.sudo(context.polkadotJs().tx.parameters.setParameter(param.toU8a()))
                   .signAsync(alith),
-                {allowFailures: false}
+                { allowFailures: false }
               );
 
-              const balBefore = await context.viem().getBalance({address: TREASURY_ACCOUNT});
-              const collatorBalBefore = await context.viem().getBalance({address: collatorAddress});
+              const balBefore = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
+              const collatorBalBefore = await context
+                .viem()
+                .getBalance({ address: collatorAddress });
               const issuanceBefore = (
                 await context.polkadotJs().query.balances.totalIssuance()
               ).toBigInt();
 
-              const nextFeeMultiplier = (await context.polkadotJs().query.transactionPayment.nextFeeMultiplier()).toBigInt();
-              const baseFee = nextFeeMultiplier * (WEIGHT_FEE * WEIGHT_PER_GAS) / 1_000_000_000_000_000_000n;
+              const nextFeeMultiplier = (
+                await context.polkadotJs().query.transactionPayment.nextFeeMultiplier()
+              ).toBigInt();
+              const baseFee =
+                (nextFeeMultiplier * (WEIGHT_FEE * WEIGHT_PER_GAS)) / 1_000_000_000_000_000_000n;
 
-              console.log("baseFee:", baseFee);
-
-              const {result} = await context.createBlock(
+              const { result } = await context.createBlock(
                 await createRawTransfer(context, receiver, t.transfer_amount, {
                   privateKey: senderPrivateKey,
                   type: txnType,
@@ -157,12 +159,12 @@ describeSuite({
 
               const receipt = await context
                 .viem("public")
-                .getTransactionReceipt({hash: result!.hash as `0x${string}`});
+                .getTransactionReceipt({ hash: result!.hash as `0x${string}` });
 
-              console.log("receipt:", receipt);
-
-              const balAfter = await context.viem().getBalance({address: TREASURY_ACCOUNT});
-              const collatorBalAfter = await context.viem().getBalance({address: collatorAddress});
+              const balAfter = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
+              const collatorBalAfter = await context
+                .viem()
+                .getBalance({ address: collatorAddress });
               const issuanceAfter = (
                 await context.polkadotJs().query.balances.totalIssuance()
               ).toBigInt();
@@ -170,22 +172,17 @@ describeSuite({
               const treasuryIncrease = balAfter - balBefore;
               const issuanceDecrease = issuanceBefore - issuanceAfter;
               const collatorIncrease = collatorBalAfter - collatorBalBefore;
-              const tipPaid = withTip ? (() => {
-                let priorityPerGas = (GENESIS_BASE_FEE - baseFee);
-                if (priorityPerGas > t.priorityFeePerGas) {
-                  priorityPerGas = t.priorityFeePerGas;
-                }
-                return BigInt(priorityPerGas) * BigInt(receipt!.gasUsed);
-              })() : 0n;
+              const tipPaid = withTip
+                ? (() => {
+                    let priorityPerGas = GENESIS_BASE_FEE - baseFee;
+                    if (priorityPerGas > t.priorityFeePerGas) {
+                      priorityPerGas = t.priorityFeePerGas;
+                    }
+                    return BigInt(priorityPerGas) * BigInt(receipt!.gasUsed);
+                  })()
+                : 0n;
               const fee = extractFee(result?.events)!.amount.toBigInt();
               const feeWithoutTip = fee - tipPaid;
-
-              console.log("treasuryIncrease:", treasuryIncrease);
-              console.log("issuanceDecrease:", issuanceDecrease);
-              console.log("collatorIncrease:", collatorIncrease);
-              console.log("total fees      :", fee);
-              console.log("feeWithoutTip   :", feeWithoutTip);
-              console.log("tipPaid         :", tipPaid);
 
               expect(
                 treasuryIncrease + issuanceDecrease,
@@ -234,23 +231,23 @@ describeSuite({
                 .polkadotJs()
                 .tx.sudo.sudo(context.polkadotJs().tx.parameters.setParameter(param.toU8a()))
                 .signAsync(alith),
-              {allowFailures: false}
+              { allowFailures: false }
             );
 
-            const balanceBefore = await context.viem().getBalance({address: TREASURY_ACCOUNT});
+            const balanceBefore = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
             const issuanceBefore = (
               await context.polkadotJs().query.balances.totalIssuance()
             ).toBigInt();
 
-            const {result} = await context.createBlock(
+            const { result } = await context.createBlock(
               context
                 .polkadotJs()
                 .tx.balances.transferKeepAlive(receiver, t.transfer_amount)
-                .signAsync(senderKeyPair, {tip: withTip ? t.tipAmount : 0n}),
-              {allowFailures: false}
+                .signAsync(senderKeyPair, { tip: withTip ? t.tipAmount : 0n }),
+              { allowFailures: false }
             );
 
-            const balanceAfter = await context.viem().getBalance({address: TREASURY_ACCOUNT});
+            const balanceAfter = await context.viem().getBalance({ address: TREASURY_ACCOUNT });
             const issuanceAfter = (
               await context.polkadotJs().query.balances.totalIssuance()
             ).toBigInt();

--- a/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
+++ b/test/suites/dev/moonbase/test-parameters/test-parameters-runtime-FeesTreasuryProportion.ts
@@ -141,6 +141,8 @@ describeSuite({
             expect(issuanceDecrease, `${burnPercentage}% of the fees should be burned`).to.equal(
               calcIssuanceDecrease(fee)
             );
+
+            await verifyLatestBlockFees(context, t.transfer_amount);
           },
         });
       }

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xtokens.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xtokens.ts
@@ -1,6 +1,13 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect, fetchCompiledContract } from "@moonwall/cli";
-import { ALITH_ADDRESS, GLMR, PRECOMPILES, createViemTransaction } from "@moonwall/util";
+import {
+  ALITH_ADDRESS,
+  GLMR,
+  PRECOMPILES,
+  createViemTransaction,
+  CHARLETH_ADDRESS,
+  CHARLETH_PRIVATE_KEY,
+} from "@moonwall/util";
 import {
   verifyLatestBlockFees,
   expectEVMResult,
@@ -214,7 +221,7 @@ describeSuite({
         const fee_item = 0;
         const weight = 100;
 
-        const balBefore = await context.viem().getBalance({ address: ALITH_ADDRESS });
+        const balBefore = await context.viem().getBalance({ address: CHARLETH_ADDRESS });
         const { abi } = fetchCompiledContract("Xtokens");
         const data = encodeFunctionData({
           abi,
@@ -229,10 +236,11 @@ describeSuite({
           txnType: "legacy",
           gas: 500_000n,
           gasPrice: BigInt(DEFAULT_TXN_MAX_BASE_FEE),
+          privateKey: CHARLETH_PRIVATE_KEY,
         });
 
         const { result } = await context.createBlock(rawTxn);
-        const balAfter = await context.viem().getBalance({ address: ALITH_ADDRESS });
+        const balAfter = await context.viem().getBalance({ address: CHARLETH_ADDRESS });
         const receipt = await context
           .viem()
           .getTransactionReceipt({ hash: result!.hash as `0x${string}` });


### PR DESCRIPTION
### What does it do?
Expand on the work done in #2923 and #3043, and send the priority fees to the block author (collator).

### What important points reviewers should know?

- This is how we handle fees in this change:
    - `FeesTreasuryProportion` is used to split the following
	    - Substrate txs fees
	    - Eth base fees
    - The eth priority fees / tips and substrate tips are sent fully to the block author.
 - I've removed `DealWithFees` struct and replaced it with
     - `DealWithSubstrateFeesAndTip`
     - `DealWithEthereumBaseFees`
     - `DealWithEthereumPriorityFees`



#### Tests
Some tests that were checking fees have been updated. Previously, they used the block author (ALITH), who will now receive tips due to this change, causing inaccuracies in the calculations.

#### Reviewer Checklist:
- [ ] Base Eth Fees are split using FeesTreasuryProportion
- [ ] Substrate Base fees are split using FeesTreasuryProportion
- [ ] Priority fees and substrate tips are sent to the collator (Block author)
- [ ] Make sure all runtimes have the same implementation
- [ ] Changed test work the same way as before (I just changed the sender/revicver account)
- [ ] All the new functionality are tested correctly for all scenarios.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
