### PR TITLE
add support "finalized" tag in debug_* RPC methods (like `debug_traceBlockByHash`)

### DIFF
--- a/client/rpc-core/types/src/lib.rs
+++ b/client/rpc-core/types/src/lib.rs
@@ -29,6 +29,7 @@ pub enum RequestBlockId {
 #[serde(rename_all = "camelCase")]
 pub enum RequestBlockTag {
 	Earliest,
+	Finalized,
 	Latest,
 	Pending,
 }

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -378,6 +378,9 @@ where
 			RequestBlockId::Tag(RequestBlockTag::Latest) => {
 				Ok(BlockId::Number(client.info().best_number))
 			}
+			RequestBlockId::Tag(RequestBlockTag::Finalized) => {
+				Ok(BlockId::Number(client.info().finalized_hash))
+			}
 			RequestBlockId::Tag(RequestBlockTag::Earliest) => {
 				Ok(BlockId::Number(0u32.unique_saturated_into()))
 			}
@@ -859,6 +862,9 @@ where
 			RequestBlockId::Number(n) => Ok(BlockId::Number(n.unique_saturated_into())),
 			RequestBlockId::Tag(RequestBlockTag::Latest) => {
 				Ok(BlockId::Number(client.info().best_number))
+			}
+			RequestBlockId::Tag(RequestBlockTag::Finalized) => {
+				Ok(BlockId::Number(client.info().finalized_hash))
 			}
 			RequestBlockId::Tag(RequestBlockTag::Earliest) => {
 				Ok(BlockId::Number(0u32.unique_saturated_into()))

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -102,6 +102,9 @@ where
 				Ok(self.client.info().best_number)
 			}
 			Some(RequestBlockId::Tag(RequestBlockTag::Earliest)) => Ok(0),
+			Some(RequestBlockId::Tag(RequestBlockTag::Finalized)) => {
+				Ok(self.client.info().finalized_hash)
+			}
 			Some(RequestBlockId::Tag(RequestBlockTag::Pending)) => {
 				Err("'pending' is not supported")
 			}


### PR DESCRIPTION
### What does it do?

We already support tags `"latest"`, `"pending"`, and `"earliest"` in debug_* RPC methods, so at this point, we can support `"finalized"` as well. The change is small and should not require future maintenance, as the client object has exposed the finalized hash since the beginning of Substrate.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
