### PR TITLE
Retrieve `state_version` from WASM in `export-genesis-state` subcommand

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -49,7 +49,7 @@ fn validate_url(arg: &str) -> Result<Url, String> {
 pub enum Subcommand {
 	/// Export the genesis state of the parachain.
 	#[clap(name = "export-genesis-state")]
-	ExportGenesisHead(ExportGenesisHeadCommand),
+	ExportGenesisHead(cumulus_client_cli::ExportGenesisHeadCommand),
 
 	/// Export the genesis wasm of the parachain.
 	#[clap(name = "export-genesis-wasm")]
@@ -106,26 +106,6 @@ pub struct BuildSpecCommand {
 	/// Warning: This flag implies a development spec and overrides any explicitly supplied spec
 	#[clap(long, conflicts_with = "chain")]
 	pub mnemonic: Option<String>,
-}
-
-/// Command for exporting the genesis state of the parachain
-#[derive(Debug, Parser)]
-pub struct ExportGenesisHeadCommand {
-	/// Output file name or stdout if unspecified.
-	#[clap(value_parser)]
-	pub output: Option<PathBuf>,
-
-	/// Id of the parachain this state is for.
-	#[clap(long)]
-	pub parachain_id: Option<u32>,
-
-	/// Write output in binary. Default is to write in hex.
-	#[clap(short, long)]
-	pub raw: bool,
-
-	/// The name of the chain for that the genesis state should be exported.
-	#[clap(long)]
-	pub chain: Option<String>,
 }
 
 /// Command for exporting the genesis wasm file.

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -419,16 +419,13 @@ pub fn run() -> Result<()> {
 			}
 		}
 		Some(Subcommand::ExportGenesisHead(params)) => {
+			let runner = cli.create_runner(params)?;
+			let chain_spec = (runner.config().chain_spec).cloned_box();
+
 			let mut builder = sc_cli::LoggerBuilder::new("");
 			builder.with_profiling(sc_tracing::TracingReceiver::Log, "");
 			let _ = builder.init();
 
-			// Cumulus approach here, we directly call the generic load_spec func
-			let chain_spec = load_spec(
-				params.chain.as_deref().unwrap_or_default(),
-				params.parachain_id.unwrap_or(1000).into(),
-				&cli.run,
-			)?;
 			let state_version = Cli::runtime_version(&chain_spec).state_version();
 
 			let output_buf = match chain_spec {

--- a/scripts/generate-parachain-specs.sh
+++ b/scripts/generate-parachain-specs.sh
@@ -28,8 +28,6 @@ $MOONBEAM_BINARY export-genesis-wasm \
 echo $ALPHANET_WASM generated
 
 $MOONBEAM_BINARY export-genesis-state \
-  --parachain-id $ALPHANET_PARACHAIN_ID \
-  --chain $ALPHANET_PARACHAIN_SPEC_RAW \
   > $ALPHANET_GENESIS;
 echo $ALPHANET_GENESIS generated
 


### PR DESCRIPTION
### What does it do?
Retrieve `state_version` from WASM blob in `export-genesis-state` subcommand. 

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
