### PR TITLE
backport fix to perm-client-v0.44.1

### DIFF
--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Setup Variables
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -493,7 +493,7 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Setup Variables
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3157,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3212,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3436,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3459,7 +3459,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "environmental",
  "evm",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3491,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3503,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8546,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "environmental",
  "ethereum",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8722,7 +8722,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fp-evm",
 ]
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fp-evm",
  "num",
@@ -9182,7 +9182,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9201,7 +9201,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-storage-cleaner"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -11929,7 +11929,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "derive_more",
  "environmental",
@@ -11958,7 +11958,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#9e11a443a94a4e86c638ebf7774fae2867fe9f6e"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2409#7cbf4ddb133c654d8dac0691217367076a29d98a"
 dependencies = [
  "case",
  "num_enum 0.7.3",

--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -107,6 +107,7 @@ pub struct RpcConfig {
 	pub eth_statuses_cache: usize,
 	pub fee_history_limit: u64,
 	pub max_past_logs: u32,
+	pub max_block_range: u32,
 	pub relay_chain_rpc_urls: Vec<url::Url>,
 	pub tracing_raw_max_memory_usage: usize,
 	pub frontier_backend_config: FrontierBackendConfig,

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -295,6 +295,10 @@ pub struct RunCmd {
 	#[clap(long, default_value = "10000")]
 	pub max_past_logs: u32,
 
+	/// Maximum block range to query logs from.
+	#[clap(long, default_value = "1024")]
+	pub max_block_range: u32,
+
 	/// Force using Moonbase native runtime.
 	#[clap(long = "force-moonbase")]
 	pub force_moonbase: bool,
@@ -351,6 +355,7 @@ impl RunCmd {
 			eth_statuses_cache: self.eth_statuses_cache,
 			fee_history_limit: self.fee_history_limit,
 			max_past_logs: self.max_past_logs,
+			max_block_range: self.max_block_range,
 			relay_chain_rpc_urls: self.base.relay_chain_rpc_urls.clone(),
 			tracing_raw_max_memory_usage: self.tracing_raw_max_memory_usage,
 			frontier_backend_config: match self.frontier_backend_type {

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -761,6 +761,7 @@ where
 		let sync = sync_service.clone();
 		let ethapi_cmd = ethapi_cmd.clone();
 		let max_past_logs = rpc_config.max_past_logs;
+		let max_block_range = rpc_config.max_block_range;
 		let overrides = overrides.clone();
 		let fee_history_cache = fee_history_cache.clone();
 		let block_data_cache = block_data_cache.clone();
@@ -783,6 +784,7 @@ where
 				pool: pool.clone(),
 				is_authority: collator,
 				max_past_logs,
+				max_block_range,
 				fee_history_limit,
 				fee_history_cache: fee_history_cache.clone(),
 				network: network.clone(),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -790,6 +790,7 @@ where
 		let backend = backend.clone();
 		let ethapi_cmd = ethapi_cmd.clone();
 		let max_past_logs = rpc_config.max_past_logs;
+		let max_block_range = rpc_config.max_block_range;
 		let overrides = overrides.clone();
 		let fee_history_cache = fee_history_cache.clone();
 		let block_data_cache = block_data_cache.clone();
@@ -831,6 +832,7 @@ where
 				pool: pool.clone(),
 				is_authority: collator,
 				max_past_logs,
+				max_block_range,
 				fee_history_limit,
 				fee_history_cache: fee_history_cache.clone(),
 				network: network.clone(),
@@ -1538,6 +1540,7 @@ where
 		let sync = sync_service.clone();
 		let ethapi_cmd = ethapi_cmd.clone();
 		let max_past_logs = rpc_config.max_past_logs;
+		let max_block_range = rpc_config.max_block_range;
 		let overrides = overrides.clone();
 		let fee_history_cache = fee_history_cache.clone();
 		let block_data_cache = block_data_cache.clone();
@@ -1559,6 +1562,7 @@ where
 				pool: pool.clone(),
 				is_authority: collator,
 				max_past_logs,
+				max_block_range,
 				fee_history_limit,
 				fee_history_cache: fee_history_cache.clone(),
 				network: network.clone(),

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -122,6 +122,8 @@ pub struct FullDeps<C, P, A: ChainApi, BE> {
 	pub command_sink: Option<futures::channel::mpsc::Sender<EngineCommand<Hash>>>,
 	/// Maximum number of logs in a query.
 	pub max_past_logs: u32,
+	/// Maximum block range in a query.
+	pub max_block_range: u32,
 	/// Maximum fee history cache size.
 	pub fee_history_limit: u64,
 	/// Fee history cache.
@@ -195,6 +197,7 @@ where
 		frontier_backend,
 		backend: _,
 		max_past_logs,
+		max_block_range,
 		fee_history_limit,
 		fee_history_cache,
 		dev_rpc_data,
@@ -275,6 +278,7 @@ where
 				filter_pool,
 				500_usize, // max stored filters
 				max_past_logs,
+				max_block_range,
 				block_data_cache,
 			)
 			.into_rpc(),

--- a/test/suites/tracing-tests/test-get-logs-limit.ts
+++ b/test/suites/tracing-tests/test-get-logs-limit.ts
@@ -1,0 +1,34 @@
+import { beforeAll, customDevRpcRequest, describeSuite, expect } from "@moonwall/cli";
+
+describeSuite({
+  id: "T20",
+  title: "Test eth_getLogs RPC",
+  foundationMethods: "dev",
+  testCases: ({ context, it }) => {
+    beforeAll(async () => {
+      // This variable needs to be modified if `--max-blocks-range` CLI parameter is changed
+      // Using the default of 1024
+      let blocksToCreate = 1025;
+      for (; blocksToCreate > 0; blocksToCreate--) {
+        await context.createBlock();
+      }
+    });
+
+    it({
+      id: "T01",
+      title: "Validate eth_getLogs block range limit",
+      test: async function () {
+        expect(
+          async () =>
+            await customDevRpcRequest("eth_getLogs", [
+              {
+                fromBlock: "0x0",
+                toBlock: "latest",
+                topics: [],
+              },
+            ])
+        ).rejects.toThrowError("block range is too wide (maximum 1024)");
+      },
+    });
+  },
+});


### PR DESCRIPTION
### What does it do?

Backport the changes included in https://github.com/moonbeam-foundation/moonbeam/pull/3250 to `perm-client-v0.44.1` branch.

## ⚠️ Breaking Changes ⚠️

Adds a cli parameter named `--max-block-range <RANGE>` for customising the block range limit when querying `eth_getLogs` RPC, the default value is `1024` blocks. Trying to query `eth_getLogs` for a block range higher than `1024` will result in the following error message: `block range is too wide (maximum 1024)`.