### PR TITLE
Fix :wrench:: XCM TransactThroughDerivative not working with new Foreign Assets

### DIFF
--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -181,7 +181,11 @@ type MoonbasePrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2054>,
 		XcmTransactorPrecompileV1<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	PrecompileAt<
 		AddressU64<2055>,
@@ -225,7 +229,11 @@ type MoonbasePrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2061>,
 		XcmTransactorPrecompileV2<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	// CouncilCollective precompile
 	RemovedPrecompileAt<AddressU64<2062>>,
@@ -265,7 +273,11 @@ type MoonbasePrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2071>,
 		XcmTransactorPrecompileV3<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	PrecompileAt<
 		AddressU64<2072>,

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -178,7 +178,11 @@ type MoonbeamPrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2054>,
 		XcmTransactorPrecompileV1<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	PrecompileAt<
 		AddressU64<2055>,
@@ -224,7 +228,11 @@ type MoonbeamPrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2061>,
 		XcmTransactorPrecompileV2<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	RemovedPrecompileAt<AddressU64<2062>>, //CouncilInstance
 	RemovedPrecompileAt<AddressU64<2063>>, // TechCommitteeInstance
@@ -262,7 +270,11 @@ type MoonbeamPrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2071>,
 		XcmTransactorPrecompileV3<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	PrecompileAt<
 		AddressU64<2072>,

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -172,7 +172,11 @@ type MoonriverPrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2054>,
 		XcmTransactorPrecompileV1<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	PrecompileAt<
 		AddressU64<2055>,
@@ -218,7 +222,11 @@ type MoonriverPrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2061>,
 		XcmTransactorPrecompileV2<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	RemovedPrecompileAt<AddressU64<2062>>, //CouncilInstance
 	RemovedPrecompileAt<AddressU64<2063>>, // TechCommitteeInstance
@@ -256,7 +264,11 @@ type MoonriverPrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2071>,
 		XcmTransactorPrecompileV3<R>,
-		(CallableByContract, CallableByPrecompile),
+		(
+			SubcallWithMaxNesting<1>,
+			CallableByContract,
+			CallableByPrecompile,
+		),
 	>,
 	PrecompileAt<
 		AddressU64<2072>,

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor.ts
@@ -1,12 +1,13 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, alith } from "@moonwall/util";
-import type { PalletAssetsAssetAccount, PalletAssetsAssetDetails } from "@polkadot/types/lookup";
+import { ALITH_ADDRESS } from "@moonwall/util";
 import { fromBytes } from "viem";
 import {
-  mockOldAssetBalance,
   verifyLatestBlockFees,
   registerXcmTransactorAndContract,
+  registerAndFundAsset,
+  RELAY_SOURCE_LOCATION,
+  relayAssetMetadata,
 } from "../../../../helpers";
 
 describeSuite({
@@ -87,45 +88,35 @@ describeSuite({
       test: async function () {
         // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
         // And we need relay tokens for issuing a transaction to be executed in the relay
-        const balance = context.polkadotJs().createType("Balance", 100000000000000);
-        const assetBalance: PalletAssetsAssetAccount = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetAccount", {
-            balance: balance,
-          });
-
-        const assetId = context
-          .polkadotJs()
-          .createType("u128", 42259045809535163221576417993425387648n);
-        const assetDetails: PalletAssetsAssetDetails = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetDetails", {
-            supply: balance,
-          });
-
-        await mockOldAssetBalance(
-          context,
-          assetBalance,
-          assetDetails,
-          alith,
-          assetId,
+  
+        const { contractAddress } = await registerAndFundAsset(
+          context, 
+          {
+            id: 42259045809535163221576417993425387648n,
+            location: RELAY_SOURCE_LOCATION,
+            metadata: relayAssetMetadata,
+            relativePrice: 1n
+          },
+          100000000000000n,
           ALITH_ADDRESS,
           true
-        );
+        )
 
-        const beforeAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-        const beforeAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
+        const beforeBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        })
 
-        expect(
-          beforeAssetBalance.unwrap().balance.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
-        expect(
-          beforeAssetDetails.unwrap().supply.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
+        const beforeSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        })
+
+        expect(beforeSupply).to.equal(100000000000000n);
+        expect(beforeBalance).to.equal(100000000000000n);
 
         const transactor = 0;
         const index = 0;
