### PR TITLE
Bump year in copyrights to 2025 :tada: 

### DIFF
--- a/bin/utils/moonkey/src/main.rs
+++ b/bin/utils/moonkey/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/formatters/blockscout.rs
+++ b/client/evm-tracing/src/formatters/blockscout.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/client/evm-tracing/src/formatters/call_tracer.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/formatters/mod.rs
+++ b/client/evm-tracing/src/formatters/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/formatters/raw.rs
+++ b/client/evm-tracing/src/formatters/raw.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/formatters/trace_filter.rs
+++ b/client/evm-tracing/src/formatters/trace_filter.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/lib.rs
+++ b/client/evm-tracing/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/listeners/call_list.rs
+++ b/client/evm-tracing/src/listeners/call_list.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/listeners/mod.rs
+++ b/client/evm-tracing/src/listeners/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/listeners/raw.rs
+++ b/client/evm-tracing/src/listeners/raw.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/types/block.rs
+++ b/client/evm-tracing/src/types/block.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/types/mod.rs
+++ b/client/evm-tracing/src/types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/types/serialization.rs
+++ b/client/evm-tracing/src/types/serialization.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/evm-tracing/src/types/single.rs
+++ b/client/evm-tracing/src/types/single.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/debug/src/lib.rs
+++ b/client/rpc-core/debug/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/trace/src/lib.rs
+++ b/client/rpc-core/trace/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/txpool/src/lib.rs
+++ b/client/rpc-core/txpool/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/txpool/src/types/content.rs
+++ b/client/rpc-core/txpool/src/types/content.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/txpool/src/types/inspect.rs
+++ b/client/rpc-core/txpool/src/types/inspect.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/txpool/src/types/mod.rs
+++ b/client/rpc-core/txpool/src/types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/types/src/lib.rs
+++ b/client/rpc-core/types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc..
+// Copyright 2019-2025 PureStake Inc..
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc/dev/src/lib.rs
+++ b/client/rpc/dev/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc/finality/src/lib.rs
+++ b/client/rpc/finality/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc/txpool/src/lib.rs
+++ b/client/rpc/txpool/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/vrf/src/lib.rs
+++ b/client/vrf/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/core-primitives/src/lib.rs
+++ b/core-primitives/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/cli-opt/src/account_key.rs
+++ b/node/cli-opt/src/account_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/chain_spec/fake_spec.rs
+++ b/node/service/src/chain_spec/fake_spec.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/chain_spec/mod.rs
+++ b/node/service/src/chain_spec/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/chain_spec/test_spec.rs
+++ b/node/service/src/chain_spec/test_spec.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/client.rs
+++ b/node/service/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/service/src/rpc/tracing.rs
+++ b/node/service/src/rpc/tracing.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/asset-manager/src/benchmarks.rs
+++ b/pallets/asset-manager/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/asset-manager/src/migrations.rs
+++ b/pallets/asset-manager/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/asset-manager/src/weights.rs
+++ b/pallets/asset-manager/src/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/erc20-xcm-bridge/src/erc20_matcher.rs
+++ b/pallets/erc20-xcm-bridge/src/erc20_matcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/erc20-xcm-bridge/src/erc20_trap.rs
+++ b/pallets/erc20-xcm-bridge/src/erc20_trap.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/erc20-xcm-bridge/src/errors.rs
+++ b/pallets/erc20-xcm-bridge/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/erc20-xcm-bridge/src/lib.rs
+++ b/pallets/erc20-xcm-bridge/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/erc20-xcm-bridge/src/mock.rs
+++ b/pallets/erc20-xcm-bridge/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/erc20-xcm-bridge/src/tests.rs
+++ b/pallets/erc20-xcm-bridge/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/erc20-xcm-bridge/src/xcm_holding_ext.rs
+++ b/pallets/erc20-xcm-bridge/src/xcm_holding_ext.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/lib.rs
+++ b/pallets/ethereum-xcm/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/mock.rs
+++ b/pallets/ethereum-xcm/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/tests/mod.rs
+++ b/pallets/ethereum-xcm/src/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/tests/v1.rs
+++ b/pallets/ethereum-xcm/src/tests/v1.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/tests/v1/legacy.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/legacy.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-xcm/src/tests/v2.rs
+++ b/pallets/ethereum-xcm/src/tests/v2.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-foreign-assets/build.rs
+++ b/pallets/moonbeam-foreign-assets/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-foreign-assets/src/benchmarks.rs
+++ b/pallets/moonbeam-foreign-assets/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-foreign-assets/src/evm.rs
+++ b/pallets/moonbeam-foreign-assets/src/evm.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-foreign-assets/src/lib.rs
+++ b/pallets/moonbeam-foreign-assets/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-foreign-assets/src/mock.rs
+++ b/pallets/moonbeam-foreign-assets/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-foreign-assets/src/tests.rs
+++ b/pallets/moonbeam-foreign-assets/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-foreign-assets/src/weights.rs
+++ b/pallets/moonbeam-foreign-assets/src/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-lazy-migrations/src/benchmarks.rs
+++ b/pallets/moonbeam-lazy-migrations/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-orbiters/src/benchmarks.rs
+++ b/pallets/moonbeam-orbiters/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-orbiters/src/mock.rs
+++ b/pallets/moonbeam-orbiters/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-orbiters/src/tests.rs
+++ b/pallets/moonbeam-orbiters/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-orbiters/src/types.rs
+++ b/pallets/moonbeam-orbiters/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-orbiters/src/weights.rs
+++ b/pallets/moonbeam-orbiters/src/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/generic/benchmarking.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/generic/mock.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/generic/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/generic/mod.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/generic/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/lib.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/mock.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/weights/fungible.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/weights/fungible.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/weights/generic.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/weights/generic.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/auto_compound.rs
+++ b/pallets/parachain-staking/src/auto_compound.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/precompile-benchmarks/src/benchmarks.rs
+++ b/pallets/precompile-benchmarks/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/precompile-benchmarks/src/lib.rs
+++ b/pallets/precompile-benchmarks/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/precompile-benchmarks/src/mock.rs
+++ b/pallets/precompile-benchmarks/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/precompile-benchmarks/src/weights.rs
+++ b/pallets/precompile-benchmarks/src/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/proxy-genesis-companion/src/lib.rs
+++ b/pallets/proxy-genesis-companion/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/proxy-genesis-companion/src/mock.rs
+++ b/pallets/proxy-genesis-companion/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/proxy-genesis-companion/src/tests.rs
+++ b/pallets/proxy-genesis-companion/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/benchmarks.rs
+++ b/pallets/xcm-transactor/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/encode.rs
+++ b/pallets/xcm-transactor/src/encode.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/migrations.rs
+++ b/pallets/xcm-transactor/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/relay_indices.rs
+++ b/pallets/xcm-transactor/src/relay_indices.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/weights.rs
+++ b/pallets/xcm-transactor/src/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/assets-erc20/src/eip2612.rs
+++ b/precompiles/assets-erc20/src/eip2612.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/author-mapping/src/mock.rs
+++ b/precompiles/author-mapping/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/batch/src/lib.rs
+++ b/precompiles/batch/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/call-permit/src/tests.rs
+++ b/precompiles/call-permit/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/collective/src/lib.rs
+++ b/precompiles/collective/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/collective/src/mock.rs
+++ b/precompiles/collective/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/collective/src/tests.rs
+++ b/precompiles/collective/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/conviction-voting/src/mock.rs
+++ b/precompiles/conviction-voting/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/conviction-voting/src/tests.rs
+++ b/precompiles/conviction-voting/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/crowdloan-rewards/src/tests.rs
+++ b/precompiles/crowdloan-rewards/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/foreign-asset-migrator/src/lib.rs
+++ b/precompiles/foreign-asset-migrator/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/gmp/src/lib.rs
+++ b/precompiles/gmp/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/gmp/src/mock.rs
+++ b/precompiles/gmp/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/gmp/src/tests.rs
+++ b/precompiles/gmp/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/gmp/src/types.rs
+++ b/precompiles/gmp/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/identity/src/lib.rs
+++ b/precompiles/identity/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/identity/src/mock.rs
+++ b/precompiles/identity/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/identity/src/tests.rs
+++ b/precompiles/identity/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/p256verify/src/lib.rs
+++ b/precompiles/p256verify/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/precompile-registry/src/lib.rs
+++ b/precompiles/precompile-registry/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/precompile-registry/src/mock.rs
+++ b/precompiles/precompile-registry/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/precompile-registry/src/tests.rs
+++ b/precompiles/precompile-registry/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/preimage/src/lib.rs
+++ b/precompiles/preimage/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/preimage/src/mock.rs
+++ b/precompiles/preimage/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/preimage/src/tests.rs
+++ b/precompiles/preimage/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/proxy/src/tests.rs
+++ b/precompiles/proxy/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/randomness/src/mock.rs
+++ b/precompiles/randomness/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/randomness/src/solidity_types.rs
+++ b/precompiles/randomness/src/solidity_types.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/randomness/src/tests.rs
+++ b/precompiles/randomness/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/referenda/src/mock.rs
+++ b/precompiles/referenda/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/referenda/src/tests.rs
+++ b/precompiles/referenda/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-data-verifier/src/lib.rs
+++ b/precompiles/relay-data-verifier/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-data-verifier/src/mock.rs
+++ b/precompiles/relay-data-verifier/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-data-verifier/src/tests.rs
+++ b/precompiles/relay-data-verifier/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-data-verifier/src/weights.rs
+++ b/precompiles/relay-data-verifier/src/weights.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-encoder/src/mock.rs
+++ b/precompiles/relay-encoder/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/relay-encoder/src/tests.rs
+++ b/precompiles/relay-encoder/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-transactor/src/functions.rs
+++ b/precompiles/xcm-transactor/src/functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-transactor/src/lib.rs
+++ b/precompiles/xcm-transactor/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-transactor/src/tests.rs
+++ b/precompiles/xcm-transactor/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-transactor/src/v1/mod.rs
+++ b/precompiles/xcm-transactor/src/v1/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-transactor/src/v2/mod.rs
+++ b/precompiles/xcm-transactor/src/v2/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-transactor/src/v3/mod.rs
+++ b/precompiles/xcm-transactor/src/v3/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-utils/src/lib.rs
+++ b/precompiles/xcm-utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-utils/src/mock.rs
+++ b/precompiles/xcm-utils/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xcm-utils/src/tests.rs
+++ b/precompiles/xcm-utils/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xtokens/src/mock.rs
+++ b/precompiles/xtokens/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/precompiles/xtokens/src/tests.rs
+++ b/precompiles/xtokens/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/ext/src/lib.rs
+++ b/primitives/ext/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/rpc/evm-tracing-events/src/evm.rs
+++ b/primitives/rpc/evm-tracing-events/src/evm.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/rpc/evm-tracing-events/src/gasometer.rs
+++ b/primitives/rpc/evm-tracing-events/src/gasometer.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/rpc/evm-tracing-events/src/lib.rs
+++ b/primitives/rpc/evm-tracing-events/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/rpc/evm-tracing-events/src/runtime.rs
+++ b/primitives/rpc/evm-tracing-events/src/runtime.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/rpc/txpool/src/lib.rs
+++ b/primitives/rpc/txpool/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/storage-proof/src/lib.rs
+++ b/primitives/storage-proof/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/storage-proof/src/tests.rs
+++ b/primitives/storage-proof/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/xcm/src/asset_id_conversions.rs
+++ b/primitives/xcm/src/asset_id_conversions.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/xcm/src/constants.rs
+++ b/primitives/xcm/src/constants.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/xcm/src/filter_asset_max_fee.rs
+++ b/primitives/xcm/src/filter_asset_max_fee.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/xcm/src/origin_conversion.rs
+++ b/primitives/xcm/src/origin_conversion.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/xcm/src/transactor_traits.rs
+++ b/primitives/xcm/src/transactor_traits.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/benchmarking.rs
+++ b/runtime/common/src/benchmarking.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/impl_moonbeam_xcm_call.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/impl_on_charge_evm_transaction.rs
+++ b/runtime/common/src/impl_on_charge_evm_transaction.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/impl_self_contained_call.rs
+++ b/runtime/common/src/impl_self_contained_call.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/impl_xcm_evm_runner.rs
+++ b/runtime/common/src/impl_xcm_evm_runner.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/timestamp.rs
+++ b/runtime/common/src/timestamp.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/types.rs
+++ b/runtime/common/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/evm_tracer/src/lib.rs
+++ b/runtime/evm_tracer/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/build.rs
+++ b/runtime/moonbase/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/asset_config.rs
+++ b/runtime/moonbase/src/asset_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/genesis_config_preset.rs
+++ b/runtime/moonbase/src/genesis_config_preset.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/governance/councils.rs
+++ b/runtime/moonbase/src/governance/councils.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/governance/mod.rs
+++ b/runtime/moonbase/src/governance/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/governance/origins.rs
+++ b/runtime/moonbase/src/governance/origins.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/governance/referenda.rs
+++ b/runtime/moonbase/src/governance/referenda.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/migrations.rs
+++ b/runtime/moonbase/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation Inc.
+// Copyright 2025 Moonbeam Foundation.Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/runtime_params.rs
+++ b/runtime/moonbase/src/runtime_params.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/weights/mod.rs
+++ b/runtime/moonbase/src/weights/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/weights/pallet_collective.rs
+++ b/runtime/moonbase/src/weights/pallet_collective.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/tests/evm_tracing.rs
+++ b/runtime/moonbase/tests/evm_tracing.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/tests/runtime_apis.rs
+++ b/runtime/moonbase/tests/runtime_apis.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/build.rs
+++ b/runtime/moonbeam/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/genesis_config_preset.rs
+++ b/runtime/moonbeam/src/genesis_config_preset.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/governance/councils.rs
+++ b/runtime/moonbeam/src/governance/councils.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/governance/mod.rs
+++ b/runtime/moonbeam/src/governance/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/governance/origins.rs
+++ b/runtime/moonbeam/src/governance/origins.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/governance/referenda.rs
+++ b/runtime/moonbeam/src/governance/referenda.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/migrations.rs
+++ b/runtime/moonbeam/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation Inc.
+// Copyright 2025 Moonbeam Foundation.Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/runtime_params.rs
+++ b/runtime/moonbeam/src/runtime_params.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/weights/mod.rs
+++ b/runtime/moonbeam/src/weights/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/weights/pallet_collective.rs
+++ b/runtime/moonbeam/src/weights/pallet_collective.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/tests/evm_tracing.rs
+++ b/runtime/moonbeam/tests/evm_tracing.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/tests/runtime_apis.rs
+++ b/runtime/moonbeam/tests/runtime_apis.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/build.rs
+++ b/runtime/moonriver/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/asset_config.rs
+++ b/runtime/moonriver/src/asset_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/genesis_config_preset.rs
+++ b/runtime/moonriver/src/genesis_config_preset.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/governance/councils.rs
+++ b/runtime/moonriver/src/governance/councils.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/governance/mod.rs
+++ b/runtime/moonriver/src/governance/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/governance/origins.rs
+++ b/runtime/moonriver/src/governance/origins.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/governance/referenda.rs
+++ b/runtime/moonriver/src/governance/referenda.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/migrations.rs
+++ b/runtime/moonriver/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation Inc.
+// Copyright 2025 Moonbeam Foundation.Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/runtime_params.rs
+++ b/runtime/moonriver/src/runtime_params.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Moonbeam Foundation.
+// Copyright 2025 Moonbeam Foundation.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/weights/mod.rs
+++ b/runtime/moonriver/src/weights/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/weights/pallet_collective.rs
+++ b/runtime/moonriver/src/weights/pallet_collective.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/tests/evm_tracing.rs
+++ b/runtime/moonriver/tests/evm_tracing.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/tests/runtime_apis.rs
+++ b/runtime/moonriver/tests/runtime_apis.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/relay-encoder/src/lib.rs
+++ b/runtime/relay-encoder/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/summarize-precompile-checks/src/main.rs
+++ b/runtime/summarize-precompile-checks/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 PureStake Inc.
+// Copyright 2019-2025 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify


### PR DESCRIPTION
### What does it do?

Bump the year in the copyright text in all files to 2025.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
