### PR TITLE
Fix foreign assets migration

### DIFF
--- a/pallets/moonbeam-foreign-assets/src/evm.rs
+++ b/pallets/moonbeam-foreign-assets/src/evm.rs
@@ -16,7 +16,7 @@
 
 use crate::{AssetId, Error, Pallet};
 use ethereum_types::{BigEndianHash, H160, H256, U256};
-use fp_evm::{ExitError, ExitReason, ExitSucceed};
+use fp_evm::{ExitReason, ExitSucceed};
 use frame_support::ensure;
 use frame_support::pallet_prelude::Weight;
 use pallet_evm::{GasWeightMapping, Runner};

--- a/pallets/moonbeam-foreign-assets/src/evm.rs
+++ b/pallets/moonbeam-foreign-assets/src/evm.rs
@@ -33,13 +33,13 @@ const ERC20_CALL_MAX_CALLDATA_SIZE: usize = 4 + 32 + 32; // selector + address +
 const ERC20_CREATE_MAX_CALLDATA_SIZE: usize = 16 * 1024; // 16Ko
 
 // Hardcoded gas limits (from manual binary search)
-const ERC20_CREATE_GAS_LIMIT: u64 = 3_410_000; // highest failure: 3_406_000
-pub(crate) const ERC20_BURN_FROM_GAS_LIMIT: u64 = 155_000; // highest failure: 154_000
-pub(crate) const ERC20_MINT_INTO_GAS_LIMIT: u64 = 155_000; // highest failure: 154_000
-const ERC20_PAUSE_GAS_LIMIT: u64 = 150_500; // highest failure: 150_500
-pub(crate) const ERC20_TRANSFER_GAS_LIMIT: u64 = 155_000; // highest failure: 154_000
-pub(crate) const ERC20_APPROVE_GAS_LIMIT: u64 = 154_000; // highest failure: 153_000
-const ERC20_UNPAUSE_GAS_LIMIT: u64 = 151_000; // highest failure: 149_500
+const ERC20_CREATE_GAS_LIMIT: u64 = 3_600_000; // highest failure: 3_600_000
+pub(crate) const ERC20_BURN_FROM_GAS_LIMIT: u64 = 160_000; // highest failure: 154_000
+pub(crate) const ERC20_MINT_INTO_GAS_LIMIT: u64 = 160_000; // highest failure: 154_000
+const ERC20_PAUSE_GAS_LIMIT: u64 = 160_000; // highest failure: 150_500
+pub(crate) const ERC20_TRANSFER_GAS_LIMIT: u64 = 160_000; // highest failure: 154_000
+pub(crate) const ERC20_APPROVE_GAS_LIMIT: u64 = 160_000; // highest failure: 153_000
+const ERC20_UNPAUSE_GAS_LIMIT: u64 = 160_000; // highest failure: 149_500
 
 #[derive(Debug)]
 pub enum EvmError {

--- a/pallets/moonbeam-foreign-assets/src/lib.rs
+++ b/pallets/moonbeam-foreign-assets/src/lib.rs
@@ -172,7 +172,6 @@ pub mod pallet {
 		AssetIdFiltered,
 		AssetNotFrozen,
 		CorruptedStorageOrphanLocation,
-		//Erc20ContractCallFail,
 		Erc20ContractCreationFail,
 		EvmCallPauseFail,
 		EvmCallUnpauseFail,

--- a/pallets/moonbeam-lazy-migrations/src/benchmarks.rs
+++ b/pallets/moonbeam-lazy-migrations/src/benchmarks.rs
@@ -21,6 +21,7 @@ use frame_support::traits::Currency;
 use frame_support::BoundedVec;
 use frame_system::RawOrigin;
 use pallet_asset_manager::AssetRegistrar;
+use sp_core::H160;
 use sp_core::{Get, U256};
 use sp_runtime::traits::StaticLookup;
 use sp_runtime::Saturating;
@@ -112,6 +113,7 @@ benchmarks! {
 		where
 		<T as pallet_assets::Config>::Balance: Into<U256>,
 		T::ForeignAssetType: Into<Option<Location>>,
+		<T as frame_system::Config>::AccountId: Into<H160> + From<H160>,
 	}
 	approve_assets_to_migrate {
 		let n in 1 .. 100u32;

--- a/pallets/moonbeam-lazy-migrations/src/foreign_asset.rs
+++ b/pallets/moonbeam-lazy-migrations/src/foreign_asset.rs
@@ -20,7 +20,7 @@ use super::*;
 use frame_support::sp_runtime::Saturating;
 use frame_support::traits::{fungibles::metadata::Inspect, ReservableCurrency};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use sp_core::U256;
+use sp_core::{H160, U256};
 
 #[derive(Debug, Encode, Decode, scale_info::TypeInfo, PartialEq, MaxEncodedLen)]
 pub enum ForeignAssetMigrationStatus {
@@ -47,6 +47,7 @@ impl<T: Config> Pallet<T>
 where
 	<T as pallet_assets::Config>::Balance: Into<U256>,
 	<T as pallet_asset_manager::Config>::ForeignAssetType: Into<Option<Location>>,
+	<T as frame_system::Config>::AccountId: Into<H160> + From<H160>,
 {
 	/// Start a foreign asset migration by freezing the asset and creating the SC with the moonbeam
 	/// foreign assets pallet.
@@ -139,14 +140,20 @@ where
 						_ => {}
 					};
 
-					MIGRATING_FOREIGN_ASSETS::using_once(&mut true, || {
-						pallet_moonbeam_foreign_assets::Pallet::<T>::mint_into(
-							info.asset_id,
-							who.clone(),
-							asset.balance.into(),
-						)
-					})
-					.map_err(|_| Error::<T>::MintFailed)?;
+					let zero_address = T::AccountId::from(H160::zero());
+					if who.clone() != zero_address {
+						MIGRATING_FOREIGN_ASSETS::using_once(&mut true, || {
+							pallet_moonbeam_foreign_assets::Pallet::<T>::mint_into(
+								info.asset_id,
+								who.clone(),
+								asset.balance.into(),
+							)
+						})
+						.map_err(|err| {
+							log::debug!("Error: {err:?}");
+							Error::<T>::MintFailed
+						})?;
+					}
 
 					info.remaining_balances = info.remaining_balances.saturating_sub(1);
 					Ok::<(), Error<T>>(())
@@ -155,6 +162,8 @@ where
 			Ok(())
 		})
 	}
+
+	pub(super) fn call_without_metadata() {}
 
 	pub(super) fn do_migrate_foreign_asset_approvals(limit: u32) -> DispatchResult {
 		ensure!(limit != 0, Error::<T>::LimitCannotBeZero);
@@ -171,14 +180,29 @@ where
 					<T as pallet_assets::Config>::Currency::unreserve(&owner, approval.deposit);
 
 					MIGRATING_FOREIGN_ASSETS::using_once(&mut true, || {
-						pallet_moonbeam_foreign_assets::Pallet::<T>::approve(
+						let address: H160 = owner.clone().into();
+
+						// Temporarily remove metadata
+						let meta = pallet_evm::AccountCodesMetadata::<T>::take(address.clone());
+
+						let result = pallet_moonbeam_foreign_assets::Pallet::<T>::approve(
 							info.asset_id,
 							owner.clone(),
 							beneficiary,
 							approval.amount.into(),
-						)
+						);
+
+						// Re-add metadata
+						if let Some(metadata) = meta {
+							pallet_evm::AccountCodesMetadata::<T>::insert(address, metadata);
+						}
+
+						result
 					})
-					.map_err(|_| Error::<T>::ApprovalFailed)?;
+					.map_err(|err| {
+						log::debug!("Error: {err:?}");
+						Error::<T>::ApprovalFailed
+					})?;
 
 					info.remaining_approvals = info.remaining_approvals.saturating_sub(1);
 					Ok::<(), Error<T>>(())

--- a/pallets/moonbeam-lazy-migrations/src/foreign_asset.rs
+++ b/pallets/moonbeam-lazy-migrations/src/foreign_asset.rs
@@ -163,8 +163,6 @@ where
 		})
 	}
 
