### PR TITLE
runtime 3600 bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Docker images are published for every tagged release. Learn more with `moonbeam 
 
 ```bash
 # Join the public testnet
-docker run --network="host" moonbeamfoundation/moonbeam:v0.42.1 --chain alphanet
+docker run --network="host" moonbeamfoundation/moonbeam:v0.43.0 --chain alphanet
 ```
 
 You can find more detailed instructions to [run a full node in our TestNet](https://docs.moonbeam.network/node-operators/networks/run-a-node/overview/)
@@ -28,7 +28,7 @@ locally. You can quickly set up a single node without a relay chain backing it u
 
 ```bash
 # Run a dev service node
-docker run --network="host" moonbeamfoundation/moonbeam:v0.42.1 --dev
+docker run --network="host" moonbeamfoundation/moonbeam:v0.43.0 --dev
 ```
 
 For more information, see our detailed instructions to [run a development node](https://docs.moonbeam.network/builders/get-started/networks/moonbeam-dev/)
@@ -39,10 +39,10 @@ The above command will start the node in instant seal mode. It creates a block w
 
 ```bash
 # Author a block every 6 seconds.
-docker run --network="host" moonbeamfoundation/moonbeam:v0.42.1 --dev --sealing 6000
+docker run --network="host" moonbeamfoundation/moonbeam:v0.43.0 --dev --sealing 6000
 
 # Manually control the block authorship and finality
-docker run --network="host" moonbeamfoundation/moonbeam:v0.42.1 --dev --sealing manual
+docker run --network="host" moonbeamfoundation/moonbeam:v0.43.0 --dev --sealing manual
 ```
 
 ### Prefunded Development Addresses

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -195,7 +195,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 4,
-	spec_version: 3500,
+	spec_version: 3600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -193,7 +193,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 3500,
+	spec_version: 3600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -198,7 +198,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 3500,
+	spec_version: 3600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
- **trigger checks**
- **Update the client docker image to moonbeamfoundation/moonbeam:v0.43.0**
- **Update runtime spec version to 3600**
