### PR TITLE
Disable genesis presets when building the wasm runtime files

### DIFF
--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -115,18 +115,27 @@ macro_rules! impl_runtime_apis_plus_common {
 				}
 			}
 
-			#[cfg(not(feature = "disable-genesis-builder"))]
 			impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
 				fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
 					frame_support::genesis_builder_helper::build_state::<RuntimeGenesisConfig>(config)
 				}
 
+				#[cfg(not(feature = "disable-genesis-builder"))]
 				fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
 					frame_support::genesis_builder_helper::get_preset::<RuntimeGenesisConfig>(id, genesis_config_preset::get_preset)
 				}
+				#[cfg(feature = "disable-genesis-builder")]
+				fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+					None
+				}
 
+				#[cfg(not(feature = "disable-genesis-builder"))]
 				fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
 					genesis_config_preset::preset_names()
+				}
+				#[cfg(feature = "disable-genesis-builder")]
+				fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
+					Default::default()
 				}
 			}
 

--- a/runtime/moonbase/build.rs
+++ b/runtime/moonbase/build.rs
@@ -16,7 +16,10 @@
 
 #[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		// Genesis presets increase the runtime side, we only want it enabled in the client
+		.enable_feature("disable-genesis-builder")
+		.build()
 }
 
 #[cfg(all(feature = "std", feature = "metadata-hash"))]

--- a/runtime/moonbase/build.rs
+++ b/runtime/moonbase/build.rs
@@ -14,23 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
-#[cfg(not(feature = "metadata-hash"))]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
 }
 
-#[cfg(feature = "metadata-hash")]
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
 		.enable_metadata_hash("DEV", 18)
+		// Genesis presets increase the runtime side, we only want it enabled in the client
+		.enable_feature("disable-genesis-builder")
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/runtime/moonbeam/build.rs
+++ b/runtime/moonbeam/build.rs
@@ -14,23 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
-#[cfg(not(feature = "metadata-hash"))]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
 }
 
-#[cfg(feature = "metadata-hash")]
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
 		.enable_metadata_hash("GLMR", 18)
+		// Genesis presets increase the runtime side, we only want it enabled in the client
+		.enable_feature("disable-genesis-builder")
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/runtime/moonbeam/build.rs
+++ b/runtime/moonbeam/build.rs
@@ -16,7 +16,10 @@
 
 #[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		// Genesis presets increase the runtime side, we only want it enabled in the client
+		.enable_feature("disable-genesis-builder")
+		.build()
 }
 
 #[cfg(all(feature = "std", feature = "metadata-hash"))]

--- a/runtime/moonriver/build.rs
+++ b/runtime/moonriver/build.rs
@@ -16,7 +16,10 @@
 
 #[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		// Genesis presets increase the runtime side, we only want it enabled in the client
+		.enable_feature("disable-genesis-builder")
+		.build()
 }
 
 #[cfg(all(feature = "std", feature = "metadata-hash"))]

--- a/runtime/moonriver/build.rs
+++ b/runtime/moonriver/build.rs
@@ -14,23 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
-#[cfg(not(feature = "metadata-hash"))]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
 }
 
-#[cfg(feature = "metadata-hash")]
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
 		.enable_metadata_hash("MOVR", 18)
+		// Genesis presets increase the runtime side, we only want it enabled in the client
+		.enable_feature("disable-genesis-builder")
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}


### PR DESCRIPTION
### What does it do?

Currently the `dev` runtimes are bloated with a dev `genesis preset`. It is only needed for the client, this PR disables it when generating wasm files. 

**Important to node:** Production runtimes never included this preset.