### PR TITLE
Validate depth limit decoding in XCM transact instruction

### DIFF
--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -333,7 +333,7 @@ pub type XcmRouter = WithUniqueTopic<(
 	XcmpQueue,
 )>;
 
-type XcmExecutor = pallet_erc20_xcm_bridge::XcmExecutorWrapper<
+pub type XcmExecutor = pallet_erc20_xcm_bridge::XcmExecutorWrapper<
 	XcmExecutorConfig,
 	xcm_executor::XcmExecutor<XcmExecutorConfig>,
 >;

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -36,6 +36,7 @@ use frame_support::{
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 	StorageHasher, Twox128,
 };
+use moonbase_runtime::xcm_config::XcmExecutor;
 use moonbase_runtime::{
 	xcm_config::SelfReserve, AccountId, AssetId, Balances, CrowdloanRewards, EvmForeignAssets,
 	Executive, OpenTechCommitteeCollective, ParachainStaking, PolkadotXcm, Precompiles, Runtime,
@@ -2666,6 +2667,43 @@ fn test_xcm_utils_ml_tp_account() {
 			.expect_cost(3338)
 			.expect_no_logs()
 			.execute_returns(Address(expected_address_alice_in_parachain_2000));
+	});
+}
+
+#[test]
+fn test_nested_batch_calls_from_xcm_transact() {
+	ExtBuilder::default().build().execute_with(|| {
+		// This ensures we notice if MAX_XCM_DECODE_DEPTH changes
+		// in a future polkadot-sdk version
+		assert_eq!(xcm::MAX_XCM_DECODE_DEPTH, 8);
+
+		let mut valid_nested_calls =
+			RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+		for _ in 0..xcm::MAX_XCM_DECODE_DEPTH {
+			valid_nested_calls = RuntimeCall::Utility(pallet_utility::Call::batch {
+				calls: vec![valid_nested_calls],
+			});
+		}
+
+		let valid_message = Xcm(vec![Transact {
+			origin_kind: OriginKind::SovereignAccount,
+			fallback_max_weight: None,
+			call: valid_nested_calls.encode().into(),
+		}]);
+
+		assert!(XcmExecutor::prepare(valid_message).is_ok());
+
+		let excessive_nested_calls = RuntimeCall::Utility(pallet_utility::Call::batch {
+			calls: vec![valid_nested_calls],
+		});
+
+		let invalid_message = Xcm(vec![Transact {
+			origin_kind: OriginKind::SovereignAccount,
+			fallback_max_weight: None,
+			call: excessive_nested_calls.encode().into(),
+		}]);
+		// Expect to fail because we have too many nested calls
+		assert!(XcmExecutor::prepare(invalid_message).is_err());
 	});
 }
 

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -307,7 +307,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type XcmRecorder = PolkadotXcm;
 }
 
-type XcmExecutor = pallet_erc20_xcm_bridge::XcmExecutorWrapper<
+pub type XcmExecutor = pallet_erc20_xcm_bridge::XcmExecutorWrapper<
 	XcmExecutorConfig,
 	xcm_executor::XcmExecutor<XcmExecutorConfig>,
 >;

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -37,6 +37,7 @@ use frame_support::{
 };
 use moonbeam_runtime::currency::{GIGAWEI, WEI};
 use moonbeam_runtime::runtime_params::dynamic_params;
+use moonbeam_runtime::xcm_config::XcmExecutor;
 use moonbeam_runtime::{
 	asset_config::ForeignAssetInstance,
 	currency::GLMR,
@@ -2544,6 +2545,43 @@ fn test_xcm_utils_weight_message() {
 			.expect_cost(1669)
 			.expect_no_logs()
 			.execute_returns(expected_weight);
+	});
+}
+
+#[test]
+fn test_nested_batch_calls_from_xcm_transact() {
+	ExtBuilder::default().build().execute_with(|| {
+		// This ensures we notice if MAX_XCM_DECODE_DEPTH changes
+		// in a future polkadot-sdk version
+		assert_eq!(xcm::MAX_XCM_DECODE_DEPTH, 8);
+
+		let mut valid_nested_calls =
+			RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+		for _ in 0..xcm::MAX_XCM_DECODE_DEPTH {
+			valid_nested_calls = RuntimeCall::Utility(pallet_utility::Call::batch {
+				calls: vec![valid_nested_calls],
+			});
+		}
+
+		let valid_message = Xcm(vec![Transact {
+			origin_kind: OriginKind::SovereignAccount,
+			fallback_max_weight: None,
+			call: valid_nested_calls.encode().into(),
+		}]);
+
+		assert!(XcmExecutor::prepare(valid_message).is_ok());
+
+		let excessive_nested_calls = RuntimeCall::Utility(pallet_utility::Call::batch {
+			calls: vec![valid_nested_calls],
+		});
+
+		let invalid_message = Xcm(vec![Transact {
+			origin_kind: OriginKind::SovereignAccount,
+			fallback_max_weight: None,
+			call: excessive_nested_calls.encode().into(),
+		}]);
+		// Expect to fail because we have too many nested calls
+		assert!(XcmExecutor::prepare(invalid_message).is_err());
 	});
 }
 

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -315,7 +315,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type XcmRecorder = PolkadotXcm;
 }
 
-type XcmExecutor = pallet_erc20_xcm_bridge::XcmExecutorWrapper<
+pub type XcmExecutor = pallet_erc20_xcm_bridge::XcmExecutorWrapper<
 	XcmExecutorConfig,
 	xcm_executor::XcmExecutor<XcmExecutorConfig>,
 >;


### PR DESCRIPTION
### What does it do?

This test adds a simple validation to make we will detect if `MAX_XCM_DECODE_DEPTH` changes in future polkadot-sdk versions.