### PR TITLE
Foreign Assets Tests: update `dev/test-xcm-v4` to use new foreign assets

### DIFF
--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-3.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-3.ts
@@ -8,7 +8,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   sovereignAccountOfSibling,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 const foreign_para_id = 2000;
 

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-4.ts
@@ -9,7 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   weightMessage,
   sovereignAccountOfSibling,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 const foreign_para_id = 2000;
 

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-5.ts
@@ -7,8 +7,10 @@ import {
   XcmFragment,
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
-} from "../../../../helpers/xcm.js";
-import { registerOldForeignAsset } from "../../../../helpers/assets.js";
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
+} from "../../../../helpers";
 
 const FOREIGN_TOKEN = 1_000_000_000_000n;
 
@@ -51,22 +53,18 @@ describeSuite({
   id: "D024112",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
-  testCases: ({ context, it, log }) => {
-    let assetIdZero: string;
-    let assetIdOne: string;
+  testCases: ({ context, it }) => {
+    const assetIdZero = 1n;
+    const assetIdOne = 2n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset 0
-      const { registeredAssetId: registeredAssetIdZero, registeredAsset: registeredAssetZero } =
-        await registerOldForeignAsset(context, STATEMINT_LOCATION, assetMetadata);
-      assetIdZero = registeredAssetIdZero;
-      // registerOldForeignAsset 1
-      const { registeredAssetId: registeredAssetIdOne, registeredAsset: registeredAssetOne } =
-        await registerOldForeignAsset(context, STATEMINT_ASSET_ONE_LOCATION, assetMetadata, 0, 1);
-      assetIdOne = registeredAssetIdOne;
+      // Register foreign asset 0
+      await registerForeignAsset(context, assetIdZero, STATEMINT_LOCATION, assetMetadata);
+      // Register foreign asset 1
+      await registerForeignAsset(context, assetIdOne, STATEMINT_ASSET_ONE_LOCATION, assetMetadata);
 
-      expect(registeredAssetZero.owner.toHex()).to.eq(palletId.toLowerCase());
-      expect(registeredAssetOne.owner.toHex()).to.eq(palletId.toLowerCase());
+      await addAssetToWeightTrader(STATEMINT_LOCATION, 0n, context);
+      await addAssetToWeightTrader(STATEMINT_ASSET_ONE_LOCATION, 0n, context);
     });
 
     it({
@@ -123,11 +121,11 @@ describeSuite({
         } as RawXcmMessage);
 
         // Make sure the state has ALITH's foreign parachain tokens
-        const alithAssetZeroBalance = (
-          await context.polkadotJs().query.assets.account(assetIdZero, alith.address)
-        )
-          .unwrap()
-          .balance.toBigInt();
+        const alithAssetZeroBalance = await foreignAssetBalance(
+          context,
+          assetIdZero,
+          alith.address as `0x{string}`
+        );
 
         expect(alithAssetZeroBalance).to.eq(10n * FOREIGN_TOKEN);
       },

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-asset-transfer-6.ts
@@ -6,8 +6,10 @@ import {
   XcmFragment,
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
-} from "../../../../helpers/xcm.js";
-import { registerOldForeignAsset } from "../../../../helpers/assets.js";
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
+} from "../../../../helpers";
 
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 const statemint_para_id = 1001;
@@ -36,18 +38,14 @@ describeSuite({
   id: "D024113",
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
-  testCases: ({ context, it, log }) => {
-    let assetId: string;
+  testCases: ({ context, it }) => {
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
-        context,
-        STATEMINT_LOCATION,
-        assetMetadata
-      );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+      // Register foreign asset
+      await registerForeignAsset(context, assetId, STATEMINT_LOCATION, assetMetadata);
+
+      await addAssetToWeightTrader(STATEMINT_LOCATION, 0n, context);
     });
 
     it({
@@ -85,11 +83,13 @@ describeSuite({
         } as RawXcmMessage);
 
         // Make sure the state has ALITH's foreign parachain tokens
-        const alithAssetZeroBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId, alith.address);
+        const alithAssetZeroBalance = await foreignAssetBalance(
+          context,
+          assetId,
+          alith.address as `0x{string}`
+        );
 
-        expect(alithAssetZeroBalance.isNone).to.eq(true);
+        expect(alithAssetZeroBalance).to.eq(0n);
       },
     });
   },

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-10.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-10.ts
@@ -7,7 +7,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024119",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-4.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-4.ts
@@ -8,7 +8,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024121",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-5.ts
@@ -8,7 +8,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024122",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-6.ts
@@ -8,7 +8,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 import { ConstantStore } from "../../../../helpers/constants.js";
 
 describeSuite({

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-7.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-7.ts
@@ -8,7 +8,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024124",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-8.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-mock-hrmp-transact-ethereum-8.ts
@@ -8,7 +8,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024125",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer-two-ERC20.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer-two-ERC20.ts
@@ -8,7 +8,7 @@ import {
   type XcmFragmentConfig,
   injectHrmpMessageAndSeal,
   sovereignAccountOfSibling,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-erc20-transfer.ts
@@ -9,7 +9,7 @@ import {
   type XcmFragmentConfig,
   injectHrmpMessageAndSeal,
   sovereignAccountOfSibling,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 export const ERC20_TOTAL_SUPPLY = 1_000_000_000n;
 

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-evm-fee-with-origin-token.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-evm-fee-with-origin-token.ts
@@ -19,7 +19,7 @@ import {
   XcmFragment,
   descendOriginFromAddress20,
   injectHrmpMessageAndSeal,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 export const InterlayAssetMetadata: AssetMetadata = {
   name: "INTR",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-evm-with-dot.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-evm-with-dot.ts
@@ -54,18 +54,8 @@ describeSuite({
       sendingAddress = originAddress;
       descendAddress = descendOriginAddress;
 
-      // Create types for funding descend address
-      const balance = api.createType("Balance", initialSenderBalance);
-
-      const assetBalance: PalletAssetsAssetAccount = api.createType("PalletAssetsAssetAccount", {
-        balance: balance,
-      });
-      const assetDetails: PalletAssetsAssetDetails = api.createType("PalletAssetsAssetDetails", {
-        supply: balance,
-      });
-
       // Fund descend address with enough xcDOTs to pay XCM message and EVM execution fees
-      await mockAssetBalance(context, assetBalance, assetDetails, alith, assetId, descendAddress);
+      await mockAssetBalance(context, initialSenderBalance, assetId, alith, descendAddress);
 
       // Deploy example contract to be called through XCM
       const { contractAddress, abi } = await context.deployContract!("Incrementor");

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-evm-with-dot.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-evm-with-dot.ts
@@ -9,28 +9,28 @@ import { hexToBigInt } from "@polkadot/util";
 import { type Abi, encodeFunctionData } from "viem";
 import {
   RELAY_SOURCE_LOCATION,
-  mockOldAssetBalance,
-  registerOldForeignAsset,
+  mockAssetBalance,
+  registerForeignAsset,
   relayAssetMetadata,
   verifyLatestBlockFees,
-} from "../../../../helpers/index.js";
-import {
+  foreignAssetBalance,
+  addAssetToWeightTrader,
   type RawXcmMessage,
   XcmFragment,
   type XcmFragmentConfig,
   descendOriginFromAddress20,
   injectHrmpMessageAndSeal,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers/index.js";
 
 describeSuite({
   id: "D024131",
   title: "Mock XCM - Send EVM transaction through and pay with xcDOT",
   foundationMethods: "dev",
-  testCases: ({ context, it, log }) => {
+  testCases: ({ context, it }) => {
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let api: ApiPromise;
-    let assetId: u128;
+    const assetId = 1n;
     let contractDeployed: `0x${string}`;
     let contractABI: Abi;
 
@@ -40,12 +40,14 @@ describeSuite({
       api = context.polkadotJs();
 
       // Register DOT as foreign asset, obtaining xcDOTs
-      const { registeredAssetId } = await registerOldForeignAsset(
+      await registerForeignAsset(
         context,
+        assetId,
         RELAY_SOURCE_LOCATION,
-        relayAssetMetadata as any,
-        1
+        relayAssetMetadata as any
       );
+
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, 0n, context);
 
       // Descend address from origin address
       const { originAddress, descendOriginAddress } = descendOriginFromAddress20(context);
@@ -54,7 +56,6 @@ describeSuite({
 
       // Create types for funding descend address
       const balance = api.createType("Balance", initialSenderBalance);
-      assetId = api.createType("u128", hexToBigInt(registeredAssetId as `0x${string}`));
 
       const assetBalance: PalletAssetsAssetAccount = api.createType("PalletAssetsAssetAccount", {
         balance: balance,
@@ -64,14 +65,7 @@ describeSuite({
       });
 
       // Fund descend address with enough xcDOTs to pay XCM message and EVM execution fees
-      await mockOldAssetBalance(
-        context,
-        assetBalance,
-        assetDetails,
-        alith,
-        assetId,
-        descendAddress
-      );
+      await mockAssetBalance(context, assetBalance, assetDetails, alith, assetId, descendAddress);
 
       // Deploy example contract to be called through XCM
       const { contractAddress, abi } = await context.deployContract!("Incrementor");
@@ -151,9 +145,7 @@ describeSuite({
           })
           .as_v3();
 
-        let senderBalance = (await api.query.assets.account(assetId, descendAddress))
-          .unwrap()
-          .balance.toBigInt();
+        let senderBalance = await foreignAssetBalance(context, assetId, descendAddress);
 
         expect(senderBalance).toBe(initialSenderBalance);
         // Send an XCM and create block to execute it
@@ -162,9 +154,7 @@ describeSuite({
           payload: xcmMessage,
         } as RawXcmMessage);
 
-        senderBalance = (await api.query.assets.account(assetId, descendAddress))
-          .unwrap()
-          .balance.toBigInt();
+        senderBalance = await foreignAssetBalance(context, assetId, descendAddress);
 
         // Check that xcDOT where debited from Alith to pay the fees of the XCM execution
         expect(initialSenderBalance - senderBalance).toBe(XCDOT_FEE_AMOUNT);

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-payment-api-transact-foreign.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-payment-api-transact-foreign.ts
@@ -13,23 +13,24 @@ import {
   descendOriginFromAddress20,
   relayAssetMetadata,
   RELAY_SOURCE_LOCATION,
-  registerOldForeignAsset,
-  mockOldAssetBalance,
+  registerForeignAsset,
+  mockAssetBalance,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
 } from "../../../../helpers";
 
 describeSuite({
   id: "D024133",
   title: "XCM - XcmPaymentApi - Transact",
   foundationMethods: "dev",
-  testCases: ({ context, it, log }) => {
+  testCases: ({ context, it }) => {
     let polkadotJs: ApiPromise;
     let amountForFees: bigint;
     let amountForTransfer: bigint;
-    let assetId: u128;
+    const assetId = 1n;
     let sendingAddress: `0x${string}`;
     let descendAddress: `0x${string}`;
     let random: KeyringPair;
-    let foreignAssetId: string;
     const weightLimit = {
       refTime: 40_000_000_000n,
       proofSize: 120_583n,
@@ -39,14 +40,14 @@ describeSuite({
     beforeAll(async () => {
       polkadotJs = context.polkadotJs();
 
-      const { registeredAssetId } = await registerOldForeignAsset(
+      await registerForeignAsset(
         context,
+        assetId,
         RELAY_SOURCE_LOCATION,
-        relayAssetMetadata as any,
-        20000000000
+        relayAssetMetadata as any
       );
 
-      foreignAssetId = registeredAssetId;
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, 1_000_000_000_000_000_000n, context);
 
       // Fetch the exact amount of foreign fees that we will use given
       // the indicated weightLimit
@@ -68,31 +69,8 @@ describeSuite({
       // Amount to transfer to random address
       amountForTransfer = 1_000_000_000_000_000_000n;
 
-      const balance = polkadotJs.createType("Balance", amountForFees);
-      assetId = polkadotJs.createType("u128", hexToBigInt(foreignAssetId as `0x${string}`));
-
-      const assetBalance: PalletAssetsAssetAccount = polkadotJs.createType(
-        "PalletAssetsAssetAccount",
-        {
-          balance: balance,
-        }
-      );
-      const assetDetails: PalletAssetsAssetDetails = polkadotJs.createType(
-        "PalletAssetsAssetDetails",
-        {
-          supply: balance,
-        }
-      );
-
       // Fund descendAddress with enough xcDOTs to pay XCM execution fees
-      await mockOldAssetBalance(
-        context,
-        assetBalance,
-        assetDetails,
-        alith,
-        assetId,
-        descendAddress
-      );
+      await mockAssetBalance(context, amountForFees, assetId, alith, descendAddress);
 
       // We need to fund the descendAddress with both amounts.
       // This account takes care of paying the foreign fees and also transfering the
@@ -102,11 +80,7 @@ describeSuite({
         { allowFailures: false }
       );
 
-      const descendForeignBalance = (
-        await polkadotJs.query.assets.account(foreignAssetId, descendAddress)
-      )
-        .unwrap()
-        .balance.toBigInt();
+      const descendForeignBalance = await foreignAssetBalance(context, assetId, descendAddress);
 
       const descendNativeBalance = (
         await polkadotJs.query.system.account(descendAddress)
@@ -169,11 +143,7 @@ describeSuite({
         ).data.free.toBigInt();
 
         // Make sure the descendOrigin address has zero foreign balance now
-        const testDescendBalance = (
-          await polkadotJs.query.assets.account(foreignAssetId, descendAddress)
-        )
-          .unwrap()
-          .balance.toBigInt();
+        const testDescendBalance = await foreignAssetBalance(context, assetId, descendAddress);
 
         expect(testAccountBalance).to.eq(amountForTransfer);
         expect(testDescendBalance).to.eq(0n);

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-payment-api-transact-native.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-payment-api-transact-native.ts
@@ -8,7 +8,7 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
   descendOriginFromAddress20,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 describeSuite({
   id: "D024134",

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-1.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-1.ts
@@ -9,7 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   weightMessage,
   sovereignAccountOfSibling,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 const foreign_para_id = 2000;
 

--- a/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v4/test-xcm-ver-conversion-2.ts
@@ -9,7 +9,7 @@ import {
   injectHrmpMessageAndSeal,
   weightMessage,
   sovereignAccountOfSibling,
-} from "../../../../helpers/xcm.js";
+} from "../../../../helpers";
 
 const foreign_para_id = 2000;
 


### PR DESCRIPTION
### What does it do?

Update tests in `suites/moonbase/dev/test-xcm-v4` to use the new foreign assets instead of the old `asset-manager`.