### PR TITLE
Allow multiple un-bonding requests per address

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -711,12 +711,13 @@ mod benchmarks {
 		_(RawOrigin::Signed(caller.clone()), min_candidate_stk);
 
 		let state = Pallet::<T>::candidate_info(&caller).expect("request bonded less so exists");
+		assert_eq!(state.bond_less_requests.len(), 1);
 		assert_eq!(
-			state.request,
-			Some(CandidateBondLessRequest {
+			state.bond_less_requests[0],
+			CandidateBondLessRequest {
 				amount: min_candidate_stk,
 				when_executable: T::CandidateBondLessDelay::get() + 1,
-			})
+			}
 		);
 		Ok(())
 	}
@@ -832,8 +833,8 @@ mod benchmarks {
 
 		assert!(Pallet::<T>::candidate_info(&caller)
 			.expect("must exist")
-			.request
-			.is_none());
+			.bond_less_requests
+			.is_empty());
 		Ok(())
 	}
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1636,13 +1636,6 @@ pub mod pallet {
 						error: err,
 					})?;
 
-			// Emit event for the total amount executed
-			Self::deposit_event(Event::CandidateBondedLess {
-				candidate: candidate.clone(),
-				amount: total_executed.into(),
-				new_bond: state.bond.into(),
-			});
-
 			<CandidateInfo<T>>::insert(&candidate, state);
 			Ok(Some(actual_weight).into())
 		}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1628,7 +1628,7 @@ pub mod pallet {
 			let actual_weight =
 				<T as Config>::WeightInfo::execute_candidate_bond_less(T::MaxCandidates::get());
 
-			let total_executed =
+			let _total_executed =
 				state
 					.execute_bond_less::<T>(candidate.clone())
 					.map_err(|err| DispatchErrorWithPostInfo {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -80,7 +80,9 @@ pub mod pallet {
 	use crate::delegation_requests::{
 		CancelledScheduledRequest, DelegationAction, ScheduledRequest,
 	};
-	use crate::{set::BoundedOrderedSet, traits::*, types::*, InflationInfo, Range, WeightInfo};
+	use crate::{
+		migrations, set::BoundedOrderedSet, traits::*, types::*, InflationInfo, Range, WeightInfo,
+	};
 	use crate::{AutoCompoundConfig, AutoCompoundDelegations};
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
@@ -98,6 +100,7 @@ pub mod pallet {
 	/// Pallet for parachain staking
 	#[pallet::pallet]
 	#[pallet::without_storage_info]
+	#[pallet::storage_version(migrations::STORAGE_VERSION)]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	pub type RoundIndex = u32;

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1628,12 +1628,21 @@ pub mod pallet {
 			let actual_weight =
 				<T as Config>::WeightInfo::execute_candidate_bond_less(T::MaxCandidates::get());
 
-			state
-				.execute_bond_less::<T>(candidate.clone())
-				.map_err(|err| DispatchErrorWithPostInfo {
-					post_info: Some(actual_weight).into(),
-					error: err,
-				})?;
+			let total_executed =
+				state
+					.execute_bond_less::<T>(candidate.clone())
+					.map_err(|err| DispatchErrorWithPostInfo {
+						post_info: Some(actual_weight).into(),
+						error: err,
+					})?;
+
+			// Emit event for the total amount executed
+			Self::deposit_event(Event::CandidateBondedLess {
+				candidate: candidate.clone(),
+				amount: total_executed.into(),
+				new_bond: state.bond.into(),
+			});
+
 			<CandidateInfo<T>>::insert(&candidate, state);
 			Ok(Some(actual_weight).into())
 		}

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use sp_std::{vec::Vec, vec};
 use frame_support::{
 	traits::{Get, OnRuntimeUpgrade},
 	weights::Weight,
@@ -22,6 +21,7 @@ use frame_support::{
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
+use sp_std::{vec, vec::Vec};
 
 use crate::*;
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -27,7 +27,7 @@ use crate::delegation_requests::{CancelledScheduledRequest, DelegationAction, Sc
 use crate::mock::{
 	inflation_configs, roll_blocks, roll_to, roll_to_round_begin, roll_to_round_end, set_author,
 	set_block_author, AccountId, Balances, BlockNumber, ExtBuilder, ParachainStaking, RuntimeEvent,
-	RuntimeOrigin, Test, POINTS_PER_BLOCK, POINTS_PER_ROUND,
+	RuntimeOrigin, System, Test, POINTS_PER_BLOCK, POINTS_PER_ROUND,
 };
 use crate::{
 	assert_events_emitted, assert_events_emitted_match, assert_events_eq, assert_no_events,
@@ -39,7 +39,6 @@ use frame_support::traits::{Currency, ExistenceRequirement, WithdrawReasons};
 use frame_support::{assert_noop, assert_ok, BoundedVec};
 use pallet_balances::{Event as BalancesEvent, PositiveImbalance};
 use sp_runtime::{traits::Zero, DispatchError, ModuleError, Perbill, Percent};
-// ~~ ROOT ~~
 
 #[test]
 fn invalid_root_origin_fails() {

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -181,28 +181,6 @@ pub struct DelayedPayout<Balance> {
 	pub collator_commission: Perbill,
 }
 
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
-/// DEPRECATED
-/// Collator state with commission fee, bonded stake, and delegations
-pub struct Collator2<AccountId, Balance> {
-	/// The account of this collator
-	pub id: AccountId,
-	/// This collator's self stake.
-	pub bond: Balance,
-	/// Set of all nominator AccountIds (to prevent >1 nomination per AccountId)
-	pub nominators: OrderedSet<AccountId>,
-	/// Top T::MaxDelegatorsPerCollator::get() nominators, ordered greatest to least
-	pub top_nominators: Vec<Bond<AccountId, Balance>>,
-	/// Bottom nominators (unbounded), ordered least to greatest
-	pub bottom_nominators: Vec<Bond<AccountId, Balance>>,
-	/// Sum of top delegations + self.bond
-	pub total_counted: Balance,
-	/// Sum of all delegations + self.bond = (total_counted + uncounted)
-	pub total_backing: Balance,
-	/// Current status of the collator
-	pub state: CollatorStatus,
-}
-
 #[derive(PartialEq, Clone, Copy, Encode, Decode, RuntimeDebug, TypeInfo)]
 /// Request scheduled to change the collator candidate self-bond
 pub struct CandidateBondLessRequest<Balance> {
@@ -1541,38 +1519,6 @@ pub mod deprecated {
 		}
 	}
 }
-
-#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
-/// DEPRECATED in favor of Delegator
-/// Nominator state
-pub struct Nominator2<AccountId, Balance> {
-	/// All current delegations
-	pub delegations: OrderedSet<Bond<AccountId, Balance>>,
-	/// Delegations scheduled to be revoked
-	pub revocations: OrderedSet<AccountId>,
-	/// Total balance locked for this nominator
-	pub total: Balance,
-	/// Total number of revocations scheduled to be executed
-	pub scheduled_revocations_count: u32,
-	/// Total amount to be unbonded once revocations are executed
-	pub scheduled_revocations_total: Balance,
-	/// Status for this nominator
-	pub status: DelegatorStatus,
-}
-
-// /// Temporary function to migrate state
-// pub(crate) fn migrate_nominator_to_delegator_state<T: Config>(
-// 	id: T::AccountId,
-// 	nominator: Nominator2<T::AccountId, BalanceOf<T>>,
-// ) -> Delegator<T::AccountId, BalanceOf<T>> {
-// 	Delegator {
-// 		id,
-// 		delegations: nominator.delegations,
-// 		total: nominator.total,
-// 		requests: PendingDelegationRequests::new(),
-// 		status: nominator.status,
-// 	}
-// }
 
 #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
 /// The current round index and transition information

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -203,51 +203,11 @@ pub struct Collator2<AccountId, Balance> {
 	pub state: CollatorStatus,
 }
 
-impl<A, B> From<Collator2<A, B>> for CollatorCandidate<A, B> {
-	fn from(other: Collator2<A, B>) -> CollatorCandidate<A, B> {
-		CollatorCandidate {
-			id: other.id,
-			bond: other.bond,
-			delegators: other.nominators,
-			top_delegations: other.top_nominators,
-			bottom_delegations: other.bottom_nominators,
-			total_counted: other.total_counted,
-			total_backing: other.total_backing,
-			request: None,
-			state: other.state,
-		}
-	}
-}
-
 #[derive(PartialEq, Clone, Copy, Encode, Decode, RuntimeDebug, TypeInfo)]
 /// Request scheduled to change the collator candidate self-bond
 pub struct CandidateBondLessRequest<Balance> {
 	pub amount: Balance,
 	pub when_executable: RoundIndex,
-}
-
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
-/// DEPRECATED, replaced by `CandidateMetadata` and two storage instances of `Delegations`
-/// Collator candidate state with self bond + delegations
-pub struct CollatorCandidate<AccountId, Balance> {
-	/// The account of this collator
-	pub id: AccountId,
-	/// This collator's self stake.
-	pub bond: Balance,
-	/// Set of all delegator AccountIds (to prevent >1 delegation per AccountId)
-	pub delegators: OrderedSet<AccountId>,
-	/// Top T::MaxDelegatorsPerCollator::get() delegations, ordered greatest to least
-	pub top_delegations: Vec<Bond<AccountId, Balance>>,
-	/// Bottom delegations (unbounded), ordered least to greatest
-	pub bottom_delegations: Vec<Bond<AccountId, Balance>>,
-	/// Sum of top delegations + self.bond
-	pub total_counted: Balance,
-	/// Sum of all delegations + self.bond = (total_counted + uncounted)
-	pub total_backing: Balance,
-	/// Maximum 1 pending request to decrease candidate self bond at any given time
-	pub request: Option<CandidateBondLessRequest<Balance>>,
-	/// Current status of the collator
-	pub state: CollatorStatus,
 }
 
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
@@ -1160,102 +1120,12 @@ impl<
 	}
 }
 
-// Temporary manual implementation for migration testing purposes
-impl<A: PartialEq, B: PartialEq> PartialEq for CollatorCandidate<A, B> {
-	fn eq(&self, other: &Self) -> bool {
-		let must_be_true = self.id == other.id
-			&& self.bond == other.bond
-			&& self.total_counted == other.total_counted
-			&& self.total_backing == other.total_backing
-			&& self.request == other.request
-			&& self.state == other.state;
-		if !must_be_true {
-			return false;
-		}
-		for (x, y) in self.delegators.0.iter().zip(other.delegators.0.iter()) {
-			if x != y {
-				return false;
-			}
-		}
-		for (
-			Bond {
-				owner: o1,
-				amount: a1,
-			},
-			Bond {
-				owner: o2,
-				amount: a2,
-			},
-		) in self
-			.top_delegations
-			.iter()
-			.zip(other.top_delegations.iter())
-		{
-			if o1 != o2 || a1 != a2 {
-				return false;
-			}
-		}
-		for (
-			Bond {
-				owner: o1,
-				amount: a1,
-			},
-			Bond {
-				owner: o2,
-				amount: a2,
-			},
-		) in self
-			.bottom_delegations
-			.iter()
-			.zip(other.bottom_delegations.iter())
-		{
-			if o1 != o2 || a1 != a2 {
-				return false;
-			}
-		}
-		true
-	}
-}
-
 /// Convey relevant information describing if a delegator was added to the top or bottom
 /// Delegations added to the top yield a new total
 #[derive(Clone, Copy, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub enum DelegatorAdded<B> {
 	AddedToTop { new_total: B },
 	AddedToBottom,
-}
-
-impl<
-		A: Ord + Clone + sp_std::fmt::Debug,
-		B: AtLeast32BitUnsigned
-			+ Ord
-			+ Copy
-			+ sp_std::ops::AddAssign
-			+ sp_std::ops::SubAssign
-			+ sp_std::fmt::Debug,
-	> CollatorCandidate<A, B>
-{
-	pub fn is_active(&self) -> bool {
-		self.state == CollatorStatus::Active
-	}
-}
-
-impl<A: Clone, B: Copy> From<CollatorCandidate<A, B>> for CollatorSnapshot<A, B> {
-	fn from(other: CollatorCandidate<A, B>) -> CollatorSnapshot<A, B> {
-		CollatorSnapshot {
-			bond: other.bond,
-			delegations: other
-				.top_delegations
-				.into_iter()
-				.map(|d| BondWithAutoCompound {
-					owner: d.owner,
-					amount: d.amount,
-					auto_compound: Percent::zero(),
-				})
-				.collect(),
-			total: other.total_counted,
-		}
-	}
 }
 
 #[allow(deprecated)]

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -439,7 +439,7 @@ where
 		let pending = if let Some(state) =
 			<pallet_parachain_staking::Pallet<Runtime>>::candidate_info(&candidate)
 		{
-			state.request.is_some()
+			!state.bond_less_requests.is_empty()
 		} else {
 			log::trace!(
 				target: "staking-precompile",

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -19,34 +19,23 @@
 //! This module acts as a registry where each migration is defined. Each migration should implement
 //! the "Migration" trait declared in the pallet-migrations crate.
 
-use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_migrations::{GetMigrations, Migration};
 use sp_std::{marker::PhantomData, prelude::*, vec};
 
-pub struct MigrateToLatestXcmVersion<Runtime>(PhantomData<Runtime>);
-impl<Runtime> Migration for MigrateToLatestXcmVersion<Runtime>
-where
-	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>: OnRuntimeUpgrade,
-{
-	fn friendly_name(&self) -> &str {
-		"MM_MigrateToV5XcmVersion"
-	}
+/// Unreleased migrations. Add new ones here:
+pub type UnreleasedSingleBlockMigrations<Runtime> =
+	(pallet_parachain_staking::migrations::MigrateToV1<Runtime>,);
 
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		pallet_xcm::migration::MigrateToLatestXcmVersion::<Runtime>::on_runtime_upgrade()
-	}
+/// Migrations/checks that do not need to be versioned and can run on every update.
+pub type PermanentSingleBlockMigrations<Runtime> =
+	(pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);
 
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
-		pallet_xcm::migration::MigrateToLatestXcmVersion::<Runtime>::pre_upgrade()
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self, state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		pallet_xcm::migration::MigrateToLatestXcmVersion::<Runtime>::post_upgrade(state)
-	}
-}
+/// All migrations that will run on the next runtime upgrade.
+pub type SingleBlockMigrations<Runtime> = (
+	UnreleasedSingleBlockMigrations<Runtime>,
+	PermanentSingleBlockMigrations<Runtime>,
+);
 
 pub struct CommonMigrations<Runtime>(PhantomData<Runtime>);
 
@@ -202,7 +191,7 @@ where
 			// Box::new(MigrateStakingParachainBondConfig::<Runtime>(Default::default())),
 
 			// permanent migrations
-			Box::new(MigrateToLatestXcmVersion::<Runtime>(Default::default())),
+			//Box::new(MigrateToLatestXcmVersion::<Runtime>(Default::default())),
 		]
 	}
 }

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -308,7 +308,10 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<1287>;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type SingleBlockMigrations = ();
+	type SingleBlockMigrations = (
+		// Common migrations applied on all Moonbeam runtime
+		moonbeam_runtime_common::migrations::SingleBlockMigrations<Runtime>,
+	);
 	type MultiBlockMigrator = MultiBlockMigrations;
 	type PreInherents = ();
 	type PostInherents = ();

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -299,7 +299,10 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<1284>;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type SingleBlockMigrations = ();
+	type SingleBlockMigrations = (
+		// Common migrations applied on all Moonbeam runtime
+		moonbeam_runtime_common::migrations::SingleBlockMigrations<Runtime>,
+	);
 	type MultiBlockMigrator = MultiBlockMigrations;
 	type PreInherents = ();
 	type PostInherents = ();

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -307,7 +307,10 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<1285>;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
-	type SingleBlockMigrations = ();
+	type SingleBlockMigrations = (
+		// Common migrations applied on all Moonbeam runtime
+		moonbeam_runtime_common::migrations::SingleBlockMigrations<Runtime>,
+	);
 	type MultiBlockMigrator = MultiBlockMigrations;
 	type PreInherents = ();
 	type PostInherents = ();

--- a/test/suites/dev/moonbase/test-staking/test-candidate-join3.ts
+++ b/test/suites/dev/moonbase/test-staking/test-candidate-join3.ts
@@ -35,7 +35,7 @@ describeSuite({
           lowestBottomDelegationAmount: 0,
           topCapacity: "Empty",
           bottomCapacity: "Empty",
-          request: null,
+          bondLessRequests: [],
           status: { active: null },
         });
       },


### PR DESCRIPTION
## ⚠️ Breaking Changes ⚠️

  - **Storage Changes**: The `CandidateMetadata` structure has changed. Any code directly accessing `candidate.request` must now use `candidate.bond_less_requests`.
  - **Behavior Changes**:
    - `schedule_candidate_bond_less` extrinsic no longer fails with **PendingCandidateRequestAlreadyExists** when a request exists. Multiple requests can now be scheduled.
    - `cancel_candidate_bond_less` extrinsic cancels **ALL** pending requests, not just one. Multiple CancelledCandidateBondLess events will be emitted.
    - `execute_candidate_bond_less` extrinsic executes only the first eligible request per call, maintaining backward compatibility with existing behavior.
  - **Runtime Upgrade Required**: A migration is included to convert the storage to the new format.


### What does it do?

This PR enhances the `parachain-staking` pallet to support multiple candidate bond less requests, allowing collators to schedule multiple bond reduction requests that can be executed as they become eligible.

#### Core Changes

  - **Storage**: Changed the `CandidateMetadata` struct by replacing `request: Option<CandidateBondLessRequest>` with `bond_less_requests: Vec<CandidateBondLessRequest>` to store multiple pending requests
  - **Request Scheduling**: `schedule_candidate_bond_less` extrinsic now adds requests to a vector instead of replacing a single request
  - **Request Execution**: `execute_candidate_bond_less` extrinsic executes the first eligible request (FIFO) instead of a single pending request
  - **Request Cancellation**: `cancel_candidate_bond_less` extrinsic now cancels all pending requests and emits an event for each cancelled request

#### Additional Updates

  - Added migration MigrateCandidateBondLessRequests to convert existing single requests to the new vector format
  - Updated benchmarks to work with the new structure
  - Updated the staking precompile to check if any bond less requests exist
  - Added comprehensive tests for multiple request scenarios


###  Security Considerations

  - The total pending bond reductions are validated against the minimum candidate stake requirement when scheduling new requests
  - Requests are executed in FIFO order (first scheduled, first executed when eligible)
  - All existing security checks remain in place


### Testing

  - Added new tests for multiple request scenarios:
    - can_schedule_multiple_candidate_bond_less_requests
    - execute_candidate_bond_less_with_multiple_requests
    - cancel_candidate_bond_less_with_multiple_requests
    - cannot_schedule_candidate_bond_less_if_total_pending_exceeds_available

---

🤖 The changes in this PR contain assistance from an AI agent.