### PR TITLE
Typo fix in README.md

### DIFF
--- a/moonbeam-types-bundle/README.md
+++ b/moonbeam-types-bundle/README.md
@@ -1,6 +1,6 @@
 # Moonbeam Types Bundle
 
-Exports npm package `moonbeam-types-bundle`, formated as per polkadot-js specification to use
+Exports npm package `moonbeam-types-bundle`, formatted as per polkadot-js specification to use
 with the app or the API.
 
 ## ⚠️Warning: Types deprecation⚠️


### PR DESCRIPTION
### Title:
Fix Typo in `README.md`

### Description:
This pull request fixes a small typo in the `moonbeam-types-bundle/README.md` file.

### Changes:
- Corrected the word "formated" to "formatted":
  - **Before**: `formated as per polkadot-js specification`
  - **After**: `formatted as per polkadot-js specification`
