### PR TITLE
remove pallet-precompile-benchmarks instance from on-chain runtime

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1403,6 +1403,7 @@ impl pallet_relay_storage_roots::Config for Runtime {
 	type WeightInfo = moonbase_weights::pallet_relay_storage_roots::WeightInfo<Runtime>;
 }
 
+#[cfg(feature = "runtime-benchmarks")]
 impl pallet_precompile_benchmarks::Config for Runtime {
 	type WeightInfo = moonbase_weights::pallet_precompile_benchmarks::WeightInfo<Runtime>;
 }
@@ -1490,7 +1491,10 @@ construct_runtime! {
 		AsyncBacking: pallet_async_backing::{Pallet, Storage} = 50,
 		MoonbeamLazyMigrations: pallet_moonbeam_lazy_migrations::{Pallet, Call, Storage} = 51,
 		RelayStorageRoots: pallet_relay_storage_roots::{Pallet, Storage} = 52,
+
+		#[cfg(feature = "runtime-benchmarks")]
 		PrecompileBenchmarks: pallet_precompile_benchmarks::{Pallet} = 53,
+
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 54,
 		EmergencyParaXcm: pallet_emergency_para_xcm::{Pallet, Call, Storage, Event} = 55,
 		EvmForeignAssets: pallet_moonbeam_foreign_assets::{Pallet, Call, Storage, Event<T>} = 56,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1384,6 +1384,7 @@ impl pallet_relay_storage_roots::Config for Runtime {
 	type WeightInfo = moonbeam_weights::pallet_relay_storage_roots::WeightInfo<Runtime>;
 }
 
+#[cfg(feature = "runtime-benchmarks")]
 impl pallet_precompile_benchmarks::Config for Runtime {
 	type WeightInfo = moonbeam_weights::pallet_precompile_benchmarks::WeightInfo<Runtime>;
 }
@@ -1499,7 +1500,7 @@ construct_runtime! {
 		// Utils
 		RelayStorageRoots: pallet_relay_storage_roots::{Pallet, Storage} = 112,
 
-		// TODO should not be included in production
+		#[cfg(feature = "runtime-benchmarks")]
 		PrecompileBenchmarks: pallet_precompile_benchmarks::{Pallet} = 113,
 
 		// Randomness

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1389,6 +1389,7 @@ impl pallet_relay_storage_roots::Config for Runtime {
 	type WeightInfo = moonriver_weights::pallet_relay_storage_roots::WeightInfo<Runtime>;
 }
 
+#[cfg(feature = "runtime-benchmarks")]
 impl pallet_precompile_benchmarks::Config for Runtime {
 	type WeightInfo = moonriver_weights::pallet_precompile_benchmarks::WeightInfo<Runtime>;
 }
@@ -1502,6 +1503,8 @@ construct_runtime! {
 
 		// Utils
 		RelayStorageRoots: pallet_relay_storage_roots::{Pallet, Storage} = 112,
+
+		#[cfg(feature = "runtime-benchmarks")]
 		PrecompileBenchmarks: pallet_precompile_benchmarks::{Pallet} = 113,
 
 		// Randomness


### PR DESCRIPTION
### What does it do?

Removes `pallet-precompile-benchmark` instance from production runtimes. This pallet is only used to benchmarking precompiles and should not be included in the runtime.