### PR TITLE
Fix isolated runtime build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7644,7 +7644,6 @@ dependencies = [
  "pallet-referenda",
  "pallet-relay-storage-roots",
  "pallet-scheduler",
- "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-treasury",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -50,7 +50,6 @@ pallet-parameters = { workspace = true }
 pallet-proxy = { workspace = true }
 pallet-referenda = { workspace = true }
 pallet-scheduler = { workspace = true }
-pallet-sudo = { workspace = true }
 pallet-timestamp = { workspace = true }
 pallet-transaction-payment = { workspace = true }
 pallet-treasury = { workspace = true }
@@ -162,7 +161,6 @@ runtime-benchmarks = [
 	"pallet-referenda/runtime-benchmarks",
 	"pallet-referenda/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
-	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",


### PR DESCRIPTION
### What does it do?

Fixes the runtime build when run in isolation. (e.g by passing `-p moonriver-runtime`)