-	pub(super) fn call_without_metadata() {}
-
 	pub(super) fn do_migrate_foreign_asset_approvals(limit: u32) -> DispatchResult {
 		ensure!(limit != 0, Error::<T>::LimitCannotBeZero);
 

--- a/pallets/moonbeam-lazy-migrations/src/lib.rs
+++ b/pallets/moonbeam-lazy-migrations/src/lib.rs
@@ -130,6 +130,7 @@ pub mod pallet {
 	where
 		<T as pallet_assets::Config>::Balance: Into<U256>,
 		<T as pallet_asset_manager::Config>::ForeignAssetType: Into<Option<Location>>,
+		<T as frame_system::Config>::AccountId: Into<H160> + From<H160>,
 	{
 		#[pallet::call_index(2)]
 		#[pallet::weight(Pallet::<T>::create_contract_metadata_weight(MAX_CONTRACT_CODE_SIZE))]

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-hrmp-transact-ethereum-12.ts
@@ -56,7 +56,7 @@ describeSuite({
 
         const amountToTransfer = transferredBalance / 10n;
 
-        const GAS_LIMIT = 500_000;
+        const GAS_LIMIT = 500_000n;
 
         // We will put a very high gas limit. However, the weight accounted
         // for the block should only
@@ -82,13 +82,7 @@ describeSuite({
         let expectedTransferredAmount = 0n;
         let expectedTransferredAmountPlusFees = 0n;
 
-        // Just to make sure lazy state trie migration is done
-        // probably not needed after migration is done
-        for (let i = 0; i < 10; i++) {
-          await context.createBlock();
-        }
-
-        const targetXcmWeight = 500_000n * 25000n + STORAGE_READ_COST + 4_250_000_000n;
+        const targetXcmWeight = GAS_LIMIT * 25000n + STORAGE_READ_COST + 4_250_000_000n;
         const targetXcmFee = targetXcmWeight * 50_000n;
 
         for (const xcmTransaction of xcmTransactions) {
@@ -114,7 +108,7 @@ describeSuite({
             ],
             weight_limit: {
               refTime: targetXcmWeight,
-              proofSize: (GAS_LIMIT / GAS_LIMIT_POV_RATIO) * 2,
+              proofSize: (Number(GAS_LIMIT) / GAS_LIMIT_POV_RATIO) * 2,
             } as any,
             descend_origin: sendingAddress,
           })
@@ -126,8 +120,8 @@ describeSuite({
                 originKind: "SovereignAccount",
                 // 500_000 gas limit + db read (41_742_000)
                 requireWeightAtMost: {
-                  refTime: 12_525_000_000n + STORAGE_READ_COST,
-                  proofSize: GAS_LIMIT / GAS_LIMIT_POV_RATIO,
+                  refTime: 12_500_000_000n + STORAGE_READ_COST,
+                  proofSize: Number(GAS_LIMIT) / GAS_LIMIT_POV_RATIO,
                 },
                 call: {
                   encoded: transferCallEncoded,
@@ -149,7 +143,7 @@ describeSuite({
           expect(testAccountBalance).to.eq(expectedTransferredAmount);
 
           // Make sure ALITH has been deducted fees once (in xcm-executor) and balance has been
-          // transfered through evm.
+          // transferred through evm.
           const alithAccountBalance = await context.viem().getBalance({ address: descendAddress });
           expect(BigInt(alithAccountBalance)).to.eq(
             transferredBalance - expectedTransferredAmountPlusFees


### PR DESCRIPTION
### What does it do?

Fixes the foreign assets migration.

The fix has been dry-run on the following networks:

- [x] Moonbase Alpha
- [x] Moonriver
- [ ] Moonbeam (90%)

### What is being fixed?

- When migrating approvals, some calls require calling the contract with the `approval owner (a smart-contract in this case)` origin, which is not allowed, only EOA can perform external calls. In the case of this migration this must be allowed.

- The mint fails because in some situations, the target address is the burn address (0x0000...). In this scenarios, the migration should skip the minting.

- The gas limit provided when creating the erc-20 was not big enough.