### PR TITLE
Re-enable lazy-loading tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -690,7 +690,6 @@ jobs:
       labels: bare-metal
     permissions:
       contents: read
-    if: false # Temporarily disabled
     needs: ["set-tags", "build"]
     strategy:
       fail-fast: false

--- a/node/service/src/lazy_loading/backend.rs
+++ b/node/service/src/lazy_loading/backend.rs
@@ -1100,7 +1100,13 @@ impl<Block: BlockT + DeserializeOwned> sp_state_machine::Backend<HashingFor<Bloc
 		} else {
 			let next_storage_key = self.db.read().next_storage_key(key);
 			match next_storage_key {
-				Ok(Some(next_key)) if key != next_key => Some(next_key),
+				Ok(Some(next_key)) => {
+					if key != next_key {
+						Some(next_key)
+					} else {
+						None
+					}
+				}
 				_ if !self.removed_keys.read().contains_key(key) => {
 					remote_fetch(Some(self.fork_block))
 				}

--- a/node/service/src/lazy_loading/backend.rs
+++ b/node/service/src/lazy_loading/backend.rs
@@ -1100,7 +1100,7 @@ impl<Block: BlockT + DeserializeOwned> sp_state_machine::Backend<HashingFor<Bloc
 		} else {
 			let next_storage_key = self.db.read().next_storage_key(key);
 			match next_storage_key {
-				Ok(Some(key)) => Some(key),
+				Ok(Some(next_key)) if key != next_key => Some(next_key),
 				_ if !self.removed_keys.read().contains_key(key) => {
 					remote_fetch(Some(self.fork_block))
 				}

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -33,7 +33,6 @@ use nimbus_primitives::NimbusId;
 use parity_scale_codec::Encode;
 use polkadot_primitives::{
 	AbridgedHostConfiguration, AsyncBackingParams, PersistedValidationData, Slot, UpgradeGoAhead,
-	UpgradeRestriction,
 };
 use sc_chain_spec::{get_extension, BuildGenesisBlock, GenesisBlockBuilder};
 use sc_client_api::{Backend, BadBlocks, ExecutorProvider, ForkBlocks};
@@ -642,12 +641,6 @@ where
 							(
 								relay_chain::well_known_keys::CURRENT_SLOT.to_vec(),
 								Slot::from(u64::from(current_para_block)).encode(),
-							),
-							(
-								relay_chain::well_known_keys::upgrade_restriction_signal(
-									ParaId::new(parachain_id),
-								),
-								None::<UpgradeRestriction>.encode(),
 							),
 						];
 

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -207,7 +207,7 @@ where
 					SyncMode::LightState { .. } | SyncMode::Warp { .. }
 				),
 				wasm_runtime_substitutes,
-				enable_import_proof_recording: false,
+				enable_import_proof_recording: true,
 			},
 		)?;
 


### PR DESCRIPTION
- Fixes the lazy-loading storage iterator;
- Removes `upgrade_restriction_signal` override from relay proof. (Needs to be done differently)
- Reverts commit af375e850f2d9a99dd0cfabe4f239b45bc35ba03.