### PR TITLE
Test :test_tube:: add gas/weight tests for Foreign Assets calls

### DIFF
--- a/test/suites/dev/moonbase/test-assets/test-foreign-assets-costs.ts
+++ b/test/suites/dev/moonbase/test-assets/test-foreign-assets-costs.ts
@@ -19,23 +19,12 @@ describeSuite({
   id: "D010111",
   title: "XCM - Costs of managing foreign assets",
   foundationMethods: "dev",
-  testCases: ({ context, it, log }) => {
-    let address: string;
+  testCases: ({ context, it }) => {
     let assetId: bigint;
     let assetLocation = RELAY_SOURCE_LOCATION_V4;
     let xcmLoc = patchLocationV4recursively(assetLocation);
     let decimals = 18;
 
-    beforeAll(async () => {
-    });
-
-    // Cases
-    // 1. Cost of creating an asset
-    // 2. Cost of changing an asset's location
-    // 3. Cost of freezing an asset
-    // 4. Cost of unfreezing an asset
-    // 6. Size of the created contract
-    // 7. Cost of sending an asset
     it({
         id: "T01",
         "title": "Cost of creating an asset",
@@ -47,8 +36,8 @@ describeSuite({
 
             const { weight, proofSize } = await calculateWeight(context, createAsset);
 
-            expect(weight).toMatchInlineSnapshot(`6287470000`);
-            expect(proofSize).toMatchInlineSnapshot(`3284782`);
+            expect(weight).toMatchInlineSnapshot(`2435166000`);
+            expect(proofSize).toMatchInlineSnapshot(`14519`);
         }
     })
 
@@ -63,8 +52,8 @@ describeSuite({
 
             const { weight, proofSize } = await calculateWeight(context, changeLocation);
 
-            expect(weight).toMatchInlineSnapshot(`479200000`);
-            expect(proofSize).toMatchInlineSnapshot(`9906`);
+            expect(weight).toMatchInlineSnapshot(`443464000`);
+            expect(proofSize).toMatchInlineSnapshot(`7594`);
         }
     })
 
@@ -79,8 +68,8 @@ describeSuite({
 
             const { weight, proofSize } = await calculateWeight(context, freezeAsset);
 
-            expect(weight).toMatchInlineSnapshot(`4945940000`);
-            expect(proofSize).toMatchInlineSnapshot(`3302014`);
+            expect(weight).toMatchInlineSnapshot(`1279934000`);
+            expect(proofSize).toMatchInlineSnapshot(`31612`);
         }
     })
 
@@ -95,8 +84,8 @@ describeSuite({
 
             const { weight, proofSize } = await calculateWeight(context, unfreezeAsset);
 
-            expect(weight).toMatchInlineSnapshot(`4945940000`);
-            expect(proofSize).toMatchInlineSnapshot(`3302014`);
+            expect(weight).toMatchInlineSnapshot(`1279934000`);
+            expect(proofSize).toMatchInlineSnapshot(`31612`);
         }
     })
 
@@ -109,7 +98,7 @@ describeSuite({
             const assetId = 1n;
 
             // Register the asset
-            const {contractAddress, registeredAssetId } = await registerForeignAsset(context, assetId, assetLocation, relayAssetMetadata);
+            const {contractAddress} = await registerForeignAsset(context, assetId, assetLocation, relayAssetMetadata);
             // Mock asset balance
             await mockAssetBalance(context, someBalance, assetId, alith, ALITH_ADDRESS);
 

--- a/test/suites/dev/moonbase/test-assets/test-foreign-assets-costs.ts
+++ b/test/suites/dev/moonbase/test-assets/test-foreign-assets-costs.ts
@@ -1,0 +1,152 @@
+import "@moonbeam-network/api-augment";
+import "@moonbeam-network/api-augment/moonbase";
+import { describeSuite, expect, beforeAll, fetchCompiledContract } from "@moonwall/cli";
+import {
+  ARBITRARY_ASSET_ID,
+  PARA_1000_SOURCE_LOCATION_V4,
+  RELAY_SOURCE_LOCATION_V4,
+  foreignAssetBalance,
+  mockAssetBalance,
+  patchLocationV4recursively,
+  registerForeignAsset,
+  relayAssetMetadata,
+} from "../../../../helpers";
+import { parseAbi } from "viem";
+import exp from "constants";
+import { alith, ALITH_ADDRESS, BALTATHAR_ADDRESS } from "@moonwall/util";
+
+describeSuite({
+  id: "D010111",
+  title: "XCM - Costs of managing foreign assets",
+  foundationMethods: "dev",
+  testCases: ({ context, it, log }) => {
+    let address: string;
+    let assetId: bigint;
+    let assetLocation = RELAY_SOURCE_LOCATION_V4;
+    let xcmLoc = patchLocationV4recursively(assetLocation);
+    let decimals = 18;
+
+    beforeAll(async () => {
+    });
+
+    // Cases
+    // 1. Cost of creating an asset
+    // 2. Cost of changing an asset's location
+    // 3. Cost of freezing an asset
+    // 4. Cost of unfreezing an asset
+    // 6. Size of the created contract
+    // 7. Cost of sending an asset
+    it({
+        id: "T01",
+        "title": "Cost of creating an asset",
+        test: async function () {
+
+            const createAsset = context.polkadotJs().tx.sudo.sudo(
+                context.polkadotJs().tx.evmForeignAssets.createForeignAsset(assetId, xcmLoc, decimals, "test", "test")
+            );
+
+            const { weight, proofSize } = await calculateWeight(context, createAsset);
+
+            expect(weight).toMatchInlineSnapshot(`6287470000`);
+            expect(proofSize).toMatchInlineSnapshot(`3284782`);
+        }
+    })
+
+    it({
+        id: "T01",
+        "title": "Cost of changing an asset location",
+        test: async function () {
+
+            const changeLocation = context.polkadotJs().tx.sudo.sudo(
+                context.polkadotJs().tx.evmForeignAssets.changeXcmLocation(assetId, xcmLoc)
+            );
+
+            const { weight, proofSize } = await calculateWeight(context, changeLocation);
+
+            expect(weight).toMatchInlineSnapshot(`479200000`);
+            expect(proofSize).toMatchInlineSnapshot(`9906`);
+        }
+    })
+
+    it({
+        id: "T01",
+        "title": "Cost of freezing an asset",
+        test: async function () {
+
+            const freezeAsset = context.polkadotJs().tx.sudo.sudo(
+                context.polkadotJs().tx.evmForeignAssets.freezeForeignAsset(assetId, false)
+            );
+
+            const { weight, proofSize } = await calculateWeight(context, freezeAsset);
+
+            expect(weight).toMatchInlineSnapshot(`4945940000`);
+            expect(proofSize).toMatchInlineSnapshot(`3302014`);
+        }
+    })
+
+    it({
+        id: "T01",
+        "title": "Cost of unfreezing an asset",
+        test: async function () {
+
+            const unfreezeAsset = context.polkadotJs().tx.sudo.sudo(
+                context.polkadotJs().tx.evmForeignAssets.freezeForeignAsset(assetId, true)
+            );
+
+            const { weight, proofSize } = await calculateWeight(context, unfreezeAsset);
+
+            expect(weight).toMatchInlineSnapshot(`4945940000`);
+            expect(proofSize).toMatchInlineSnapshot(`3302014`);
+        }
+    })
+
+    it({
+        id: "T01",
+        "title": "Size of the created contract",
+        test: async function () {
+            const someBalance = 100_000_000_000_000n;
+            const assetLocation = RELAY_SOURCE_LOCATION_V4;
+            const assetId = 1n;
+
+            // Register the asset
+            const {contractAddress, registeredAssetId } = await registerForeignAsset(context, assetId, assetLocation, relayAssetMetadata);
+            // Mock asset balance
+            await mockAssetBalance(context, someBalance, assetId, alith, ALITH_ADDRESS);
+
+            const newBalance = await foreignAssetBalance(context, assetId, ALITH_ADDRESS);
+            expect(newBalance).toBe(someBalance);
+
+
+            const { request } = await context.viem().simulateContract({
+                address: contractAddress as `0x${string}`,
+                abi: fetchCompiledContract("ERC20Instance").abi,
+                functionName: "transfer",
+                args: [BALTATHAR_ADDRESS, someBalance / 2n],
+            });
+
+            const hash = await context.viem().writeContract(request);
+
+            await context.createBlock();
+
+            const receipt = await context.viem().getTransactionReceipt({hash});
+
+            console.log(receipt);
+
+            expect(receipt.status).toBe('success');
+            expect(receipt.gasUsed).toMatchInlineSnapshot(`154976n`);
+
+            const transferredBalance = await foreignAssetBalance(context, assetId, BALTATHAR_ADDRESS);
+            expect(transferredBalance).toBe(someBalance / 2n);
+
+        }
+    })
+  },
+});
+
+async function calculateWeight(context, transaction) {
+    const info = await context.polkadotJs().call.transactionPaymentApi.queryInfo(transaction.toU8a(), transaction.encodedLength);
+    return {
+        weight: info.weight.refTime,
+        proofSize: info.weight.proofSize
+    }
+}


### PR DESCRIPTION
### What does it do?

This PR adds tests for checking weight and gas costs associated with creating and interacting with Foreign Assets. On the Substrate side it checks the weights for creation, freeze, unfreeze and changing the XCM location. On the EVM side it just checks gas costs associated with a simple transfer.

### What important points should reviewers know?

The key aspect of these tests is checking that the costs are not over the block limits and seem reasonable. This comes after detecting an issue in the benchmarks for these calls that caused much higher weights than the actual used storage and compute time.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
