### PR TITLE
Foreign Assets Tests: update `dev/test-xcm`  to use new foreign assets

### DIFF
--- a/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-1.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-1.ts
@@ -16,7 +16,6 @@ import {
 // Twelve decimal places in the moonbase relay chain's token
 const RELAY_TOKEN = 10n ** relayAssetMetadata.decimals; // 12 decimals
 
-
 describeSuite({
   id: "D024002",
   title: "Mock XCM - downward transfer with non-triggered error handler",
@@ -25,18 +24,9 @@ describeSuite({
     const assetId = 1n;
 
     beforeAll(async () => {
-      await registerForeignAsset(
-        context,
-        assetId,
-        RELAY_SOURCE_LOCATION,
-        relayAssetMetadata
-      );
+      await registerForeignAsset(context, assetId, RELAY_SOURCE_LOCATION, relayAssetMetadata);
 
-      await addAssetToWeightTrader(
-        RELAY_SOURCE_LOCATION,
-        1_000_000_000_000_000_000n,
-        context
-      )
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, 1_000_000_000_000_000_000n, context);
     });
 
     for (const xcmVersion of XCM_VERSIONS) {
@@ -44,7 +34,6 @@ describeSuite({
         id: `T01-XCM-v${xcmVersion}`,
         title: `Should make sure that Alith does not receive 10 dot without error (XCM v${xcmVersion})`,
         test: async function () {
-
           const aliceBeforeBalance = await foreignAssetBalance(
             context,
             assetId,
@@ -94,9 +83,11 @@ describeSuite({
             context,
             assetId,
             alith.address as `0x{string}`
-          )
+          );
 
-          expect(alithAfterBalance, "Alith's DOT balance is not empty").to.be.equal(aliceBeforeBalance);
+          expect(alithAfterBalance, "Alith's DOT balance is not empty").to.be.equal(
+            aliceBeforeBalance
+          );
         },
       });
     }

--- a/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-1.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-1.ts
@@ -6,32 +6,37 @@ import {
   RELAY_SOURCE_LOCATION,
   XcmFragment,
   XCM_VERSIONS,
-  registerOldForeignAsset,
   relayAssetMetadata,
   convertXcmFragmentToVersion,
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
 } from "../../../../helpers";
 
 // Twelve decimal places in the moonbase relay chain's token
-const RELAY_TOKEN = 1_000_000_000_000n;
+const RELAY_TOKEN = 10n ** relayAssetMetadata.decimals; // 12 decimals
 
-const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
 describeSuite({
   id: "D024002",
   title: "Mock XCM - downward transfer with non-triggered error handler",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetId: string;
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
+      await registerForeignAsset(
         context,
+        assetId,
         RELAY_SOURCE_LOCATION,
         relayAssetMetadata
       );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+
+      await addAssetToWeightTrader(
+        RELAY_SOURCE_LOCATION,
+        1_000_000_000_000_000_000n,
+        context
+      )
     });
 
     for (const xcmVersion of XCM_VERSIONS) {
@@ -39,6 +44,13 @@ describeSuite({
         id: `T01-XCM-v${xcmVersion}`,
         title: `Should make sure that Alith does not receive 10 dot without error (XCM v${xcmVersion})`,
         test: async function () {
+
+          const aliceBeforeBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
+
           let xcmMessage = new XcmFragment({
             assets: [
               {
@@ -78,11 +90,13 @@ describeSuite({
           await context.createBlock();
           await context.createBlock();
           // Make sure ALITH did not reveive anything
-          const alith_dot_balance = await context
-            .polkadotJs()
-            .query.assets.account(assetId, alith.address);
+          const alithAfterBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          )
 
-          expect(alith_dot_balance.isNone, "Alith's DOT balance is not empty").to.be.true;
+          expect(alithAfterBalance, "Alith's DOT balance is not empty").to.be.equal(aliceBeforeBalance);
         },
       });
     }

--- a/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-2.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-2.ts
@@ -6,32 +6,27 @@ import {
   RELAY_SOURCE_LOCATION,
   XcmFragment,
   XCM_VERSIONS,
-  registerOldForeignAsset,
   relayAssetMetadata,
   convertXcmFragmentToVersion,
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
 } from "../../../../helpers";
 
 // Twelve decimal places in the moonbase relay chain's token
-const RELAY_TOKEN = 1_000_000_000_000n;
-
-const palletId = "0x6D6f646c617373746d6E67720000000000000000";
+const RELAY_TOKEN = 10n ** relayAssetMetadata.decimals; // 12 decimals
 
 describeSuite({
   id: "D024003",
   title: "Mock XCM - downward transfer with triggered error handler",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetId: string;
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
-        context,
-        RELAY_SOURCE_LOCATION,
-        relayAssetMetadata
-      );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+      await registerForeignAsset(context, assetId, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, 0n, context);
     });
 
     for (const xcmVersion of XCM_VERSIONS) {
@@ -39,13 +34,11 @@ describeSuite({
         id: `T01-XCM-v${xcmVersion}`,
         title: `Should make sure that Alith does receive 10 dot because there is error (XCM v${xcmVersion})`,
         test: async function () {
-          // Get initial balance
-          const initialBalance = await context
-            .polkadotJs()
-            .query.assets.account(assetId, alith.address);
-          const initialDotBalance = initialBalance.isSome
-            ? initialBalance.unwrap().balance.toBigInt()
-            : 0n;
+          const initialDotBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
           let xcmMessage = new XcmFragment({
             assets: [
               {
@@ -85,10 +78,11 @@ describeSuite({
           await context.createBlock();
           await context.createBlock();
           // Make sure the state has ALITH's to DOT tokens
-          const finalBalance = await context
-            .polkadotJs()
-            .query.assets.account(assetId, alith.address);
-          const alith_dot_balance = finalBalance.unwrap().balance.toBigInt();
+          const alith_dot_balance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
 
           // Check that Alith received exactly 10 DOT more than initial balance
           expect(

--- a/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-3.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-3.ts
@@ -6,32 +6,27 @@ import {
   RELAY_SOURCE_LOCATION,
   XcmFragment,
   XCM_VERSIONS,
-  registerOldForeignAsset,
   relayAssetMetadata,
   convertXcmFragmentToVersion,
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
 } from "../../../../helpers";
 
 // Twelve decimal places in the moonbase relay chain's token
-const RELAY_TOKEN = 1_000_000_000_000n;
-
-const palletId = "0x6D6f646c617373746d6E67720000000000000000";
+const RELAY_TOKEN = 10n ** relayAssetMetadata.decimals; // 12 decimals
 
 describeSuite({
   id: "D024004",
   title: "Mock XCM - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetId: string;
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
-        context,
-        RELAY_SOURCE_LOCATION,
-        relayAssetMetadata
-      );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+      await registerForeignAsset(context, assetId, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, 0n, context);
     });
 
     for (const xcmVersion of XCM_VERSIONS) {
@@ -39,13 +34,11 @@ describeSuite({
         id: `T01-XCM-v${xcmVersion}`,
         title: `Should make sure Alith receives 10 dot with appendix and without error (XCM v${xcmVersion})`,
         test: async function () {
-          // Get initial balance
-          const initialBalance = await context
-            .polkadotJs()
-            .query.assets.account(assetId, alith.address);
-          const initialDotBalance = initialBalance.isSome
-            ? initialBalance.unwrap().balance.toBigInt()
-            : 0n;
+          const initialDotBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
 
           let xcmMessage = new XcmFragment({
             assets: [
@@ -83,11 +76,11 @@ describeSuite({
           await context.createBlock();
           await context.createBlock();
           // Make sure the state has ALITH's to DOT tokens
-          const alith_dot_balance = (
-            await context.polkadotJs().query.assets.account(assetId, alith.address)
-          )
-            .unwrap()
-            .balance.toBigInt();
+          const alith_dot_balance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
 
           expect(
             alith_dot_balance - initialDotBalance,

--- a/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-4.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-4.ts
@@ -6,32 +6,27 @@ import {
   RELAY_SOURCE_LOCATION,
   XcmFragment,
   XCM_VERSIONS,
-  registerOldForeignAsset,
   relayAssetMetadata,
   convertXcmFragmentToVersion,
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
 } from "../../../../helpers";
 
 // Twelve decimal places in the moonbase relay chain's token
-const RELAY_TOKEN = 1_000_000_000_000n;
-
-const palletId = "0x6D6f646c617373746d6E67720000000000000000";
+const RELAY_TOKEN = 10n ** relayAssetMetadata.decimals; // 12 decimals
 
 describeSuite({
   id: "D024005",
   title: "Mock XCM - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetId: string;
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
-        context,
-        RELAY_SOURCE_LOCATION,
-        relayAssetMetadata
-      );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+      await registerForeignAsset(context, assetId, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, 0n, context);
     });
 
     for (const xcmVersion of XCM_VERSIONS) {
@@ -39,13 +34,11 @@ describeSuite({
         id: `T01-XCM-v${xcmVersion}`,
         title: `Should make sure Alith receives 10 dot with appendix and error (XCM v${xcmVersion})`,
         test: async function () {
-          // Get initial balance
-          const initialBalance = await context
-            .polkadotJs()
-            .query.assets.account(assetId, alith.address);
-          const initialDotBalance = initialBalance.isSome
-            ? initialBalance.unwrap().balance.toBigInt()
-            : 0n;
+          const initialDotBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
 
           let xcmMessage = new XcmFragment({
             assets: [
@@ -86,11 +79,11 @@ describeSuite({
           await context.createBlock();
           await context.createBlock();
           // Make sure the state has ALITH's to DOT tokens
-          const alith_dot_balance = (
-            await context.polkadotJs().query.assets.account(assetId, alith.address)
-          )
-            .unwrap()
-            .balance.toBigInt();
+          const alith_dot_balance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
 
           expect(
             alith_dot_balance - initialDotBalance,

--- a/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-5.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-dmp-error-and-appendix-5.ts
@@ -6,32 +6,27 @@ import {
   RELAY_SOURCE_LOCATION,
   XcmFragment,
   XCM_VERSIONS,
-  registerOldForeignAsset,
   relayAssetMetadata,
   convertXcmFragmentToVersion,
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
 } from "../../../../helpers";
 
 // Twelve decimal places in the moonbase relay chain's token
-const RELAY_TOKEN = 1_000_000_000_000n;
-
-const palletId = "0x6D6f646c617373746d6E67720000000000000000";
+const RELAY_TOKEN = 10n ** relayAssetMetadata.decimals; // 12 decimals
 
 describeSuite({
   id: "D024006",
   title: "Mock XCM - downward transfer with always triggered appendix",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetId: string;
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
-        context,
-        RELAY_SOURCE_LOCATION,
-        relayAssetMetadata
-      );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+      await registerForeignAsset(context, assetId, RELAY_SOURCE_LOCATION, relayAssetMetadata);
+
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, 0n, context);
     });
 
     for (const xcmVersion of XCM_VERSIONS) {
@@ -39,13 +34,11 @@ describeSuite({
         id: `T01-XCM-v${xcmVersion}`,
         title: `Should make sure Alith receives 10 dot with appendix and error (XCM v${xcmVersion})`,
         test: async function () {
-          // Get initial balance
-          const initialBalance = await context
-            .polkadotJs()
-            .query.assets.account(assetId, alith.address);
-          const initialDotBalance = initialBalance.isSome
-            ? initialBalance.unwrap().balance.toBigInt()
-            : 0n;
+          const initialDotBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
 
           let xcmMessage = new XcmFragment({
             assets: [
@@ -86,11 +79,11 @@ describeSuite({
           await context.createBlock();
           await context.createBlock();
           // Make sure the state has ALITH's to DOT tokens
-          const alith_dot_balance = (
-            await context.polkadotJs().query.assets.account(assetId, alith.address)
-          )
-            .unwrap()
-            .balance.toBigInt();
+          const alith_dot_balance = await foreignAssetBalance(
+            context,
+            assetId,
+            alith.address as `0x{string}`
+          );
 
           expect(
             alith_dot_balance - initialDotBalance,

--- a/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-1.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-1.ts
@@ -10,7 +10,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
   convertXcmFragmentToVersion,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024015",

--- a/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-2.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-2.ts
@@ -10,7 +10,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
   convertXcmFragmentToVersion,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024016",

--- a/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-3.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-3.ts
@@ -10,7 +10,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
   convertXcmFragmentToVersion,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024017",

--- a/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-4.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-4.ts
@@ -10,7 +10,7 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
   convertXcmFragmentToVersion,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024018",

--- a/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-ethereum-1.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-ethereum-1.ts
@@ -10,8 +10,8 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
   convertXcmFragmentToVersion,
-} from "../../../../helpers/xcm.js";
-import { ConstantStore } from "../../../../helpers/constants.js";
+  ConstantStore,
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024019",

--- a/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-ethereum-2.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-ethereum-2.ts
@@ -9,8 +9,8 @@ import {
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
   convertXcmFragmentToVersion,
-} from "../../../../helpers/xcm.js";
-import { ConstantStore } from "../../../../helpers";
+  ConstantStore,
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024023",

--- a/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-ethereum-3.ts
+++ b/test/suites/dev/moonbase/test-xcm/test-mock-hrmp-transact-ethereum-3.ts
@@ -3,7 +3,7 @@ import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 
 import { BN } from "@polkadot/util";
 import type { KeyringPair } from "@polkadot/keyring/types";
-import { type Abi, encodeFunctionData } from "viem";
+import { type Abi, encodeFunctionData, parseAbi } from "viem";
 import { generateKeyringPair } from "@moonwall/util";
 import {
   XcmFragment,
@@ -14,9 +14,11 @@ import {
   type MultiLocation,
   weightMessage,
   convertXcmFragmentToVersion,
-} from "../../../../helpers/xcm.js";
-import { registerOldForeignAsset } from "../../../../helpers/assets.js";
-import { ConstantStore } from "../../../../helpers/constants.js";
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
+  ConstantStore,
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024024",
@@ -26,12 +28,11 @@ describeSuite({
     const assetMetadata = {
       name: "FOREIGN",
       symbol: "FOREIGN",
-      decimals: new BN(12),
+      decimals: 12n, // TODO the deposit seems to be done with 14 decimals no matter what this config is
       isFrozen: false,
     };
     const statemint_para_id = 1001;
     const statemint_assets_pallet_instance = 50;
-    const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 
     const ASSET_MULTILOCATION: MultiLocation = {
       parents: 1,
@@ -48,14 +49,14 @@ describeSuite({
       Xcm: ASSET_MULTILOCATION,
     };
 
-    let assetId: string;
+    const assetId = 1n;
     let sendingAddress: `0x${string}`;
     let descendedAddress: `0x${string}`;
     let random: KeyringPair;
     let contractDeployed: `0x${string}`;
     let contractABI: Abi;
 
-    const assetsToTransfer = 100_000_000_000n;
+    const assetsToTransfer = 2n;
 
     let STORAGE_READ_COST: bigint;
 
@@ -76,15 +77,30 @@ describeSuite({
       descendedAddress = descendOriginAddress;
       random = generateKeyringPair();
 
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
+      const { contractAddress: assetAddress } = await registerForeignAsset(
         context,
+        assetId,
         STATEMINT_LOCATION,
-        assetMetadata,
-        1_000_000_000_000
+        assetMetadata
       );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+
+      // Expect to confirm the contract has the correct decimals
+      
+      expect(
+        await context.viem().readContract({
+          address: assetAddress as `0x${string}`,
+          functionName: "decimals",
+          args: [],
+          abi: parseAbi(["function decimals() view returns (uint8)"]),
+        })
+      ).toBe(12);
+
+      // Foreign asset is registered with the same price as the native token
+      await addAssetToWeightTrader(
+        STATEMINT_LOCATION,
+        1_000_000_000_000_000_000n,
+        context
+      );
     });
 
     for (const xcmVersion of XCM_VERSIONS) {
@@ -92,6 +108,15 @@ describeSuite({
         id: `T01-XCM-v${xcmVersion}`,
         title: `should receive transact and should be able to execute (XCM v${xcmVersion})`,
         test: async function () {
+
+          const initialBalance = await foreignAssetBalance(
+            context, 
+            assetId,
+            descendedAddress
+          );
+
+          console.log("initial balance:" + initialBalance);
+
           const config = {
             assets: [
               {
@@ -118,9 +143,19 @@ describeSuite({
               ) as any
           );
 
+          console.log("calculated weight:" + chargedWeight);
+
+          // Foreign asset was registered with the same price as the native token
+          // so we can calculate the fees using the txPaymentApi  
+          const fees = await context
+            .polkadotJs()
+            .call.transactionPaymentApi.queryWeightToFee({refTime: chargedWeight, proofSize: 0n});
+
+
+          console.log("calculated fees:" + fees);
           // we modify the config now:
           // we send assetsToTransfer plus whatever we will be charged in weight
-          config.assets[0].fungible = assetsToTransfer + chargedWeight;
+          config.assets[0].fungible = assetsToTransfer + fees;
 
           // Construct the real message
           const xcmMessage = new XcmFragment(config)
@@ -137,11 +172,13 @@ describeSuite({
           } as RawXcmMessage);
 
           // Make sure descended address has the transferred foreign assets (minus the xcm fees).
-          expect(
-            (await context.polkadotJs().query.assets.account(assetId, descendedAddress))
-              .unwrap()
-              .balance.toBigInt()
-          ).to.eq(assetsToTransfer);
+          const descendedBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            descendedAddress
+          );
+          console.log("descended balance:" + descendedBalance);
+          expect(descendedBalance - initialBalance).to.eq(assetsToTransfer * 10n ** assetMetadata.decimals);
 
           // Get initial contract count
           const initialCount = (
@@ -244,9 +281,12 @@ describeSuite({
             expect(BigInt(actualCalls!.toString()) - initialCountBigInt).to.eq(expectedCalls);
           }
           // Make sure descended address went below existential deposit and was killed
-          expect(
-            (await context.polkadotJs().query.assets.account(assetId, descendedAddress)).isNone
-          ).to.be.true;
+          const finalBalance = await foreignAssetBalance(
+            context,
+            assetId,
+            descendedAddress
+          );
+          expect(finalBalance).to.eq(0n);
           // Even if the account does not exist in assets aymore, we still have a nonce 1. Reason is:
           // - First transact withdrew 1/2 of assets, nonce was increased to 1.
           // - Second transact withdrew the last 1/2 of assets, account was reaped and zeroed.


### PR DESCRIPTION
### What does it do?

This PR updates the tests under `suites/dev/test-xcm` to use the new foreign assets instead of the old `asset-manager` pallet.

