### PR TITLE
Update ERC20_CREATE_GAS_LIMIT

### DIFF
--- a/pallets/moonbeam-foreign-assets/src/evm.rs
+++ b/pallets/moonbeam-foreign-assets/src/evm.rs
@@ -33,7 +33,7 @@ const ERC20_CALL_MAX_CALLDATA_SIZE: usize = 4 + 32 + 32; // selector + address +
 const ERC20_CREATE_MAX_CALLDATA_SIZE: usize = 16 * 1024; // 16Ko
 
 // Hardcoded gas limits (from manual binary search)
-const ERC20_CREATE_GAS_LIMIT: u64 = 3_367_000; // highest failure: 3_366_468
+const ERC20_CREATE_GAS_LIMIT: u64 = 3_410_000; // highest failure: 3_406_000
 pub(crate) const ERC20_BURN_FROM_GAS_LIMIT: u64 = 155_000; // highest failure: 154_000
 pub(crate) const ERC20_MINT_INTO_GAS_LIMIT: u64 = 155_000; // highest failure: 154_000
 const ERC20_PAUSE_GAS_LIMIT: u64 = 150_500; // highest failure: 150_500


### PR DESCRIPTION
### What does it do?

Reverts a recent change for `ERC20_CREATE_GAS_LIMIT`, the value was changed in https://github.com/moonbeam-foundation/moonbeam/pull/3166, which broke the some benchmarks.