### PR TITLE
feat(Moonbeam): Increase PoV limit to 10 MB

### DIFF
--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -156,7 +156,8 @@ pub mod currency {
 }
 
 /// Maximum PoV size we support right now.
-pub const MAX_POV_SIZE: u32 = relay_chain::MAX_POV_SIZE;
+// Reference: https://github.com/polkadot-fellows/runtimes/pull/553
+pub const MAX_POV_SIZE: u32 = 10 * 1024 * 1024;
 
 /// Maximum weight per block
 pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
@@ -410,13 +411,13 @@ parameter_types! {
 	pub MaximumMultiplier: Multiplier = Multiplier::from(100_000u128);
 	pub PrecompilesValue: MoonbeamPrecompiles<Runtime> = MoonbeamPrecompiles::<_>::new();
 	pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
-	/// The amount of gas per pov. A ratio of 4 if we convert ref_time to gas and we compare
+	/// The amount of gas per pov. A ratio of 8 if we convert ref_time to gas and we compare
 	/// it with the pov_size for a block. E.g.
 	/// ceil(
 	///     (max_extrinsic.ref_time() / max_extrinsic.proof_size()) / WEIGHT_PER_GAS
 	/// )
 	/// We should re-check `xcm_config::Erc20XcmBridgeTransferGasLimit` when changing this value
-	pub const GasLimitPovSizeRatio: u64 = 16;
+	pub const GasLimitPovSizeRatio: u64 = 8;
 	/// The amount of gas per storage (in bytes): BLOCK_GAS_LIMIT / BLOCK_STORAGE_LIMIT
 	/// The current definition of BLOCK_STORAGE_LIMIT is 160 KB, resulting in a value of 366.
 	pub GasLimitStorageGrowthRatio: u64 = 366;

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -660,7 +660,7 @@ parameter_types! {
 
 	// To be able to support almost all erc20 implementations,
 	// we provide a sufficiently hight gas limit.
-	pub Erc20XcmBridgeTransferGasLimit: u64 = 800_000;
+	pub Erc20XcmBridgeTransferGasLimit: u64 = 400_000;
 }
 
 impl pallet_erc20_xcm_bridge::Config for Runtime {

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -815,10 +815,6 @@ impl pallet_timestamp::Config for Runtime {
 
 use sp_core::U256;
 
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
-/// Block storage limit in bytes. Set to 160 KB.
-const BLOCK_STORAGE_LIMIT: u64 = 160 * 1024;
-
 parameter_types! {
 	pub BlockGasLimit: U256 = U256::from(u64::MAX);
 	pub WeightPerGas: Weight = Weight::from_parts(1, 0);
@@ -1074,7 +1070,7 @@ pub(crate) fn para_events() -> Vec<RuntimeEvent> {
 
 use frame_support::traits::tokens::{PayFromAccount, UnityAssetBalanceConversion};
 use frame_support::traits::{OnFinalize, OnInitialize, UncheckedOnRuntimeUpgrade};
-use moonbeam_runtime::EvmForeignAssets;
+use moonbeam_runtime::{EvmForeignAssets, BLOCK_STORAGE_LIMIT};
 use pallet_evm::FrameSystemAccountProvider;
 use sp_weights::constants::WEIGHT_REF_TIME_PER_SECOND;
 use xcm_primitives::AsAssetType;

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -820,7 +820,7 @@ parameter_types! {
 	pub WeightPerGas: Weight = Weight::from_parts(1, 0);
 	pub GasLimitPovSizeRatio: u64 = {
 		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
-		block_gas_limit.saturating_div(MAX_POV_SIZE)
+		block_gas_limit.saturating_div(MAX_POV_SIZE as u64)
 	};
 	pub GasLimitStorageGrowthRatio: u64 =
 		BlockGasLimit::get().min(u64::MAX.into()).low_u64().saturating_div(BLOCK_STORAGE_LIMIT);
@@ -1070,7 +1070,7 @@ pub(crate) fn para_events() -> Vec<RuntimeEvent> {
 
 use frame_support::traits::tokens::{PayFromAccount, UnityAssetBalanceConversion};
 use frame_support::traits::{OnFinalize, OnInitialize, UncheckedOnRuntimeUpgrade};
-use moonbeam_runtime::{EvmForeignAssets, BLOCK_STORAGE_LIMIT};
+use moonbeam_runtime::{EvmForeignAssets, BLOCK_STORAGE_LIMIT, MAX_POV_SIZE};
 use pallet_evm::FrameSystemAccountProvider;
 use sp_weights::constants::WEIGHT_REF_TIME_PER_SECOND;
 use xcm_primitives::AsAssetType;


### PR DESCRIPTION
Follow-up of: https://github.com/moonbeam-foundation/moonbeam/pull/3228

Referenda increasing the PoV limit for Polkadot relay: https://polkadot.subsquare.io/referenda/1480 

### What does it do?

Increased the PoV limit to 10 MB in the `moonbeam` runtime.

### What important points should reviewers know?

- `gas per PoV ratio` is now expected to be half, resulting in cheaper ethereum transactions when (PoV gas is the effective gas).

## ⚠️ Breaking Changes ⚠️

- [**Moonbeam ONLY**] `proof_size` worst case scenario in `pallet-ethereum-xcm` extrinsics has now doubled, because of `GasWeightMapping::gas_to_weight`, which computes the proof size in the following way: `let proof_size = gas.saturating_div(ratio)`. This is a worst case scenario which needs to be accounted since PoV gas is now cheaper.