### PR TITLE
Improvements: make the EvmProxyCallFilter::Any consistent on all runtimes

### DIFF
--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -381,9 +381,8 @@ where
 		// Read subcall recipient code
 		// AccountCodesMetadata: 16 (hash) + 20 (key) + 40 (CodeMetadata).
 		handle.record_db_read::<Runtime>(ACCOUNT_CODES_METADATA_PROOF_SIZE.saturated_into())?;
-		let recipient_has_code = pallet_evm::AccountCodesMetadata::<Runtime>::get(evm_subcall.to.0)
-			.unwrap_or_default()
-			.size > 0;
+		let recipient_has_code =
+			pallet_evm::AccountCodesMetadata::<Runtime>::get(evm_subcall.to.0).is_some();
 
 		// Apply proxy type filter
 		frame_support::ensure!(

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -18,7 +18,9 @@
 
 use account::SYSTEM_ACCOUNT_SIZE;
 use evm::ExitReason;
-use fp_evm::{Context, PrecompileFailure, PrecompileHandle, Transfer};
+use fp_evm::{
+	Context, PrecompileFailure, PrecompileHandle, Transfer, ACCOUNT_CODES_METADATA_PROOF_SIZE,
+};
 use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
 use pallet_balances::Call as BalancesCall;
 use pallet_evm::AddressMapping;
@@ -30,6 +32,7 @@ use sp_core::{Get, H160, U256};
 use sp_runtime::{
 	codec::Decode,
 	traits::{ConstU32, Dispatchable, StaticLookup, Zero},
+	SaturatedConversion,
 };
 use sp_std::marker::PhantomData;
 
@@ -376,11 +379,11 @@ where
 		frame_support::ensure!(def.delay.is_zero(), revert("Unannounced"));
 
 		// Read subcall recipient code
-		// AccountCodes: Blake2128(16) + H160(20) + Vec(5)
-		// decode_len reads the first 5 bytes to find the payload len under this key
-		handle.record_db_read::<Runtime>(41)?;
-		let recipient_has_code =
-			pallet_evm::AccountCodes::<Runtime>::decode_len(evm_subcall.to.0).unwrap_or(0) > 0;
+		// AccountCodesMetadata: 16 (hash) + 20 (key) + 40 (CodeMetadata).
+		handle.record_db_read::<Runtime>(ACCOUNT_CODES_METADATA_PROOF_SIZE.saturated_into())?;
+		let recipient_has_code = pallet_evm::AccountCodesMetadata::<Runtime>::get(evm_subcall.to.0)
+			.unwrap_or_default()
+			.size > 0;
 
 		// Apply proxy type filter
 		frame_support::ensure!(

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -977,7 +977,35 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 		gas: u64,
 	) -> precompile_utils::EvmResult<bool> {
 		Ok(match self {
-			ProxyType::Any => true,
+			ProxyType::Any => {
+				match PrecompileName::from_address(call.to.0) {
+					// Any precompile that can execute a subcall should be forbidden here,
+					// to ensure that unauthorized smart contract can't be called
+					// indirectly.
+					// To be safe, we only allow the precompiles we need.
+					Some(
+						PrecompileName::AuthorMappingPrecompile
+						| PrecompileName::ParachainStakingPrecompile,
+					) => true,
+					Some(ref precompile) if is_governance_precompile(precompile) => true,
+					// All non-whitelisted precompiles are forbidden
+					Some(_) => false,
+					// Allow evm transfer to "simple" account (no code nor precompile)
+					// For the moment, no smart contract other than precompiles is allowed.
+					// In the future, we may create a dynamic whitelist to authorize some audited
+					// smart contracts through governance.
+					None => {
+						// If the address is not recognized, allow only evm transfer to "simple"
+						// accounts (no code nor precompile).
+						// Note: Checking the presence of the code is not enough because some
+						// precompiles have no code.
+						!recipient_has_code
+							&& precompile_utils::precompile_set::is_precompile_or_fail::<Runtime>(
+								call.to.0, gas,
+							)?
+					}
+				}
+			}
 			ProxyType::NonTransfer => {
 				call.value == U256::zero()
 					&& match PrecompileName::from_address(call.to.0) {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1000,7 +1000,7 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 						// Note: Checking the presence of the code is not enough because some
 						// precompiles have no code.
 						!recipient_has_code
-							&& precompile_utils::precompile_set::is_precompile_or_fail::<Runtime>(
+							&& !precompile_utils::precompile_set::is_precompile_or_fail::<Runtime>(
 								call.to.0, gas,
 							)?
 					}

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -965,7 +965,7 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 					// In the future, we may create a dynamic whitelist to authorize some audited
 					// smart contracts through governance.
 					None => {
-						// If the address is not recognized, allow only evm transfert to "simple"
+						// If the address is not recognized, allow only evm transfer to "simple"
 						// accounts (no code nor precompile).
 						// Note: Checking the presence of the code is not enough because some
 						// precompiles have no code.

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -970,7 +970,7 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 						// Note: Checking the presence of the code is not enough because some
 						// precompiles have no code.
 						!recipient_has_code
-							&& precompile_utils::precompile_set::is_precompile_or_fail::<Runtime>(
+							&& !precompile_utils::precompile_set::is_precompile_or_fail::<Runtime>(
 								call.to.0, gas,
 							)?
 					}

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -156,7 +156,7 @@ type MoonbeamPrecompilesAt<R> = (
 		(CallableByContract, CallableByPrecompile),
 	>,
 	PrecompileAt<
-		AddressU64<2050>,
+		AddressU64<ERC20_BALANCES_PRECOMPILE>,
 		Erc20BalancesPrecompile<R, NativeErc20Metadata>,
 		(CallableByContract, CallableByPrecompile),
 	>,

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -150,7 +150,7 @@ type MoonriverPrecompilesAt<R> = (
 		(CallableByContract, CallableByPrecompile),
 	>,
 	PrecompileAt<
-		AddressU64<2050>,
+		AddressU64<ERC20_BALANCES_PRECOMPILE>,
 		Erc20BalancesPrecompile<R, NativeErc20Metadata>,
 		(CallableByContract, CallableByPrecompile),
 	>,

--- a/test/suites/dev/moonbase/test-gas/test-gas-estimation-subcall-oog.ts
+++ b/test/suites/dev/moonbase/test-gas/test-gas-estimation-subcall-oog.ts
@@ -77,7 +77,7 @@ describeSuite({
 
     it({
       id: "T02",
-      title: "gas estimation should make pov-consuming subcall suceed",
+      title: "gas estimation should make pov-consuming subcall succeed",
       test: async function () {
         const estimatedGas = await context.viem().estimateContractGas({
           account: ALITH_ADDRESS,

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-smart-contract-call4.ts
@@ -99,31 +99,5 @@ describeSuite({
         ).rejects.toThrowError("real address must be EOA");
       },
     });
-
-    it({
-      id: "T02",
-      title: "should succeed when caller is a smart contract and real address is EOA",
-      test: async function () {
-        const rawTxn = await context.writeContract!({
-          contractAddress: testContractAddress,
-          contractName: "SmartContractPrecompileCallTest",
-          functionName: "callProxy",
-          gas: 5_000_000n,
-          rawTxOnly: true,
-          args: [
-            BALTATHAR_ADDRESS,
-            multiplyContractAddress,
-            encodeFunctionData({
-              abi: fetchCompiledContract("MultiplyBy7").abi,
-              functionName: "multiply",
-              args: [5],
-            }),
-          ],
-        });
-
-        const { result } = await context.createBlock(rawTxn);
-        expectEVMResult(result!.events, "Succeed");
-      },
-    });
   },
 });

--- a/test/suites/dev/moonbase/test-storage-growth/test-precompile-storage-growth.ts
+++ b/test/suites/dev/moonbase/test-storage-growth/test-precompile-storage-growth.ts
@@ -17,13 +17,10 @@ describeSuite({
   title: "Storage growth limit - Precompiles",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    const newAccount = "0x1ced798a66b803d0dbb665680283980a939a6432";
-
     it({
       id: "T01",
-      title: "should fail transfer due to insufficient gas required to cover the storage growth",
+      title: "should fail to addProxy due to insufficient gas required to cover the storage growth",
       test: async () => {
-        const { abi: ierc20Abi } = fetchCompiledContract("IERC20");
         const { abi: proxyAbi } = fetchCompiledContract("Proxy");
 
         const estimatedGas = await context.viem().estimateGas({
@@ -45,106 +42,44 @@ describeSuite({
           args: [BALTATHAR_ADDRESS, CONTRACT_PROXY_TYPE_ANY, 0],
           privateKey: FAITH_PRIVATE_KEY,
           rawTxOnly: true,
-          gas: estimatedGas,
+          gas: estimatedGas - 5_000n,
         });
         const { result } = await context.createBlock(rawTxn);
-        expectEVMResult(result!.events, "Succeed");
-
-        const proxyProxyEstimatedGas = await context.viem().estimateGas({
-          account: BALTATHAR_ADDRESS,
-          to: PRECOMPILE_PROXY_ADDRESS,
-          data: encodeFunctionData({
-            abi: proxyAbi,
-            functionName: "proxy",
-            args: [
-              FAITH_ADDRESS,
-              PRECOMPILE_NATIVE_ERC20_ADDRESS,
-              encodeFunctionData({
-                abi: ierc20Abi,
-                functionName: "transfer",
-                args: [newAccount, parseEther("5")],
-              }),
-            ],
-          }),
-        });
-
-        // Snapshot estimated gas
-        expect(proxyProxyEstimatedGas).toMatchInlineSnapshot(`55270n`);
-
-        const balBefore = await context.viem().getBalance({ address: FAITH_ADDRESS });
-        const rawTxn2 = await context.writePrecompile!({
-          precompileName: "Proxy",
-          functionName: "proxy",
-          args: [
-            FAITH_ADDRESS,
-            PRECOMPILE_NATIVE_ERC20_ADDRESS,
-            encodeFunctionData({
-              abi: ierc20Abi,
-              functionName: "transfer",
-              args: [newAccount, parseEther("5")],
-            }),
-          ],
-          privateKey: BALTATHAR_PRIVATE_KEY,
-          rawTxOnly: true,
-          gas: proxyProxyEstimatedGas - 10_000n,
-        });
-
-        const { result: result2 } = await context.createBlock(rawTxn2);
         // Check that the transaction failed with an out of gas error
-        expectEVMResult(result2!.events, "Error", "OutOfGas");
-
-        const balAfter = await context.viem().getBalance({ address: FAITH_ADDRESS });
-        expect(balBefore - balAfter).to.equal(0n);
+        expectEVMResult(result!.events, "Error", "OutOfGas");
       },
     });
 
     it({
       id: "T02",
-      title: "should transfer correctly with the required gas to cover the storage growth",
+      title: "should addProxy correctly with the required gas to cover the storage growth",
       test: async () => {
         const balBefore = await context.viem().getBalance({ address: FAITH_ADDRESS });
-        const { abi: ierc20Abi } = fetchCompiledContract("IERC20");
         const { abi: proxyAbi } = fetchCompiledContract("Proxy");
 
         const estimatedGas = await context.viem().estimateGas({
-          account: BALTATHAR_ADDRESS,
+          account: FAITH_ADDRESS,
           to: PRECOMPILE_PROXY_ADDRESS,
           data: encodeFunctionData({
             abi: proxyAbi,
-            functionName: "proxy",
-            args: [
-              FAITH_ADDRESS,
-              PRECOMPILE_NATIVE_ERC20_ADDRESS,
-              encodeFunctionData({
-                abi: ierc20Abi,
-                functionName: "transfer",
-                args: [newAccount, parseEther("5")],
-              }),
-            ],
+            functionName: "addProxy",
+            args: [BALTATHAR_ADDRESS, CONTRACT_PROXY_TYPE_ANY, 0],
           }),
         });
 
         // Snapshot estimated gas
-        expect(estimatedGas).toMatchInlineSnapshot(`55270n`);
+        expect(estimatedGas).toMatchInlineSnapshot(`49856n`);
 
-        const rawTxn2 = await context.writePrecompile!({
+        const rawTxn = await context.writePrecompile!({
           precompileName: "Proxy",
-          functionName: "proxy",
-          args: [
-            FAITH_ADDRESS,
-            PRECOMPILE_NATIVE_ERC20_ADDRESS,
-            encodeFunctionData({
-              abi: ierc20Abi,
-              functionName: "transfer",
-              args: [newAccount, parseEther("5")],
-            }),
-          ],
-          privateKey: BALTATHAR_PRIVATE_KEY,
+          functionName: "addProxy",
+          args: [BALTATHAR_ADDRESS, CONTRACT_PROXY_TYPE_ANY, 0],
+          privateKey: FAITH_PRIVATE_KEY,
           rawTxOnly: true,
           gas: estimatedGas,
         });
 
-        const { result } = await context.createBlock(rawTxn2);
+        const { result } = await context.createBlock(rawTxn);
         // Check that the transaction failed with an out of gas error
         expectEVMResult(result!.events, "Succeed");
 
@@ -154,12 +89,7 @@ describeSuite({
 
         // The tx can create an account, so record 148 bytes of storage growth
         // Storage growth ratio is 366
-        // storage_gas = 148 * 366 = 54168
-        // pov_gas = proof_size * GAS_LIMIT_POV_RATIO
-        expect(gasUsed).toMatchInlineSnapshot(`54168n`);
-
-        const balAfter = await context.viem().getBalance({ address: FAITH_ADDRESS });
-        expect(balBefore - balAfter).to.equal(parseEther("5"));
+        expect(gasUsed).toMatchInlineSnapshot(`31042n`);
       },
     });
   },


### PR DESCRIPTION
### What does it do?

- Reverts https://github.com/moonbeam-foundation/moonbeam/pull/2098, to make the filter check consistent with moonbeam and moonriver runtimes;
- Use the same constant `ERC20_BALANCES_PRECOMPILE` to reference the precompile index.
- Fix under-estimated read


### What important points should reviewers know?

This PR also fixes the filter on the moonbeam runtime.

## ⚠️ Breaking Changes ⚠️

- [**Moonbase ONLY**] Reverts https://github.com/moonbeam-foundation/moonbeam/pull/2098, to make the filter check consistent with moonbeam and moonriver runtimes;