### PR TITLE
Corrected typos

### DIFF
--- a/runtime-diffs/README.md
+++ b/runtime-diffs/README.md
@@ -34,7 +34,7 @@ For example, above you can see that AuthorInherent has changed, in that a new St
 Meanwhile, `LocalAssets` pallet has been removed, so you would expect references to storages, extrinsics, events; to be removed.
 
 > [!NOTE]  
-> Adding new pallets may not nessecarily correspond to new storages or extrinsics being added - althougth it often does.
+> Adding new pallets may not nessecarily correspond to new storages or extrinsics being added - although it often does.
 
 ## Resources
 


### PR DESCRIPTION
### Changes

1. **File:** `/runtime-diffs/README.md`
    - Fixed `althougth` to `although` (Line 37)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.