### PR TITLE
Smoke tests :test_tube:: remove Khala & Polkadex parachains

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -78,10 +78,6 @@ export const ForeignChainsEndpoints = [
         paraId: 2001,
       },
       {
-        name: "Khala",
-        paraId: 2004,
-      },
-      {
         name: "Shiden",
         paraId: 2007,
       },
@@ -191,10 +187,6 @@ export const ForeignChainsEndpoints = [
       {
         name: "Unique",
         paraId: 2037,
-      },
-      {
-        name: "Polkadex",
-        paraId: 2040,
       },
       {
         name: "OriginTrail",


### PR DESCRIPTION
### What does it do?

Remove Khala and Polkadex parachains from our foreign chains list used in smoke tests. Both parachains have been retired and have not renewed their slots.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
