### PR TITLE
Fix notify inactive collators failures at the end of a round

### DIFF
--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -280,7 +280,7 @@ impl ExtBuilder {
 fn roll_one_block() -> BlockNumber {
 	Balances::on_finalize(System::block_number());
 	System::on_finalize(System::block_number());
-	ParachainStaking::on_finalize(0);
+	ParachainStaking::on_finalize(System::block_number());
 	System::set_block_number(System::block_number() + 1);
 	System::reset_events();
 	System::on_initialize(System::block_number());

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -280,6 +280,7 @@ impl ExtBuilder {
 fn roll_one_block() -> BlockNumber {
 	Balances::on_finalize(System::block_number());
 	System::on_finalize(System::block_number());
+	ParachainStaking::on_finalize(0);
 	System::set_block_number(System::block_number() + 1);
 	System::reset_events();
 	System::on_initialize(System::block_number());


### PR DESCRIPTION
### What does it do?
Addresses issue #3100 for which "notify_inactive_collator" only works at the beginning of a round.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
