### PR TITLE
Use MaintenanceMode pallet as FailedMigrationHandler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -8266,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8802,7 +8802,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8822,7 +8822,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8841,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10238,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -15740,7 +15740,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -19796,7 +19796,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#96d639f534f65462058b11669a5a9b90115d8bbe"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2412#078bdc0a3b1cf166ad9fed14c9f9acc33cc08955"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1420,29 +1420,9 @@ impl pallet_multiblock_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = EnterMaintenanceModeOnFailedMigration;
+	type FailedMigrationHandler = MaintenanceMode;
 	type MaxServiceWeight = MaxServiceWeight;
 	type WeightInfo = weights::pallet_multiblock_migrations::WeightInfo<Runtime>;
-}
-
-/// A `FailedMigrationHandler` that enables maintenance mode.
-pub struct EnterMaintenanceModeOnFailedMigration;
-impl frame_support::migrations::FailedMigrationHandler for EnterMaintenanceModeOnFailedMigration {
-	fn failed(migration: Option<u32>) -> frame_support::migrations::FailedMigrationHandling {
-		// Log information about the failed migration
-		log::error!(
-			target: "runtime::migrations",
-			"Migration {:?} failed - activating maintenance mode and continuing",
-			migration
-		);
-
-		// Enable maintenance mode using the internal function.
-		MaintenanceMode::force_enter_maintenance_mode();
-
-		// We choose to ignore the failed migration, allowing the chain to continue operating
-		// in maintenance mode rather than completely halting execution
-		frame_support::migrations::FailedMigrationHandling::Ignore
-	}
 }
 
 construct_runtime! {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1398,29 +1398,9 @@ impl pallet_multiblock_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = EnterMaintenanceModeOnFailedMigration;
+	type FailedMigrationHandler = MaintenanceMode;
 	type MaxServiceWeight = MaxServiceWeight;
 	type WeightInfo = weights::pallet_multiblock_migrations::WeightInfo<Runtime>;
-}
-
-/// A `FailedMigrationHandler` that enables maintenance mode.
-pub struct EnterMaintenanceModeOnFailedMigration;
-impl frame_support::migrations::FailedMigrationHandler for EnterMaintenanceModeOnFailedMigration {
-	fn failed(migration: Option<u32>) -> frame_support::migrations::FailedMigrationHandling {
-		// Log information about the failed migration
-		log::error!(
-			target: "runtime::migrations",
-			"Migration {:?} failed - activating maintenance mode and continuing",
-			migration
-		);
-
-		// Enable maintenance mode using the internal function.
-		MaintenanceMode::force_enter_maintenance_mode();
-
-		// We choose to ignore the failed migration, allowing the chain to continue operating
-		// in maintenance mode rather than completely halting execution
-		frame_support::migrations::FailedMigrationHandling::Ignore
-	}
 }
 
 construct_runtime! {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1408,29 +1408,9 @@ impl pallet_multiblock_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = EnterMaintenanceModeOnFailedMigration;
+	type FailedMigrationHandler = MaintenanceMode;
 	type MaxServiceWeight = MaxServiceWeight;
 	type WeightInfo = weights::pallet_multiblock_migrations::WeightInfo<Runtime>;
-}
-
-/// A `FailedMigrationHandler` that enables maintenance mode.
-pub struct EnterMaintenanceModeOnFailedMigration;
-impl frame_support::migrations::FailedMigrationHandler for EnterMaintenanceModeOnFailedMigration {
-	fn failed(migration: Option<u32>) -> frame_support::migrations::FailedMigrationHandling {
-		// Log information about the failed migration
-		log::error!(
-			target: "runtime::migrations",
-			"Migration {:?} failed - activating maintenance mode and continuing",
-			migration
-		);
-
-		// Enable maintenance mode using the internal function.
-		MaintenanceMode::force_enter_maintenance_mode();
-
-		// We choose to ignore the failed migration, allowing the chain to continue operating
-		// in maintenance mode rather than completely halting execution
-		frame_support::migrations::FailedMigrationHandling::Ignore
-	}
 }
 
 construct_runtime! {


### PR DESCRIPTION
### What does it do?

Replaces redundant type with pallet MaintenanceMode as FailedMigrationHandler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the handling of failed migrations by switching to a standard maintenance mode handler across all runtimes.
  - Removed a custom migration failure handler, streamlining maintenance mode activation during migration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->