### PR TITLE
Fix Typos in Documentation and Comments Across Multiple Modules

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -18,7 +18,7 @@
 //! between them. This is the backbone of the client-side node implementation.
 //!
 //! This module can assemble:
-//! PartialComponents: For maintence tasks without a complete node (eg import/export blocks, purge)
+//! PartialComponents: For maintenance tasks without a complete node (eg import/export blocks, purge)
 //! Full Service: A complete parachain node including the pool, rpc, network, embedded relay chain
 //! Dev Service: A leaner service without the relay chain backing.
 
@@ -1154,7 +1154,7 @@ where
 }
 
 /// Start a normal parachain node.
-// Rustfmt wants to format the closure with space identation.
+// Rustfmt wants to format the closure with space indentation.
 #[rustfmt::skip]
 pub async fn start_node<RuntimeApi, Customizations>(
 	parachain_config: Configuration,

--- a/pallets/moonbeam-foreign-assets/src/lib.rs
+++ b/pallets/moonbeam-foreign-assets/src/lib.rs
@@ -200,7 +200,7 @@ pub mod pallet {
 		/// Hook to be called when new foreign asset is registered.
 		type OnForeignAssetCreated: ForeignAssetCreatedHook<Location>;
 
-		/// Maximum numbers of differnt foreign assets
+		/// Maximum numbers of different foreign assets
 		type MaxForeignAssets: Get<u32>;
 
 		/// The overarching event type.

--- a/pallets/xcm-weight-trader/src/tests.rs
+++ b/pallets/xcm-weight-trader/src/tests.rs
@@ -220,7 +220,7 @@ fn test_pause_asset_support() {
 			Error::<Test>::AssetAlreadyPaused
 		);
 
-		// Should be able to udpate relative price of paused asset
+		// Should be able to update relative price of paused asset
 		assert_ok!(XcmWeightTrader::edit_asset(
 			RuntimeOrigin::signed(EditAccount::get()),
 			Location::parent(),


### PR DESCRIPTION


---

**Description:**  
This pull request corrects several minor typos in documentation and comments throughout the codebase, including:
- Fixing spelling errors such as "maintence" → "maintenance", "identation" → "indentation", and "diffrent" → "different".

---