### PR TITLE
readme/fix: polkadot/technology broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Tests](https://github.com/moonbeam-foundation/moonbeam/workflows/Build/badge.svg)
 
-**An Ethereum compatible [Parachain](https://polkadot.network/technology/) built with the [Polkadot-SDK](https://github.com/paritytech/polkadot-sdk).**
+**An Ethereum compatible [Parachain](https://polkadot.com/parachains/) built with the [Polkadot-SDK](https://github.com/paritytech/polkadot-sdk).**
 
 👉 _Discover the Moonbeam project at [moonbeam.network](https://moonbeam.network)._<br>
 👉 _Learn to [use the Moonbeam network](https://docs.moonbeam.network/) with our technical docs._<br>


### PR DESCRIPTION
### What does it do?

Fix broken link to polkadot/technolgy and replace with https://polkadot.com/parachains/
