### PR TITLE
Default to new block import strategy

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -154,10 +154,9 @@ pub struct RunCmd {
 	#[clap(long)]
 	pub dev_service: bool,
 
-	/// Enable the new block import strategy
-	/// Deprecated in: https://github.com/Moonsong-Labs/moonkit/pull/43
+	/// Enable the legacy block import strategy
 	#[clap(long)]
-	pub experimental_block_import_strategy: bool,
+	pub legacy_block_import_strategy: bool,
 
 	/// Specifies the URL used to fetch chain data via RPC.
 	///

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -271,7 +271,7 @@ pub fn run() -> Result<()> {
 				let (client, _, import_queue, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.experimental_block_import_strategy,
+					cli.run.legacy_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
@@ -283,7 +283,7 @@ pub fn run() -> Result<()> {
 				let (client, _, _, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.experimental_block_import_strategy,
+					cli.run.legacy_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
@@ -295,7 +295,7 @@ pub fn run() -> Result<()> {
 				let (client, _, _, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.experimental_block_import_strategy,
+					cli.run.legacy_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
@@ -307,7 +307,7 @@ pub fn run() -> Result<()> {
 				let (client, _, import_queue, task_manager) = moonbeam_service::new_chain_ops(
 					&mut config,
 					&rpc_config,
-					cli.run.experimental_block_import_strategy,
+					cli.run.legacy_block_import_strategy,
 				)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
@@ -372,7 +372,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)?;
 
 					Ok((
@@ -389,7 +389,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)?;
 
 					Ok((
@@ -406,7 +406,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)?;
 
 					Ok((
@@ -558,7 +558,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.experimental_block_import_strategy,
+									cli.run.legacy_block_import_strategy,
 								)?;
 
 								cmd.run(params.client)
@@ -574,7 +574,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.experimental_block_import_strategy,
+									cli.run.legacy_block_import_strategy,
 								)?;
 
 								cmd.run(params.client)
@@ -590,7 +590,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.experimental_block_import_strategy,
+									cli.run.legacy_block_import_strategy,
 								)?;
 
 								cmd.run(params.client)
@@ -620,7 +620,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.experimental_block_import_strategy,
+									cli.run.legacy_block_import_strategy,
 								)?;
 
 								let db = params.backend.expose_db();
@@ -639,7 +639,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.experimental_block_import_strategy,
+									cli.run.legacy_block_import_strategy,
 								)?;
 
 								let db = params.backend.expose_db();
@@ -658,7 +658,7 @@ pub fn run() -> Result<()> {
 									&mut config,
 									&rpc_config,
 									false,
-									cli.run.experimental_block_import_strategy,
+									cli.run.legacy_block_import_strategy,
 								)?;
 
 								let db = params.backend.expose_db();
@@ -706,7 +706,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
@@ -724,7 +724,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
@@ -742,7 +742,7 @@ pub fn run() -> Result<()> {
 						&mut config,
 						&rpc_config,
 						false,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)?;
 
 					Ok((cmd.run(backend, config.chain_spec), task_manager))
@@ -930,7 +930,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)
 					.await
 					.map(|r| r.0)
@@ -948,7 +948,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)
 					.await
 					.map(|r| r.0)
@@ -966,7 +966,7 @@ pub fn run() -> Result<()> {
 						true,
 						cli.run.block_authoring_duration,
 						hwbench,
-						cli.run.experimental_block_import_strategy,
+						cli.run.legacy_block_import_strategy,
 					)
 					.await
 					.map(|r| r.0)


### PR DESCRIPTION
### What does it do?

This PR updates the CLI to default to the new block import strategy (blocks being considered best when imported) originally being optional via the `--experimental-block-import-strategy` parameter.

### ⚠️ Breaking Changes ⚠️

CLI no longer accepts `--experimental-block-import-strategy` parameter and is now replaced with `--legacy-block-import-strategy` for nodes who want to use the old block import strategy.