@@ -142,18 +133,24 @@ describeSuite({
 
         await context.createBlock(rawTxn);
 
+        const afterBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
+
+        const afterSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
+
         // We have used 1000 units to pay for the fees in the relay  (plus 1 transact_extra_weight),
         // so balance and supply should have changed
-        const afterAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-
         const expectedBalance = 100000000000000n - 1000n - 1n;
-        expect(afterAssetBalance.unwrap().balance.toBigInt()).to.equal(expectedBalance);
-
-        const AfterAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-
-        expect(AfterAssetDetails.unwrap().supply.toBigInt()).to.equal(expectedBalance);
+        expect(afterBalance).to.equal(expectedBalance);
+        expect(afterSupply).to.equal(expectedBalance);
 
         // 1000 fee for the relay is paid with relay assets
         await verifyLatestBlockFees(context);

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor.ts
@@ -86,34 +86,31 @@ describeSuite({
       id: "T05",
       title: "allows to issue transfer xcm transactor",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
-  
         const { contractAddress } = await registerAndFundAsset(
-          context, 
+          context,
           {
             id: 42259045809535163221576417993425387648n,
             location: RELAY_SOURCE_LOCATION,
             metadata: relayAssetMetadata,
-            relativePrice: 1n
+            relativePrice: 1n,
           },
           100000000000000n,
           ALITH_ADDRESS,
           true
-        )
+        );
 
         const beforeBalance = await context.readContract!({
           contractName: "ERC20Instance",
           contractAddress: contractAddress,
           functionName: "balanceOf",
           args: [ALITH_ADDRESS],
-        })
+        });
 
         const beforeSupply = await context.readContract!({
           contractName: "ERC20Instance",
           contractAddress: contractAddress,
           functionName: "totalSupply",
-        })
+        });
 
         expect(beforeSupply).to.equal(100000000000000n);
         expect(beforeBalance).to.equal(100000000000000n);

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
@@ -22,7 +22,7 @@ describeSuite({
 
     let assetAddress;
     beforeAll(async () => {
-      { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+      const { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
       assetAddress = contractAddress;
       await registerXcmTransactorAndContract(context);
     });
@@ -32,7 +32,6 @@ describeSuite({
       title: "allows to transact signed with custom weights V2 and fee",
       test: async function () {
         const dest: [number, any[]] = [1, []];
-        const asset = assetAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");
         const transactWeight = { refTime: 1000, proofSize: 1000 };
         const overallWeight = { refTime: 2000, proofSize: 2000 };
@@ -43,7 +42,7 @@ describeSuite({
           contractAddress: PRECOMPILE_XCM_TRANSACTOR_V3_ADDRESS,
           contractName: "XcmTransactorV3",
           functionName: "transactThroughSigned",
-          args: [dest, asset, transactWeight, transact_call, feeAmount, overallWeight, refund],
+          args: [dest, assetAddress, transactWeight, transact_call, feeAmount, overallWeight, refund],
           gas: 500_000n,
           rawTxOnly: true,
           privateKey: ALITH_PRIVATE_KEY,

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
@@ -19,10 +19,14 @@ describeSuite({
   title: "Precompiles - xcm transactor V3",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-
     let assetAddress;
     beforeAll(async () => {
-      const { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+      const { contractAddress } = await registerForeignAsset(
+        context,
+        1n,
+        RELAY_SOURCE_LOCATION,
+        relayAssetMetadata
+      );
       assetAddress = contractAddress;
       await registerXcmTransactorAndContract(context);
     });
@@ -42,7 +46,15 @@ describeSuite({
           contractAddress: PRECOMPILE_XCM_TRANSACTOR_V3_ADDRESS,
           contractName: "XcmTransactorV3",
           functionName: "transactThroughSigned",
-          args: [dest, assetAddress, transactWeight, transact_call, feeAmount, overallWeight, refund],
+          args: [
+            dest,
+            assetAddress,
+            transactWeight,
+            transact_call,
+            feeAmount,
+            overallWeight,
+            refund,
+          ],
           gas: 500_000n,
           rawTxOnly: true,
           privateKey: ALITH_PRIVATE_KEY,

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor10.ts
@@ -7,7 +7,7 @@ import {
   expectEVMResult,
   RELAY_SOURCE_LOCATION,
   relayAssetMetadata,
-  registerOldForeignAsset,
+  registerForeignAsset,
   registerXcmTransactorAndContract,
   PRECOMPILE_XCM_TRANSACTOR_V3_ADDRESS,
 } from "../../../../helpers";
@@ -19,8 +19,11 @@ describeSuite({
   title: "Precompiles - xcm transactor V3",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
+
+    let assetAddress;
     beforeAll(async () => {
-      await registerOldForeignAsset(context, RELAY_SOURCE_LOCATION, relayAssetMetadata as any);
+      { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+      assetAddress = contractAddress;
       await registerXcmTransactorAndContract(context);
     });
 
@@ -29,7 +32,7 @@ describeSuite({
       title: "allows to transact signed with custom weights V2 and fee",
       test: async function () {
         const dest: [number, any[]] = [1, []];
-        const asset = ADDRESS_RELAY_ASSETS;
+        const asset = assetAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");
         const transactWeight = { refTime: 1000, proofSize: 1000 };
         const overallWeight = { refTime: 2000, proofSize: 2000 };

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor11.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor11.ts
@@ -1,13 +1,14 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, ALITH_PRIVATE_KEY, alith } from "@moonwall/util";
-import type { PalletAssetsAssetAccount, PalletAssetsAssetDetails } from "@polkadot/types/lookup";
+import { ALITH_ADDRESS, ALITH_PRIVATE_KEY } from "@moonwall/util";
 import { fromBytes } from "viem";
 import {
-  mockOldAssetBalance,
   verifyLatestBlockFees,
   expectEVMResult,
   registerXcmTransactorDerivativeIndex,
+  registerAndFundAsset,
+  RELAY_SOURCE_LOCATION,
+  relayAssetMetadata,
   PRECOMPILE_XCM_TRANSACTOR_V3_ADDRESS,
 } from "../../../../helpers";
 
@@ -34,44 +35,35 @@ describeSuite({
       test: async function () {
         // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
         // And we need relay tokens for issuing a transaction to be executed in the relay
-        const balance = context.polkadotJs().createType("Balance", 100000000000000);
-        const assetBalance: PalletAssetsAssetAccount = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetAccount", {
-            balance: balance,
-          });
 
-        const assetId = context
-          .polkadotJs()
-          .createType("u128", 42259045809535163221576417993425387648n);
-        const assetDetails: PalletAssetsAssetDetails = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetDetails", {
-            supply: balance,
-          });
-
-        await mockOldAssetBalance(
-          context,
-          assetBalance,
-          assetDetails,
-          alith,
-          assetId,
+        const { contractAddress } = await registerAndFundAsset(
+          context, 
+          {
+            id: 42259045809535163221576417993425387648n,
+            location: RELAY_SOURCE_LOCATION,
+            metadata: relayAssetMetadata,
+            relativePrice: 1n
+          },
+          100000000000000n,
           ALITH_ADDRESS,
           true
         );
 
-        const beforeAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-        const beforeAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-        expect(
-          beforeAssetBalance.unwrap().balance.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
-        expect(
-          beforeAssetDetails.unwrap().supply.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
+        const beforeBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
+
+        const beforeSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
+
+        expect(beforeSupply).to.equal(100000000000000n);
+        expect(beforeBalance).to.equal(100000000000000n);
 
         const transactor = 0;
         const index = 0;
@@ -104,18 +96,24 @@ describeSuite({
         const { result } = await context.createBlock(rawTx);
         expectEVMResult(result!.events, "Succeed");
 
+        const afterBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
+
+        const afterSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
+
         // We have used 1000 units to pay for the fees in the relay, so balance and supply should
         // have changed
-        const afterAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-
         const expectedBalance = 100000000000000n - 1000n;
-        expect(afterAssetBalance.unwrap().balance.toBigInt()).to.equal(expectedBalance);
-
-        const AfterAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-
-        expect(AfterAssetDetails.unwrap().supply.toBigInt()).to.equal(expectedBalance);
+        expect(afterBalance).to.equal(expectedBalance);
+        expect(afterSupply).to.equal(expectedBalance);
 
         // 1000 fee for the relay is paid with relay assets
         await verifyLatestBlockFees(context);

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor11.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor11.ts
@@ -33,16 +33,13 @@ describeSuite({
       id: "T01",
       title: "allows to transact through derivative multiloc weights v2 and refund",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
-
         const { contractAddress } = await registerAndFundAsset(
-          context, 
+          context,
           {
             id: 42259045809535163221576417993425387648n,
             location: RELAY_SOURCE_LOCATION,
             metadata: relayAssetMetadata,
-            relativePrice: 1n
+            relativePrice: 1n,
           },
           100000000000000n,
           ALITH_ADDRESS,

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor12.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor12.ts
@@ -35,16 +35,13 @@ describeSuite({
       id: "T01",
       title: "allows to issue transfer xcm transactor with currency Id - weights v2 - refund",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
-
         const { contractAddress } = await registerAndFundAsset(
-          context, 
+          context,
           {
             id: 42259045809535163221576417993425387648n,
             location: RELAY_SOURCE_LOCATION,
             metadata: relayAssetMetadata,
-            relativePrice: 1n
+            relativePrice: 1n,
           },
           100000000000000n,
           ALITH_ADDRESS,

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor12.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor12.ts
@@ -1,13 +1,14 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, alith, ALITH_PRIVATE_KEY } from "@moonwall/util";
-import type { PalletAssetsAssetAccount, PalletAssetsAssetDetails } from "@polkadot/types/lookup";
+import { ALITH_ADDRESS, ALITH_PRIVATE_KEY } from "@moonwall/util";
 import { fromBytes } from "viem";
 import {
-  mockOldAssetBalance,
   verifyLatestBlockFees,
   expectEVMResult,
   registerXcmTransactorDerivativeIndex,
+  registerAndFundAsset,
+  RELAY_SOURCE_LOCATION,
+  relayAssetMetadata,
   PRECOMPILE_XCM_TRANSACTOR_V3_ADDRESS,
 } from "../../../../helpers";
 
@@ -36,44 +37,39 @@ describeSuite({
       test: async function () {
         // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
         // And we need relay tokens for issuing a transaction to be executed in the relay
-        const balance = context.polkadotJs().createType("Balance", 100000000000000);
-        const assetBalance: PalletAssetsAssetAccount = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetAccount", {
-            balance: balance,
-          });
 
-        const assetId = context
-          .polkadotJs()
-          .createType("u128", 42259045809535163221576417993425387648n);
-        const assetDetails: PalletAssetsAssetDetails = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetDetails", {
-            supply: balance,
-          });
-
-        await mockOldAssetBalance(
-          context,
-          assetBalance,
-          assetDetails,
-          alith,
-          assetId,
+        const { contractAddress } = await registerAndFundAsset(
+          context, 
+          {
+            id: 42259045809535163221576417993425387648n,
+            location: RELAY_SOURCE_LOCATION,
+            metadata: relayAssetMetadata,
+            relativePrice: 1n
+          },
+          100000000000000n,
           ALITH_ADDRESS,
           true
         );
 
-        const beforeAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
+        const beforeBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
 
-        const beforeAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
+        const beforeSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
 
-        expect(beforeAssetBalance.unwrap().balance.toBigInt()).to.equal(100000000000000n);
-        expect(beforeAssetDetails.unwrap().supply.toBigInt()).to.equal(100000000000000n);
+        expect(beforeBalance).to.equal(100000000000000n);
+        expect(beforeSupply).to.equal(100000000000000n);
 
         const transactor = 0;
         const index = 0;
-        const asset = ADDRESS_RELAY_ASSETS;
+        const asset = contractAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");
         const transactWeight = { refTime: 1000, proofSize: 1000 };
         const overallWeight = { refTime: 2000, proofSize: 2000 };
@@ -102,18 +98,24 @@ describeSuite({
         const result = await context.createBlock(rawTx);
         expectEVMResult(result.result!.events, "Succeed");
 
+        const afterBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
+
+        const afterSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
+
         // We have used 1000 units to pay for the fees in the relay  (plus 1 transact_extra_weight),
         // so balance and supply should have changed
-        const afterAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-
         const expectedBalance = 100000000000000n - 1000n;
-        expect(afterAssetBalance.unwrap().balance.toBigInt()).to.equal(expectedBalance);
-
-        const AfterAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-
-        expect(AfterAssetDetails.unwrap().supply.toBigInt()).to.equal(expectedBalance);
+        expect(afterBalance).to.equal(expectedBalance);
+        expect(afterSupply).to.equal(expectedBalance);
 
         // 1000 fee for the relay is paid with relay assets
         await verifyLatestBlockFees(context);

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor2.ts
@@ -1,13 +1,14 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, alith } from "@moonwall/util";
-import type { PalletAssetsAssetAccount, PalletAssetsAssetDetails } from "@polkadot/types/lookup";
+import { ALITH_ADDRESS } from "@moonwall/util";
 import { fromBytes } from "viem";
 import {
-  mockOldAssetBalance,
   verifyLatestBlockFees,
   expectEVMResult,
   registerXcmTransactorAndContract,
+  registerAndFundAsset,
+  RELAY_SOURCE_LOCATION,
+  relayAssetMetadata,
 } from "../../../../helpers";
 
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
@@ -28,51 +29,40 @@ describeSuite({
         // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
         // And we need relay tokens for issuing a transaction to be executed in the relay
 
-        const balance = context.polkadotJs().createType("Balance", 100000000000000);
-        const assetBalance: PalletAssetsAssetAccount = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetAccount", {
-            balance: balance,
-          });
-
-        const assetId = context
-          .polkadotJs()
-          .createType("u128", 42259045809535163221576417993425387648n);
-        const assetDetails: PalletAssetsAssetDetails = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetDetails", {
-            supply: balance,
-          });
-
-        await mockOldAssetBalance(
-          context,
-          assetBalance,
-          assetDetails,
-          alith,
-          assetId,
+        const { contractAddress } = await registerAndFundAsset(
+          context, 
+          {
+            id: 42259045809535163221576417993425387648n,
+            location: RELAY_SOURCE_LOCATION,
+            metadata: relayAssetMetadata,
+            relativePrice: 1n
+          },
+          100000000000000n,
           ALITH_ADDRESS,
           true
-        );
+        )
+        
+        const beforeBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        })
 
-        const beforeAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
+        const beforeSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        })
 
-        const beforeAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-
-        expect(
-          beforeAssetBalance.unwrap().balance.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
-        expect(
-          beforeAssetDetails.unwrap().supply.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
+        expect(beforeSupply).to.equal(100000000000000n);
+        expect(beforeBalance).to.equal(100000000000000n);
+        
 
         const transactor = 0;
         const index = 0;
         // Destination as currency Id address
-        const asset = ADDRESS_RELAY_ASSETS;
+        const asset = contractAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");
         const weight = 1000;
 

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor2.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor2.ts
@@ -26,40 +26,36 @@ describeSuite({
       id: "T01",
       title: "allows to issue transfer xcm transactor with currency Id",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
-
         const initialBalance = 100000000000000n;
 
         const { contractAddress } = await registerAndFundAsset(
-          context, 
+          context,
           {
             id: 42259045809535163221576417993425387648n,
             location: RELAY_SOURCE_LOCATION,
             metadata: relayAssetMetadata,
-            relativePrice: 1n
+            relativePrice: 1n,
           },
           initialBalance,
           ALITH_ADDRESS,
           true
-        )
-        
+        );
+
         const beforeBalance = await context.readContract!({
           contractName: "ERC20Instance",
           contractAddress: contractAddress,
           functionName: "balanceOf",
           args: [ALITH_ADDRESS],
-        })
+        });
 
         const beforeSupply = await context.readContract!({
           contractName: "ERC20Instance",
           contractAddress: contractAddress,
           functionName: "totalSupply",
-        })
+        });
 
         expect(beforeSupply).to.equal(initialBalance);
         expect(beforeBalance).to.equal(initialBalance);
-        
 
         const transactor = 0;
         const index = 0;

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor3.ts
@@ -17,11 +17,15 @@ describeSuite({
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {
-
     let assetAddress;
 
     beforeAll(async () => {
-      let { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+      let { contractAddress } = await registerForeignAsset(
+        context,
+        1n,
+        RELAY_SOURCE_LOCATION,
+        relayAssetMetadata
+      );
       assetAddress = contractAddress;
       await registerXcmTransactorAndContract(context);
     });
@@ -30,8 +34,6 @@ describeSuite({
       id: "T01",
       title: "allows to issue transfer signed xcm transactor with currency Id",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
         const dest: [number, object[]] = [1, []];
         // Destination as currency Id address
         // const asset = ADDRESS_RELAY_ASSETS;

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor3.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor3.ts
@@ -7,7 +7,7 @@ import {
   verifyLatestBlockFees,
   expectEVMResult,
   registerXcmTransactorAndContract,
-  registerOldForeignAsset,
+  registerForeignAsset,
 } from "../../../../helpers";
 
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
@@ -17,8 +17,12 @@ describeSuite({
   title: "Precompiles - xcm transactor",
   foundationMethods: "dev",
   testCases: ({ context, it }) => {
+
+    let assetAddress;
+
     beforeAll(async () => {
-      await registerOldForeignAsset(context, RELAY_SOURCE_LOCATION, relayAssetMetadata as any);
+      let { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+      assetAddress = contractAddress;
       await registerXcmTransactorAndContract(context);
     });
 
@@ -30,7 +34,8 @@ describeSuite({
         // And we need relay tokens for issuing a transaction to be executed in the relay
         const dest: [number, object[]] = [1, []];
         // Destination as currency Id address
-        const asset = ADDRESS_RELAY_ASSETS;
+        // const asset = ADDRESS_RELAY_ASSETS;
+        const asset = assetAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");
         const weight = 1000;
 

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor4.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor4.ts
@@ -20,8 +20,6 @@ describeSuite({
       id: "T01",
       title: "allows to issue transfer signed xcm transactor with multilocation",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
         const dest: [number, any[]] = [1, []];
         const asset: [number, any[]] = [1, []];
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor5.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor5.ts
@@ -20,8 +20,6 @@ describeSuite({
       id: "T01",
       title: "allows to transact signed multilocation with custom weight and fee",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
         const dest: [number, any[]] = [1, []];
         const asset: [number, any[]] = [1, []];
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor6.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor6.ts
@@ -17,11 +17,15 @@ describeSuite({
   title: "Precompiles - xcm transactor V2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-
     let assetAddress;
 
     beforeAll(async () => {
-      let { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+      let { contractAddress } = await registerForeignAsset(
+        context,
+        1n,
+        RELAY_SOURCE_LOCATION,
+        relayAssetMetadata
+      );
       assetAddress = contractAddress;
       await registerXcmTransactorAndContract(context);
     });
@@ -30,8 +34,6 @@ describeSuite({
       id: "T01",
       title: "allows to transact signed with custom weight and fee",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
         const dest: [number, any[]] = [1, []];
         const asset = assetAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor6.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor6.ts
@@ -6,19 +6,23 @@ import {
   relayAssetMetadata,
   verifyLatestBlockFees,
   expectEVMResult,
-  registerOldForeignAsset,
   registerXcmTransactorAndContract,
+  registerForeignAsset,
 } from "../../../../helpers";
 
-const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
+// const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
 
 describeSuite({
   id: "D022884",
   title: "Precompiles - xcm transactor V2",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
+
+    let assetAddress;
+
     beforeAll(async () => {
-      await registerOldForeignAsset(context, RELAY_SOURCE_LOCATION, relayAssetMetadata as any);
+      let { contractAddress } = await registerForeignAsset(context, 1n, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+      assetAddress = contractAddress;
       await registerXcmTransactorAndContract(context);
     });
 
@@ -29,7 +33,7 @@ describeSuite({
         // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
         // And we need relay tokens for issuing a transaction to be executed in the relay
         const dest: [number, any[]] = [1, []];
-        const asset = ADDRESS_RELAY_ASSETS;
+        const asset = assetAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");
         const transactWeight = 1000;
         const overallWeight = 2000;

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor7.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor7.ts
@@ -1,13 +1,14 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, alith } from "@moonwall/util";
-import type { PalletAssetsAssetAccount, PalletAssetsAssetDetails } from "@polkadot/types/lookup";
+import { ALITH_ADDRESS } from "@moonwall/util";
 import { fromBytes } from "viem";
 import {
-  mockOldAssetBalance,
   verifyLatestBlockFees,
   expectEVMResult,
   registerXcmTransactorDerivativeIndex,
+  registerAndFundAsset,
+  RELAY_SOURCE_LOCATION,
+  relayAssetMetadata,
 } from "../../../../helpers";
 
 describeSuite({
@@ -32,44 +33,35 @@ describeSuite({
       test: async function () {
         // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
         // And we need relay tokens for issuing a transaction to be executed in the relay
-        const balance = context.polkadotJs().createType("Balance", 100000000000000);
-        const assetBalance: PalletAssetsAssetAccount = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetAccount", {
-            balance: balance,
-          });
 
-        const assetId = context
-          .polkadotJs()
-          .createType("u128", 42259045809535163221576417993425387648n);
-        const assetDetails: PalletAssetsAssetDetails = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetDetails", {
-            supply: balance,
-          });
-
-        await mockOldAssetBalance(
-          context,
-          assetBalance,
-          assetDetails,
-          alith,
-          assetId,
+        const { contractAddress } = await registerAndFundAsset(
+          context, 
+          {
+            id: 42259045809535163221576417993425387648n,
+            location: RELAY_SOURCE_LOCATION,
+            metadata: relayAssetMetadata,
+            relativePrice: 1n
+          },
+          100000000000000n,
           ALITH_ADDRESS,
           true
         );
 
-        const beforeAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-        const beforeAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-        expect(
-          beforeAssetBalance.unwrap().balance.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
-        expect(
-          beforeAssetDetails.unwrap().supply.toBigInt(),
-          "supply and balance should be the same"
-        ).to.equal(100000000000000n);
+        const beforeBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
+
+        const beforeSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
+
+        expect(beforeSupply).to.equal(100000000000000n);
+        expect(beforeBalance).to.equal(100000000000000n);
 
         const transactor = 0;
         const index = 0;
@@ -92,18 +84,24 @@ describeSuite({
 
         expectEVMResult(result.result!.events, "Succeed");
 
+        const afterBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
+
+        const afterSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
+
         // We have used 1000 units to pay for the fees in the relay, so balance and supply should
         // have changed
-        const afterAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-
         const expectedBalance = 100000000000000n - 1000n;
-        expect(afterAssetBalance.unwrap().balance.toBigInt()).to.equal(expectedBalance);
-
-        const AfterAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-
-        expect(AfterAssetDetails.unwrap().supply.toBigInt()).to.equal(expectedBalance);
+        expect(afterBalance).to.equal(expectedBalance);
+        expect(afterSupply).to.equal(expectedBalance);
 
         // 1000 fee for the relay is paid with relay assets
         await verifyLatestBlockFees(context);

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor7.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor7.ts
@@ -31,16 +31,13 @@ describeSuite({
       id: "T01",
       title: "allows to transact through derivative multiloc custom fee and weight",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
-
         const { contractAddress } = await registerAndFundAsset(
-          context, 
+          context,
           {
             id: 42259045809535163221576417993425387648n,
             location: RELAY_SOURCE_LOCATION,
             metadata: relayAssetMetadata,
-            relativePrice: 1n
+            relativePrice: 1n,
           },
           100000000000000n,
           ALITH_ADDRESS,

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor8.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor8.ts
@@ -1,13 +1,14 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
-import { ALITH_ADDRESS, alith } from "@moonwall/util";
-import type { PalletAssetsAssetAccount, PalletAssetsAssetDetails } from "@polkadot/types/lookup";
+import { ALITH_ADDRESS } from "@moonwall/util";
 import { fromBytes } from "viem";
 import {
-  mockOldAssetBalance,
   verifyLatestBlockFees,
   expectEVMResult,
   registerXcmTransactorDerivativeIndex,
+  registerAndFundAsset,
+  RELAY_SOURCE_LOCATION,
+  relayAssetMetadata,
 } from "../../../../helpers";
 
 const ADDRESS_RELAY_ASSETS = "0xffffffff1fcacbd218edc0eba20fc2308c778080";
@@ -35,44 +36,38 @@ describeSuite({
         // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
         // And we need relay tokens for issuing a transaction to be executed in the relay
 
-        const balance = context.polkadotJs().createType("Balance", 100000000000000);
-        const assetBalance: PalletAssetsAssetAccount = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetAccount", {
-            balance: balance,
-          });
-
-        const assetId = context
-          .polkadotJs()
-          .createType("u128", 42259045809535163221576417993425387648n);
-        const assetDetails: PalletAssetsAssetDetails = context
-          .polkadotJs()
-          .createType("PalletAssetsAssetDetails", {
-            supply: balance,
-          });
-
-        await mockOldAssetBalance(
-          context,
-          assetBalance,
-          assetDetails,
-          alith,
-          assetId,
+        const { contractAddress } = await registerAndFundAsset(
+          context, 
+          {
+            id: 42259045809535163221576417993425387648n,
+            location: RELAY_SOURCE_LOCATION,
+            metadata: relayAssetMetadata,
+            relativePrice: 1n
+          },
+          100000000000000n,
           ALITH_ADDRESS,
           true
-        );
+        )
 
-        const beforeAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
+        const beforeBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        })
 
-        const beforeAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
+        const beforeSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        })
 
-        expect(beforeAssetBalance.unwrap().balance.toBigInt()).to.equal(100000000000000n);
-        expect(beforeAssetDetails.unwrap().supply.toBigInt()).to.equal(100000000000000n);
+        expect(beforeSupply).to.equal(100000000000000n);
+        expect(beforeBalance).to.equal(100000000000000n);
 
         const transactor = 0;
         const index = 0;
-        const asset = ADDRESS_RELAY_ASSETS;
+        const asset = contractAddress;
         const transact_call = fromBytes(new Uint8Array([0x01]), "hex");
         const transactWeight = 500;
         const overallWeight = 1000;
@@ -89,18 +84,24 @@ describeSuite({
         const result = await context.createBlock(rawTxn);
         expectEVMResult(result.result!.events, "Succeed");
 
-        // We have used 1000 units to pay for the fees in the relay  (plus 1 transact_extra_weight),
+        const afterBalance = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "balanceOf",
+          args: [ALITH_ADDRESS],
+        });
+
+        const afterSupply = await context.readContract!({
+          contractName: "ERC20Instance",
+          contractAddress: contractAddress,
+          functionName: "totalSupply",
+        });
+
+        // We have used 1000 units to pay for the fees in the relay,
         // so balance and supply should have changed
-        const afterAssetBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId.toU8a(), ALITH_ADDRESS);
-
         const expectedBalance = 100000000000000n - 1000n;
-        expect(afterAssetBalance.unwrap().balance.toBigInt()).to.equal(expectedBalance);
-
-        const AfterAssetDetails = await context.polkadotJs().query.assets.asset(assetId.toU8a());
-
-        expect(AfterAssetDetails.unwrap().supply.toBigInt()).to.equal(expectedBalance);
+        expect(afterBalance).to.equal(expectedBalance);
+        expect(afterSupply).to.equal(expectedBalance);
 
         // 1000 fee for the relay is paid with relay assets
         await verifyLatestBlockFees(context);

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor8.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-xcm-transactor8.ts
@@ -33,34 +33,31 @@ describeSuite({
       id: "T01",
       title: "allows to issue transfer xcm transactor with currency Id",
       test: async function () {
-        // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
-        // And we need relay tokens for issuing a transaction to be executed in the relay
-
         const { contractAddress } = await registerAndFundAsset(
-          context, 
+          context,
           {
             id: 42259045809535163221576417993425387648n,
             location: RELAY_SOURCE_LOCATION,
             metadata: relayAssetMetadata,
-            relativePrice: 1n
+            relativePrice: 1n,
           },
           100000000000000n,
           ALITH_ADDRESS,
           true
-        )
+        );
 
         const beforeBalance = await context.readContract!({
           contractName: "ERC20Instance",
           contractAddress: contractAddress,
           functionName: "balanceOf",
           args: [ALITH_ADDRESS],
-        })
+        });
 
         const beforeSupply = await context.readContract!({
           contractName: "ERC20Instance",
           contractAddress: contractAddress,
           functionName: "totalSupply",
-        })
+        });
 
         expect(beforeSupply).to.equal(100000000000000n);
         expect(beforeBalance).to.equal(100000000000000n);


### PR DESCRIPTION
### What does it do?

This PR allows XCM Transactor precompiles to do one nested call, needed for interacting with ERC20 contracts and handle the new Foreign Assets. In addition, it updates the XCM transactor TS tests.

### Is there something left for follow-up PRs?

While handling a specific bug, this PR is also part of the broader refactoring and removal of old foreign assets logic. There are more tests to be updated and logic to be replaced with the new `moonbeam-foreign-assets` pallet and its helpers.
