### PR TITLE
fix: eth-xcm transactions are not included in the ethereum blocks if EVM revert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,6 +8597,8 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "staging-xcm",
+ "staging-xcm-executor",
  "xcm-primitives 0.1.1",
 ]
 

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -504,6 +504,9 @@ where
 			Ok(moonbeam_rpc_primitives_debug::Response::Block)
 		};
 
+		// Offset to account for old buggy transactions that are in trace not in the ethereum block
+		let mut tx_position_offset = 0;
+
 		return match trace_type {
 			single::TraceType::CallList => {
 				let mut proxy = moonbeam_client_evm_tracing::listeners::CallList::default();
@@ -517,13 +520,18 @@ where
 								.ok_or("Trace result is empty.")
 								.map_err(|e| internal_err(format!("{:?}", e)))?
 								.into_iter()
-								.map(|mut trace| {
-									if let Some(transaction_hash) =
-										eth_transactions_by_index.get(&trace.tx_position)
+								.filter_map(|mut trace| {
+									if let Some(transaction_hash) = eth_transactions_by_index
+										.get(&(trace.tx_position + tx_position_offset))
 									{
 										trace.tx_hash = *transaction_hash;
+										Some(trace)
+									} else {
+										// If the transaction is not in the ethereum block
+										// it should not appear in the block trace
+										tx_position_offset += 1;
+										None
 									}
-									trace
 								})
 								.collect::<Vec<BlockTransactionTrace>>();
 

--- a/pallets/erc20-xcm-bridge/src/lib.rs
+++ b/pallets/erc20-xcm-bridge/src/lib.rs
@@ -171,20 +171,18 @@ pub mod pallet {
 				match erc20s_origins.drain(contract_address, amount) {
 					// We perform the evm transfers in a storage transaction to ensure that if one
 					// of them fails all the changes of the previous evm calls are rolled back.
-					Ok(tokens_to_transfer) => frame_support::storage::with_storage_layer(|| {
-						tokens_to_transfer
-							.into_iter()
-							.try_for_each(|(from, subamount)| {
-								Self::erc20_transfer(
-									contract_address,
-									from,
-									beneficiary,
-									subamount,
-									gas_limit,
-								)
-							})
-					})
-					.map_err(Into::into),
+					Ok(tokens_to_transfer) => tokens_to_transfer
+						.into_iter()
+						.try_for_each(|(from, subamount)| {
+							Self::erc20_transfer(
+								contract_address,
+								from,
+								beneficiary,
+								subamount,
+								gas_limit,
+							)
+						})
+						.map_err(Into::into),
 					Err(DrainError::AssetNotFound) => Err(XcmError::AssetNotFound),
 					Err(DrainError::NotEnoughFounds) => Err(XcmError::FailedToTransactAsset(
 						"not enough founds in xcm holding",
@@ -216,11 +214,7 @@ pub mod pallet {
 
 			let gas_limit = Self::gas_limit_of_erc20_transfer(&asset.id);
 
-			// We perform the evm transfers in a storage transaction to ensure that if it fail
-			// any contract storage changes are rolled back.
-			frame_support::storage::with_storage_layer(|| {
-				Self::erc20_transfer(contract_address, from, to, amount, gas_limit)
-			})?;
+			Self::erc20_transfer(contract_address, from, to, amount, gas_limit)?;
 
 			Ok(asset.clone().into())
 		}

--- a/pallets/ethereum-xcm/Cargo.toml
+++ b/pallets/ethereum-xcm/Cargo.toml
@@ -35,15 +35,18 @@ fp-evm = { workspace = true }
 fp-rpc = { workspace = true }
 fp-self-contained = { workspace = true }
 pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
+pallet-ethereum = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
 xcm-primitives = { workspace = true }
+
+# Polkadot
+xcm = { workspace = true }
+xcm-executor = { workspace = true }
 
 # Benchmarks
 frame-benchmarking = { workspace = true, optional = true }
 
 [dev-dependencies]
 pallet-evm-precompile-proxy = { workspace = true, features = [ "std" ] }
-
-pallet-ethereum = { workspace = true, features = [ "forbid-evm-reentrancy", "std" ] }
 pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy", "std" ] }
 pallet-proxy = { workspace = true, features = [ "std" ] }
 
@@ -68,6 +71,7 @@ std = [
 	# Substrate FRAME
 	"frame-support/std",
 	"frame-system/std",
+	"pallet-ethereum/std",
 	"pallet-evm/std",
 	"pallet-timestamp/std",
 	# Parity
@@ -81,6 +85,9 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"xcm-primitives/std",
+	# Polkadot
+	"xcm/std",
+	"xcm-executor/std",
 ]
 runtime-benchmarks = [ 
 	"frame-benchmarking", 
@@ -88,7 +95,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-evm/runtime-benchmarks", 
+	"pallet-ethereum/runtime-benchmarks",
 	"xcm-primitives/runtime-benchmarks",
-	"pallet-ethereum/runtime-benchmarks"
 ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/ethereum-xcm/src/lib.rs
+++ b/pallets/ethereum-xcm/src/lib.rs
@@ -26,6 +26,7 @@
 mod mock;
 #[cfg(all(feature = "std", test))]
 mod tests;
+mod transactional_processor;
 
 use ethereum_types::{H160, H256, U256};
 use fp_ethereum::{TransactionData, ValidatedTransaction};
@@ -42,6 +43,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{traits::UniqueSaturatedInto, DispatchErrorWithPostInfo, RuntimeDebug};
 use sp_std::{marker::PhantomData, prelude::*};
 
+pub use self::transactional_processor::XcmEthTransactionalProcessor;
 pub use ethereum::{
 	AccessListItem, BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt,
 	TransactionAction, TransactionV2 as Transaction,
@@ -372,8 +374,22 @@ impl<T: Config> Pallet<T> {
 			// transaction on chain - we increase the global nonce.
 			<Nonce<T>>::put(current_nonce.saturating_add(U256::one()));
 
-			let (dispatch_info, _) =
+			let (dispatch_info, execution_info) =
 				T::ValidatedTransaction::apply(source, transaction, maybe_force_create_address)?;
+
+			// If the transaction reverted, signal it to XCM Transactional Processor
+			match execution_info {
+				fp_evm::CallOrCreateInfo::Call(info) => {
+					if let fp_evm::ExitReason::Revert(_) = info.exit_reason {
+						XcmEthTransactionalProcessor::put_evm_revert();
+					}
+				}
+				fp_evm::CallOrCreateInfo::Create(info) => {
+					if let fp_evm::ExitReason::Revert(_) = info.exit_reason {
+						XcmEthTransactionalProcessor::put_evm_revert();
+					}
+				}
+			}
 
 			XCM_MESSAGE_HASH::with(|xcm_msg_hash| {
 				Self::deposit_event(Event::ExecutedFromXcm {

--- a/pallets/ethereum-xcm/src/lib.rs
+++ b/pallets/ethereum-xcm/src/lib.rs
@@ -381,12 +381,12 @@ impl<T: Config> Pallet<T> {
 			match execution_info {
 				fp_evm::CallOrCreateInfo::Call(info) => {
 					if let fp_evm::ExitReason::Revert(_) = info.exit_reason {
-						XcmEthTransactionalProcessor::put_evm_revert();
+						XcmEthTransactionalProcessor::signal_evm_revert();
 					}
 				}
 				fp_evm::CallOrCreateInfo::Create(info) => {
 					if let fp_evm::ExitReason::Revert(_) = info.exit_reason {
-						XcmEthTransactionalProcessor::put_evm_revert();
+						XcmEthTransactionalProcessor::signal_evm_revert();
 					}
 				}
 			}

--- a/pallets/ethereum-xcm/src/transactional_processor.rs
+++ b/pallets/ethereum-xcm/src/transactional_processor.rs
@@ -1,0 +1,63 @@
+// Copyright 2019-2025 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.$
+
+use frame_support::storage::{with_transaction, TransactionOutcome};
+use sp_runtime::DispatchError;
+use xcm::latest::prelude::*;
+use xcm_executor::traits::ProcessTransaction;
+
+environmental::environmental!(IS_EVM_REVERT: bool);
+
+/// Transactional processor implementation used by the XCM executor
+/// to execute each XCM instruction in a transactional way.
+///
+/// If an EthereumXCM transaction revert, the transaction should still
+/// be included in the "ethereum block storage".
+pub struct XcmEthTransactionalProcessor;
+
+impl XcmEthTransactionalProcessor {
+	pub fn put_evm_revert() {
+		IS_EVM_REVERT::with(|is_evm_revert| *is_evm_revert = true);
+	}
+}
+
+impl ProcessTransaction for XcmEthTransactionalProcessor {
+	const IS_TRANSACTIONAL: bool = true;
+
+	fn process<F>(f: F) -> Result<(), XcmError>
+	where
+		F: FnOnce() -> Result<(), XcmError>,
+	{
+		IS_EVM_REVERT::using(&mut false, || {
+			with_transaction(|| -> TransactionOutcome<Result<_, DispatchError>> {
+				let output = f();
+				match &output {
+					Ok(()) => TransactionOutcome::Commit(Ok(output)),
+					Err(xcm_error) => {
+						// If the XCM instruction failed from an EVM revert,
+						// we should not rollback storage change
+						if let Some(true) = IS_EVM_REVERT::with(|is_evm_revert| *is_evm_revert) {
+							TransactionOutcome::Commit(Ok(output))
+						} else {
+							TransactionOutcome::Rollback(Ok(Err(*xcm_error)))
+						}
+					}
+				}
+			})
+			.map_err(|_| XcmError::ExceedsStackLimit)?
+		})
+	}
+}

--- a/pallets/ethereum-xcm/src/transactional_processor.rs
+++ b/pallets/ethereum-xcm/src/transactional_processor.rs
@@ -24,8 +24,8 @@ environmental::environmental!(IS_EVM_REVERT: bool);
 /// Transactional processor implementation used by the XCM executor
 /// to execute each XCM instruction in a transactional way.
 ///
-/// If an EthereumXCM transaction revert, the transaction should still
-/// be included in the "ethereum block storage".
+/// Behave like FrameTransactionalProcessor except if the XCM instruction call the EVM AND the EVM Revert has occurred.
+/// In this case, the storage changes should be committed to include the eth-xcm transaction in the "ethereum block storage".
 pub struct XcmEthTransactionalProcessor;
 
 impl XcmEthTransactionalProcessor {
@@ -52,6 +52,8 @@ impl ProcessTransaction for XcmEthTransactionalProcessor {
 						if let Some(true) = IS_EVM_REVERT::with(|is_evm_revert| *is_evm_revert) {
 							TransactionOutcome::Commit(Ok(output))
 						} else {
+							// Otherwise, we should rollback storage changes
+							// to be consistent with FrameTransactionalProcessor
 							TransactionOutcome::Rollback(Ok(Err(*xcm_error)))
 						}
 					}

--- a/pallets/ethereum-xcm/src/transactional_processor.rs
+++ b/pallets/ethereum-xcm/src/transactional_processor.rs
@@ -29,7 +29,7 @@ environmental::environmental!(IS_EVM_REVERT: bool);
 pub struct XcmEthTransactionalProcessor;
 
 impl XcmEthTransactionalProcessor {
-	pub fn put_evm_revert() {
+	pub fn signal_evm_revert() {
 		IS_EVM_REVERT::with(|is_evm_revert| *is_evm_revert = true);
 	}
 }

--- a/pallets/moonbeam-foreign-assets/src/lib.rs
+++ b/pallets/moonbeam-foreign-assets/src/lib.rs
@@ -352,15 +352,11 @@ pub mod pallet {
 			beneficiary: T::AccountId,
 			amount: U256,
 		) -> Result<(), evm::EvmError> {
-			// We perform the evm call in a storage transaction to ensure that if it fail
-			// any contract storage changes are rolled back.
-			frame_support::storage::with_storage_layer(|| {
-				EvmCaller::<T>::erc20_mint_into(
-					Self::contract_address_from_asset_id(asset_id),
-					T::AccountIdToH160::convert(beneficiary),
-					amount,
-				)
-			})
+			EvmCaller::<T>::erc20_mint_into(
+				Self::contract_address_from_asset_id(asset_id),
+				T::AccountIdToH160::convert(beneficiary),
+				amount,
+			)
 			.map_err(Into::into)
 		}
 
@@ -371,8 +367,6 @@ pub mod pallet {
 			spender: T::AccountId,
 			amount: U256,
 		) -> Result<(), evm::EvmError> {
-			// We perform the evm call in a storage transaction to ensure that if it fail
-			// any contract storage changes are rolled back.
 			EvmCaller::<T>::erc20_approve(
 				Self::contract_address_from_asset_id(asset_id),
 				T::AccountIdToH160::convert(owner),
@@ -674,11 +668,7 @@ pub mod pallet {
 			let beneficiary = T::XcmLocationToH160::convert_location(who)
 				.ok_or(MatchError::AccountIdConversionFailed)?;
 
-			// We perform the evm transfers in a storage transaction to ensure that if it fail
-			// any contract storage changes are rolled back.
-			frame_support::storage::with_storage_layer(|| {
-				EvmCaller::<T>::erc20_mint_into(contract_address, beneficiary, amount)
-			})?;
+			EvmCaller::<T>::erc20_mint_into(contract_address, beneficiary, amount)?;
 
 			Ok(())
 		}
@@ -704,11 +694,7 @@ pub mod pallet {
 			let to = T::XcmLocationToH160::convert_location(to)
 				.ok_or(MatchError::AccountIdConversionFailed)?;
 
-			// We perform the evm transfers in a storage transaction to ensure that if it fail
-			// any contract storage changes are rolled back.
-			frame_support::storage::with_storage_layer(|| {
-				EvmCaller::<T>::erc20_transfer(contract_address, from, to, amount)
-			})?;
+			EvmCaller::<T>::erc20_transfer(contract_address, from, to, amount)?;
 
 			Ok(asset.clone().into())
 		}
@@ -736,11 +722,7 @@ pub mod pallet {
 				return Err(MatchError::AssetNotHandled.into());
 			}
 
-			// We perform the evm transfers in a storage transaction to ensure that if it fail
-			// any contract storage changes are rolled back.
-			frame_support::storage::with_storage_layer(|| {
-				EvmCaller::<T>::erc20_burn_from(contract_address, who, amount)
-			})?;
+			EvmCaller::<T>::erc20_burn_from(contract_address, who, amount)?;
 
 			Ok(what.clone().into())
 		}

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -308,7 +308,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type UniversalAliases = Nothing;
 	type SafeCallFilter = SafeCallFilter;
 	type Aliasers = Nothing;
-	type TransactionalProcessor = xcm_builder::FrameTransactionalProcessor;
+	type TransactionalProcessor = pallet_ethereum_xcm::XcmEthTransactionalProcessor;
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -297,7 +297,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type UniversalAliases = Nothing;
 	type SafeCallFilter = SafeCallFilter;
 	type Aliasers = Nothing;
-	type TransactionalProcessor = xcm_builder::FrameTransactionalProcessor;
+	type TransactionalProcessor = pallet_ethereum_xcm::XcmEthTransactionalProcessor;
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -305,7 +305,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type UniversalAliases = Nothing;
 	type SafeCallFilter = SafeCallFilter;
 	type Aliasers = Nothing;
-	type TransactionalProcessor = xcm_builder::FrameTransactionalProcessor;
+	type TransactionalProcessor = pallet_ethereum_xcm::XcmEthTransactionalProcessor;
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();

--- a/scripts/run-tracing-tests.sh
+++ b/scripts/run-tracing-tests.sh
@@ -1,12 +1,43 @@
 #!/bin/bash
 
-pnpm i
-
+# Default values
 BUILD_LAST_TRACING_RUNTIME="no"
+SKIP_AUGMENT_API="no"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -f|--force-rebuild)
+      BUILD_LAST_TRACING_RUNTIME="yes"
+      shift
+      ;;
+    -s|--skip-augment-api)
+      SKIP_AUGMENT_API="yes"
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: $0 [options]"
+      echo "Options:"
+      echo "  -f, --force-rebuild         Force rebuild of the tracing runtime"
+      echo "  -s, --skip-augment-api      Skip regenerating TypeScript API augmentations from runtime metadata"
+      echo "  -h, --help                  Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Use -h or --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+echo 'Make sure you have built moonbeam-types-bundle and run "npm install" in the test/ folder.'
 
 if [ -e test/moonbase-overrides/moonbase-runtime-local-substitute-tracing.wasm ]; then
-  if [[ "$1" == "-f" ]]; then
-    BUILD_LAST_TRACING_RUNTIME="yes"
+  if [[ "$BUILD_LAST_TRACING_RUNTIME" == "yes" ]]; then
+    echo "Forcing rebuild of tracing runtime..."
+  else
+    echo "Using existing tracing runtime. Use -f to force rebuild."
   fi
 else
   BUILD_LAST_TRACING_RUNTIME="yes"
@@ -16,11 +47,18 @@ if [[ "$BUILD_LAST_TRACING_RUNTIME" == "yes" ]]; then
   ./scripts/build-last-tracing-runtime.sh
   mkdir -p test/moonbase-overrides/
   mv build/wasm/moonbase-runtime-local-substitute-tracing.wasm test/moonbase-overrides/
+fi
+
+echo "Preparing tests dependencies…"
+(cd moonbeam-types-bundle && pnpm i && pnpm build)
+
+if [[ "$SKIP_AUGMENT_API" == "no" ]]; then
+  echo "Regenerating TypeScript API augmentations from runtime metadata..."
+  (cd typescript-api && pnpm i && scripts/runtime-upgrade.sh)
 else
-  echo "The tracing runtime is not rebuilt, if you want to rebuild it, use the option '-f'."
+  echo "Skipping TypeScript API augmentation regeneration..."
+  (cd typescript-api && pnpm i)
 fi
 
 echo "Run tracing tests…"
-cd test || exit
-pnpm moonwall test dev_moonbase_tracing
-cd ..
+(cd test && pnpm install && pnpm compile-solidity && pnpm moonwall test dev_moonbase_tracing)

--- a/scripts/run-tracing-tests.sh
+++ b/scripts/run-tracing-tests.sh
@@ -2,7 +2,6 @@
 
 # Default values
 BUILD_LAST_TRACING_RUNTIME="no"
-SKIP_AUGMENT_API="no"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -11,15 +10,10 @@ while [[ $# -gt 0 ]]; do
       BUILD_LAST_TRACING_RUNTIME="yes"
       shift
       ;;
-    -s|--skip-augment-api)
-      SKIP_AUGMENT_API="yes"
-      shift
-      ;;
     -h|--help)
       echo "Usage: $0 [options]"
       echo "Options:"
       echo "  -f, --force-rebuild         Force rebuild of the tracing runtime"
-      echo "  -s, --skip-augment-api      Skip regenerating TypeScript API augmentations from runtime metadata"
       echo "  -h, --help                  Show this help message"
       exit 0
       ;;
@@ -31,7 +25,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo 'Make sure you have built moonbeam-types-bundle and run "npm install" in the test/ folder.'
+# Install js dependencies
+pnpm install
 
 if [ -e test/moonbase-overrides/moonbase-runtime-local-substitute-tracing.wasm ]; then
   if [[ "$BUILD_LAST_TRACING_RUNTIME" == "yes" ]]; then
@@ -47,17 +42,6 @@ if [[ "$BUILD_LAST_TRACING_RUNTIME" == "yes" ]]; then
   ./scripts/build-last-tracing-runtime.sh
   mkdir -p test/moonbase-overrides/
   mv build/wasm/moonbase-runtime-local-substitute-tracing.wasm test/moonbase-overrides/
-fi
-
-echo "Preparing tests dependencies…"
-(cd moonbeam-types-bundle && pnpm i && pnpm build)
-
-if [[ "$SKIP_AUGMENT_API" == "no" ]]; then
-  echo "Regenerating TypeScript API augmentations from runtime metadata..."
-  (cd typescript-api && pnpm i && scripts/runtime-upgrade.sh)
-else
-  echo "Skipping TypeScript API augmentation regeneration..."
-  (cd typescript-api && pnpm i)
 fi
 
 echo "Run tracing tests…"

--- a/test/suites/tracing-tests/test-trace-erc20-xcm.ts
+++ b/test/suites/tracing-tests/test-trace-erc20-xcm.ts
@@ -180,8 +180,6 @@ describeSuite({
       // Compute XCM message ID
       const messageHash = context.polkadotJs().createType("XcmVersionedXcm", failedXcmMessage).hash;
 
-      console.log("messageHash", messageHash);
-
       // Find messageQueue.Processed event with matching message ID
       const processedEvent = allRecords.find(
         ({ event }) =>

--- a/test/suites/tracing-tests/test-trace-erc20-xcm.ts
+++ b/test/suites/tracing-tests/test-trace-erc20-xcm.ts
@@ -218,7 +218,7 @@ describeSuite({
         const receipt = await context
           .viem()
           .getTransactionReceipt({ hash: failedTransactionHash as `0x${string}` });
-        
+
         // Verify the transaction failed
         expect(receipt.status).toBe("reverted");
 
@@ -231,7 +231,7 @@ describeSuite({
         // Verify we got a trace back
         expect(trace).toBeDefined();
         expect(trace.gasUsed).toBeDefined();
-        
+
         // The traced gas used should be greater than or equal to the one in the receipt
         // since tracing doesn't account for gas refunds
         expect(hexToNumber(trace.gasUsed)).gte(Number(receipt.gasUsed));


### PR DESCRIPTION
### What does it do?

Introduce a custom XCM transactional processor that preserves Eth‑XCM transactions when the EVM reverts.

By default, any XCM failure (including an EVM revert) rolls back all storage changes—dropping the pallet‑evm `Pending` entry so the Eth‑XCM tx never appears on‑chain or via RPC.

If an XCM instruction fails, the `FrameTransactionalProcessor` rolls back all storage changes induced by that instruction’s execution.

This behavior creates a bug: if an XCM instruction calls the EVM and the EVM reverts, all storage changes are rolled back, and the Eth‑XCM transaction is not stored in the pallet‑evm’s Pending item. Consequently, the Eth‑XCM transaction is neither included in the Ethereum block nor visible via RPC calls like eth_getBlockByHash.

This PR uses a custom XCM transactional processor that still commits storage changes from XCM execution if, and only if, the instruction calls the EVM and the EVM execution reverts.

### What important points should reviewers know?

This PR assume EVM‑calling XCM instructions don’t touch non‑EVM storage—those writes would also persist on revert.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
