### PR TITLE
Remove any XCM v2 reference in codebase

### DIFF
--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -137,7 +137,7 @@ impl WrapVersion for CustomVersionWrapper {
 		xcm: impl Into<VersionedXcm<RuntimeCall>>,
 	) -> Result<VersionedXcm<RuntimeCall>, ()> {
 		let xcm_version: u32 =
-			frame_support::storage::unhashed::get(XCM_VERSION_ROOT_KEY).unwrap_or(2);
+			frame_support::storage::unhashed::get(XCM_VERSION_ROOT_KEY).unwrap_or(3);
 		let xcm_converted = xcm.into().into_version(xcm_version)?;
 		Ok(xcm_converted)
 	}

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -2085,7 +2085,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_relay() {
 		// This sets the default version, for not known destinations
 		assert_ok!(RelayChainPalletXcm::force_default_xcm_version(
 			relay_chain::RuntimeOrigin::root(),
-			Some(2)
+			Some(3)
 		));
 
 		// Wrap version, which sets VersionedStorage
@@ -2214,7 +2214,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_para_b() {
 		// This sets the default version, for not known destinations
 		assert_ok!(ParachainPalletXcm::force_default_xcm_version(
 			parachain::RuntimeOrigin::root(),
-			Some(2)
+			Some(3)
 		));
 		// Wrap version, which sets VersionedStorage
 		assert_ok!(<ParachainPalletXcm as WrapVersion>::wrap_version(

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -1960,7 +1960,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_relay() {
 		// This sets the default version, for not known destinations
 		assert_ok!(RelayChainPalletXcm::force_default_xcm_version(
 			relay_chain::RuntimeOrigin::root(),
-			Some(2)
+			Some(3)
 		));
 
 		// Wrap version, which sets VersionedStorage

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -2119,7 +2119,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_relay() {
 		// This sets the default version, for not known destinations
 		assert_ok!(RelayChainPalletXcm::force_default_xcm_version(
 			relay_chain::RuntimeOrigin::root(),
-			Some(2)
+			Some(3)
 		));
 
 		// Wrap version, which sets VersionedStorage
@@ -2249,7 +2249,7 @@ fn test_automatic_versioning_on_runtime_upgrade_with_para_b() {
 		// This sets the default version, for not known destinations
 		assert_ok!(ParachainPalletXcm::force_default_xcm_version(
 			parachain::RuntimeOrigin::root(),
-			Some(2)
+			Some(3)
 		));
 		// Wrap version, which sets VersionedStorage
 		assert_ok!(<ParachainPalletXcm as WrapVersion>::wrap_version(

--- a/test/helpers/xcm.ts
+++ b/test/helpers/xcm.ts
@@ -348,25 +348,7 @@ export class XcmFragment {
   }
 
   // Add a `DepositAsset` instruction
-  deposit_asset(max_assets = 1n, network: "Any" | XcmV3JunctionNetworkId["type"] = "Any"): this {
-    if (this.config.beneficiary == null) {
-      console.warn("!Building a DepositAsset instruction without a configured beneficiary");
-    }
-    this.instructions.push({
-      DepositAsset: {
-        assets: { Wild: "All" },
-        maxAssets: max_assets,
-        beneficiary: {
-          parents: 0,
-          interior: { X1: { AccountKey20: { network, key: this.config.beneficiary } } },
-        },
-      },
-    });
-    return this;
-  }
-
-  // Add a `DepositAsset` instruction for xcm v3
-  deposit_asset_v3(max_assets = 1n, network: XcmV3JunctionNetworkId["type"] | null = null): this {
+  deposit_asset(max_assets = 1n, network: XcmV3JunctionNetworkId["type"] | null = null): this {
     if (this.config.beneficiary == null) {
       console.warn("!Building a DepositAsset instruction without a configured beneficiary");
     }

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-1.ts
@@ -56,7 +56,7 @@ describeSuite({
           // But since there is no error, and the deposit is on the error handler, the assets
           // will be trapped
           .with(function () {
-            return this.set_error_handler_with([this.deposit_asset_v3]);
+            return this.set_error_handler_with([this.deposit_asset]);
           })
           .clear_origin()
           .as_v3();

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-2.ts
@@ -55,7 +55,7 @@ describeSuite({
           // BuyExecution does not charge for fees because we registered it for not doing so
           // As a consequence the trapped assets will be entirely credited
           .with(function () {
-            return this.set_error_handler_with([this.deposit_asset_v3]);
+            return this.set_error_handler_with([this.deposit_asset]);
           })
           .trap()
           .as_v3();

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-3.ts
@@ -54,7 +54,7 @@ describeSuite({
           .buy_execution()
           // Set an appendix to be executed after the XCM message is executed. No matter if errors
           .with(function () {
-            return this.set_appendix_with([this.deposit_asset_v3]);
+            return this.set_appendix_with([this.deposit_asset]);
           })
           .as_v3();
 

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-4.ts
@@ -56,7 +56,7 @@ describeSuite({
           // As a consequence the trapped assets will be entirely credited
           // The goal is to show appendix runs even if there is an error
           .with(function () {
-            return this.set_appendix_with([this.deposit_asset_v3]);
+            return this.set_appendix_with([this.deposit_asset]);
           })
           .trap()
           .as_v3();

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-5.ts
@@ -56,7 +56,7 @@ describeSuite({
           // As a consequence the trapped assets will be entirely credited
           // The goal is to show appendix runs even if there is an error
           .with(function () {
-            return this.set_appendix_with([this.deposit_asset_v3]);
+            return this.set_appendix_with([this.deposit_asset]);
           })
           .trap()
           .as_v3();

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-error-and-appendix-6.ts
@@ -99,7 +99,7 @@ describeSuite({
           .claim_asset()
           .buy_execution()
           // Deposit assets, this time correctly, on Alith
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         const receivedMessage: XcmVersionedXcm = context

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-2.ts
@@ -78,7 +78,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-3.ts
@@ -89,7 +89,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-4.ts
@@ -73,7 +73,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-5.ts
@@ -71,7 +71,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         const chargedWeight = await weightMessage(

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-6.ts
@@ -113,7 +113,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution(1) // buy execution with asset at index 1
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v3();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-8.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-asset-transfer-8.ts
@@ -75,7 +75,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v3();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-3.ts
@@ -100,7 +100,7 @@ describeSuite({
               .reserve_asset_deposited()
               .clear_origin()
               .buy_execution()
-              .deposit_asset_v3()
+              .deposit_asset()
               .as_v3()
           ) as any
       );
@@ -114,7 +114,7 @@ describeSuite({
         .reserve_asset_deposited()
         .clear_origin()
         .buy_execution()
-        .deposit_asset_v3()
+        .deposit_asset()
         .as_v3();
 
       // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-excess-gas.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-excess-gas.ts
@@ -159,7 +159,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v3();
 
         // Mock the reception of the xcm message
@@ -258,7 +258,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v3();
 
         // Mock the reception of the xcm message

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-fees-and-trap.ts
@@ -99,7 +99,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v3();
 
         // Mock the reception of the xcm message
@@ -254,7 +254,7 @@ describeSuite({
         const xcmMessageToClaimAssets = new XcmFragment(claimConfig)
           .claim_asset()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         const balanceBefore = (
@@ -325,7 +325,7 @@ describeSuite({
         const xcmMessageFailedClaim = new XcmFragment(failedClaimConfig)
           .claim_asset()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         await injectHrmpMessageAndSeal(context, paraId, {

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3-filter.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3-filter.ts
@@ -117,7 +117,7 @@ describeSuite({
               .withdraw_asset()
               .clear_origin()
               .buy_execution()
-              .deposit_asset_v3(limit)
+              .deposit_asset(limit)
               .as_v3(),
           });
 

--- a/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-xcm-erc20-v3.ts
@@ -112,7 +112,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v3();
 
         // Mock the reception of the xcm message

--- a/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-auto-pause-xcm.ts
@@ -70,7 +70,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         // Inject an XCM message that should be included in the next block but not executed

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-1.ts
@@ -56,7 +56,7 @@ describeSuite({
           // But since there is no error, and the deposit is on the error handler, the assets
           // will be trapped
           .with(function () {
-            return this.set_error_handler_with([this.deposit_asset_v3]);
+            return this.set_error_handler_with([this.deposit_asset]);
           })
           .clear_origin()
           .as_v4();

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-2.ts
@@ -55,7 +55,7 @@ describeSuite({
           // BuyExecution does not charge for fees because we registered it for not doing so
           // As a consequence the trapped assets will be entirely credited
           .with(function () {
-            return this.set_error_handler_with([this.deposit_asset_v3]);
+            return this.set_error_handler_with([this.deposit_asset]);
           })
           .trap()
           .as_v4();

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-3.ts
@@ -54,7 +54,7 @@ describeSuite({
           .buy_execution()
           // Set an appendix to be executed after the XCM message is executed. No matter if errors
           .with(function () {
-            return this.set_appendix_with([this.deposit_asset_v3]);
+            return this.set_appendix_with([this.deposit_asset]);
           })
           .as_v4();
 

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-4.ts
@@ -56,7 +56,7 @@ describeSuite({
           // As a consequence the trapped assets will be entirely credited
           // The goal is to show appendix runs even if there is an error
           .with(function () {
-            return this.set_appendix_with([this.deposit_asset_v3]);
+            return this.set_appendix_with([this.deposit_asset]);
           })
           .trap()
           .as_v4();

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-5.ts
@@ -56,7 +56,7 @@ describeSuite({
           // As a consequence the trapped assets will be entirely credited
           // The goal is to show appendix runs even if there is an error
           .with(function () {
-            return this.set_appendix_with([this.deposit_asset_v3]);
+            return this.set_appendix_with([this.deposit_asset]);
           })
           .trap()
           .as_v4();

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-dmp-error-and-appendix-6.ts
@@ -98,7 +98,7 @@ describeSuite({
           .claim_asset()
           .buy_execution()
           // Deposit assets, this time correctly, on Alith
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         const receivedMessage: XcmVersionedXcm = context

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-1.ts
@@ -78,7 +78,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-2.ts
@@ -89,7 +89,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-3.ts
@@ -73,7 +73,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-4.ts
@@ -72,7 +72,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         const chargedWeight = await weightMessage(

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-5.ts
@@ -113,7 +113,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution(1) // buy execution with asset at index 1
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v4();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-6.ts
@@ -75,7 +75,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v4();
 
         // Send an XCM and create block to execute it

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-dry-run-api.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-dry-run-api.ts
@@ -189,7 +189,7 @@ describeSuite({
           .reserve_asset_deposited()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v3();
 
         const dryRunXcm = await polkadotJs.call.dryRunApi.dryRunXcm(

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer-two-ERC20.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer-two-ERC20.ts
@@ -238,7 +238,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(3n)
+          .deposit_asset(3n)
           .as_v4();
 
         // Mock the reception of the xcm message

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer.ts
@@ -173,7 +173,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3(2n)
+          .deposit_asset(2n)
           .as_v4();
 
         // Mock the reception of the xcm message

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-1.ts
@@ -68,7 +68,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         const chargedWeight = await weightMessage(

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-2.ts
@@ -68,7 +68,7 @@ describeSuite({
           .withdraw_asset()
           .clear_origin()
           .buy_execution()
-          .deposit_asset_v3()
+          .deposit_asset()
           .as_v4();
 
         const chargedWeight = await weightMessage(

--- a/test/suites/tracing-tests/test-trace-erc20-xcm.ts
+++ b/test/suites/tracing-tests/test-trace-erc20-xcm.ts
@@ -103,7 +103,7 @@ describeSuite({
         .withdraw_asset()
         .clear_origin()
         .buy_execution()
-        .deposit_asset_v3(2n)
+        .deposit_asset(2n)
         .as_v3();
 
       // Mock the reception of the xcm message


### PR DESCRIPTION
### What does it do?
Given the successful increment of XCM safe version to v3, we can remove some old code mentioning/allow compatibility with XCM v2.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
