### PR TITLE
Add metaspan (IBP) boot node

### DIFF
--- a/specs/moonbeam/parachain-embedded-specs.json
+++ b/specs/moonbeam/parachain-embedded-specs.json
@@ -17,7 +17,9 @@
     "/dns/sa-01.unitedbloc.com/tcp/37060/p2p/12D3KooWC3FoL2bFJ79C5CeLDjLmL2yRyozPxSjTQbm9RY95KNsV",
     "/dns/na-01.unitedbloc.com/tcp/37060/p2p/12D3KooWLEZwHD8tWvWiEqKcD976wxdE5JRUnq1JG9a6VJxHUjiS",
     "/dns/moonbeam-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh",
-    "/dns/moonbeam-boot-ng.dwellir.com/tcp/30364/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh"
+    "/dns/moonbeam-boot-ng.dwellir.com/tcp/30364/p2p/12D3KooWSKaKdqWFhNK8XTBhqNUZL2LUTZNCgFt1iXRN2HfvoLsh",
+    "/dns/boot.metaspan.io/tcp/51143/p2p/12D3KooWQNKbTaWXMAFV24Ytgjy93ZXLVSM3sJSbf8LNKqu3yrUM",
+    "/dns/boot.metaspan.io/tcp/51146/wss/p2p/12D3KooWQNKbTaWXMAFV24Ytgjy93ZXLVSM3sJSbf8LNKqu3yrUM"
   ],
   "telemetryEndpoints": [
     ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]


### PR DESCRIPTION
### What does it do?
Adds a new boot node to the chain-spec

### What important points should reviewers know?
This has been tested internally:
```bash
./bin/moonbeam --tmp --chain ./chain-spec/moonbeam.json --bootnodes "/dns/boot.metaspan.io/tcp/51143/p2p/12D3KooWQNKbTaWXMAFV24Ytgjy93ZXLVSM3sJSbf8LNKqu3yrUM" --no-hardware-benchmarks --relay-chain-rpc-urls=ws://192.168.10.16:9944
# OK
./bin/moonbeam --tmp --chain ./chain-spec/moonbeam.json --bootnodes "/dns/boot.metaspan.io/tcp/51146/wss/p2p/12D3KooWQNKbTaWXMAFV24Ytgjy93ZXLVSM3sJSbf8LNKqu3yrUM" --no-hardware-benchmarks --relay-chain-rpc-urls=ws://192.168.10.16:9944
# OK
```

### Is there something left for follow-up PRs?
no

### What alternative implementations were considered?
n/a

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
no

### What value does it bring to the blockchain users?
enhanced decentralisation
