### PR TITLE
chore(actions): use `defaults` for `shell: bash` in actions

### DIFF
--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -8,13 +8,16 @@ inputs:
     description: features to include in the build (comma separated)
     required: false
 
+defaults:
+  run:
+    shell: bash
+
 runs:
   using: "composite"
   steps:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.4
     - name: Setup Variables
-      shell: bash
       run: |
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
@@ -24,14 +27,12 @@ runs:
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
         fi
     - name: Setup Mold Linker
-      shell: bash
       run: |
         mkdir -p mold
         curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v2.30.0/mold-2.30.0-$(uname -m)-linux.tar.gz | tar -C $(realpath mold) --strip-components=1 -xzf -
     # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
     # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
     - name: Setup Rust toolchain
-      shell: bash
       run: |
         if ! which "rustup" > /dev/null; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -40,7 +41,6 @@ runs:
         rustup show
         rustup target add wasm32-unknown-unknown
     - name: Build Node
-      shell: bash
       run: |
         env
         params=" --locked --release -p moonbeam"
@@ -50,27 +50,22 @@ runs:
         echo "cargo build $params"
         cargo build $params
     - name: Display binary comments
-      shell: bash
       run: readelf -p .comment ./target/release/moonbeam
     - name: Display sccache stats
-      shell: bash
       run: ${SCCACHE_PATH} --show-stats
     - name: Verify binary version
-      shell: bash
       run: |
         GIT_COMMIT=`git log -1 --format="%H" | cut -c1-7`
         MB_VERSION=`./target/release/moonbeam --version`
         echo "Checking $MB_VERSION contains $GIT_COMMIT"
         echo "$MB_VERSION" | grep $GIT_COMMIT
     - name: Save runtimes wasm
-      shell: bash
       run: |
         mkdir -p runtimes
         cp target/release/wbuild/moon*/moon*_runtime.compact.compressed.wasm runtimes/;
         mkdir -p uncompressed-runtimes;
         cp target/release/wbuild/moon*/moon*_runtime.wasm uncompressed-runtimes/;
     - name: Save moonbeam binary
-      shell: bash
       run: |
         mkdir -p build
         cp target/release/moonbeam build/moonbeam;


### PR DESCRIPTION
### What does it do?

This PR consolidates all the `shell: bash` keys into a single, unified section.

### What important points should reviewers know?

Reviewers should be aware that this change simplifies future updates, as any modifications will only need to be made in one place.

### Is there something left for follow-up PRs?

No, this change is self-contained.

### What alternative implementations were considered?

The alternative would have been to leave the `shell: bash` keys in their current, separate locations.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

No, there are no related PRs or issues in other repositories.

### What value does it bring to blockchain users?

There is no direct impact for end users, but this will streamline the maintenance of GitHub Actions for the repository.