### PR TITLE
Staking: make inflation linear after 1.2B total supply 

### DIFF
--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -100,7 +100,11 @@ pub fn annual_to_round<T: Config>(annual: Range<Perbill>) -> Range<Perbill> {
 
 /// Compute round issuance range from round inflation range and current total issuance
 pub fn round_issuance_range<T: Config>(round: Range<Perbill>) -> Range<BalanceOf<T>> {
-	let circulating = T::Currency::total_issuance();
+	let circulating = if let Some(threshold) = T::LinearInflationThreshold::get() {	
+		core::cmp::min(T::Currency::total_issuance(), threshold)
+	} else {
+		T::Currency::total_issuance()
+	};
 	Range {
 		min: round.min * circulating,
 		ideal: round.ideal * circulating,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -192,6 +192,10 @@ pub mod pallet {
 		/// Maximum candidates
 		#[pallet::constant]
 		type MaxCandidates: Get<u32>;
+		/// Threshold after which inflation become linear
+		/// If you don't want to use it, set it to `()`
+		#[pallet::constant]
+		type LinearInflationThreshold: Get<Option<BalanceOf<Self>>>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -148,6 +148,10 @@ impl Get<Slot> for StakingRoundSlotProvider {
 	}
 }
 
+parameter_types! {
+	pub const LinearInflationThreshold: Option<Balance> = Some(1_200_000_000);
+}
+
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
@@ -176,6 +180,7 @@ impl Config for Test {
 	type MaxCandidates = MaxCandidates;
 	type SlotDuration = frame_support::traits::ConstU64<6_000>;
 	type BlockTime = frame_support::traits::ConstU64<6_000>;
+	type LinearInflationThreshold = LinearInflationThreshold;
 }
 
 pub(crate) struct ExtBuilder {

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -230,6 +230,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxCandidates = MaxCandidates;
 	type SlotDuration = frame_support::traits::ConstU64<6_000>;
 	type BlockTime = frame_support::traits::ConstU64<6_000>;
+	type LinearInflationThreshold = ();
 }
 
 pub(crate) struct ExtBuilder {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -816,6 +816,10 @@ impl Get<Slot> for RelayChainSlotProvider {
 	}
 }
 
+parameter_types! {
+	pub const LinearInflationThreshold: Option<Balance> = Some(1_200_000_000 * currency::UNIT);
+}
+
 impl pallet_parachain_staking::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
@@ -858,6 +862,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxCandidates = ConstU32<200>;
 	type SlotDuration = ConstU64<6_000>;
 	type BlockTime = ConstU64<6_000>;
+	type LinearInflationThreshold = LinearInflationThreshold;
 }
 
 impl pallet_author_inherent::Config for Runtime {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -803,6 +803,10 @@ impl Get<Slot> for RelayChainSlotProvider {
 	}
 }
 
+parameter_types! {
+	pub const LinearInflationThreshold: Option<Balance> = Some(1_200_000_000 * currency::GLMR);
+}
+
 impl pallet_parachain_staking::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
@@ -845,6 +849,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxCandidates = ConstU32<200>;
 	type SlotDuration = ConstU64<6_000>;
 	type BlockTime = ConstU64<6_000>;
+	type LinearInflationThreshold = LinearInflationThreshold;
 }
 
 impl pallet_author_inherent::Config for Runtime {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -813,6 +813,10 @@ impl Get<Slot> for RelayChainSlotProvider {
 	}
 }
 
+parameter_types! {
+	pub const LinearInflationThreshold: Option<Balance> = Some(1_200_000_000 * currency::MOVR);
+}
+
 impl pallet_parachain_staking::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
@@ -855,6 +859,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxCandidates = ConstU32<200>;
 	type SlotDuration = ConstU64<6_000>;
 	type BlockTime = ConstU64<6_000>;
+	type LinearInflationThreshold = LinearInflationThreshold;
 }
 
 impl pallet_author_inherent::Config for Runtime {


### PR DESCRIPTION
### What does it do?

This PR adds a new associated type `LinearInflationThreshold` to the `Config` trait of `pallet-parachain-staking`.

Example configurations:
- Moonbase: `Some(1.2B DEV)`
- Moonriver: `Some(1.0B MOVR)`
- Moonbeam: `Some(1.2B GLMR)`

When the total supply reaches the configured amount, inflation becomes linear.

### Downstream projects

To maintain the same behavior, add:

```rust
type LinearInflationThreshold = ();
```

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
