### PR TITLE
Foreign Assets Tests: update `dev/test-xcm-v5` to use new foreign assets

### DIFF
--- a/test/suites/dev/moonbase/test-xcm-v5/test-mock-hrmp-asset-transfer-2.ts
+++ b/test/suites/dev/moonbase/test-xcm-v5/test-mock-hrmp-asset-transfer-2.ts
@@ -7,7 +7,11 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
 } from "../../../../helpers/xcm.js";
-import { registerOldForeignAsset } from "../../../../helpers/assets.js";
+import {
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
+} from "../../../../helpers/assets.js";
 
 const FOREIGN_TOKEN = 1_000_000_000_000n;
 
@@ -39,17 +43,11 @@ describeSuite({
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetId: string;
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
-        context,
-        STATEMINT_LOCATION,
-        assetMetadata
-      );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+      await registerForeignAsset(context, assetId, STATEMINT_LOCATION, assetMetadata);
+      await addAssetToWeightTrader(STATEMINT_LOCATION, 0n, context);
     });
 
     it({
@@ -99,11 +97,12 @@ describeSuite({
         } as RawXcmMessage);
 
         // Make sure the state has ALITH's foreign parachain tokens
-        expect(
-          (await context.polkadotJs().query.assets.account(assetId, alith.address))
-            .unwrap()
-            .balance.toBigInt()
-        ).to.eq(10n * FOREIGN_TOKEN);
+        const alith_balance = await foreignAssetBalance(
+          context,
+          assetId,
+          alith.address as `0x${string}`
+        );
+        expect(alith_balance).to.eq(10n * FOREIGN_TOKEN);
       },
     });
   },

--- a/test/suites/dev/moonbase/test-xcm-v5/test-mock-hrmp-asset-transfer-5.ts
+++ b/test/suites/dev/moonbase/test-xcm-v5/test-mock-hrmp-asset-transfer-5.ts
@@ -8,7 +8,11 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
 } from "../../../../helpers/xcm.js";
-import { registerOldForeignAsset } from "../../../../helpers/assets.js";
+import {
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
+} from "../../../../helpers/assets.js";
 
 const FOREIGN_TOKEN = 1_000_000_000_000n;
 
@@ -52,21 +56,15 @@ describeSuite({
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetIdZero: string;
-    let assetIdOne: string;
+    const assetIdZero = 1n;
+    const assetIdOne = 2n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset 0
-      const { registeredAssetId: registeredAssetIdZero, registeredAsset: registeredAssetZero } =
-        await registerOldForeignAsset(context, STATEMINT_LOCATION, assetMetadata);
-      assetIdZero = registeredAssetIdZero;
-      // registerOldForeignAsset 1
-      const { registeredAssetId: registeredAssetIdOne, registeredAsset: registeredAssetOne } =
-        await registerOldForeignAsset(context, STATEMINT_ASSET_ONE_LOCATION, assetMetadata, 0, 1);
-      assetIdOne = registeredAssetIdOne;
+      await registerForeignAsset(context, assetIdZero, STATEMINT_LOCATION, assetMetadata);
+      await registerForeignAsset(context, assetIdOne, STATEMINT_ASSET_ONE_LOCATION, assetMetadata);
 
-      expect(registeredAssetZero.owner.toHex()).to.eq(palletId.toLowerCase());
-      expect(registeredAssetOne.owner.toHex()).to.eq(palletId.toLowerCase());
+      await addAssetToWeightTrader(STATEMINT_LOCATION, 0n, context);
+      await addAssetToWeightTrader(STATEMINT_ASSET_ONE_LOCATION, 0n, context);
     });
 
     it({
@@ -123,11 +121,11 @@ describeSuite({
         } as RawXcmMessage);
 
         // Make sure the state has ALITH's foreign parachain tokens
-        const alithAssetZeroBalance = (
-          await context.polkadotJs().query.assets.account(assetIdZero, alith.address)
-        )
-          .unwrap()
-          .balance.toBigInt();
+        const alithAssetZeroBalance = await foreignAssetBalance(
+          context,
+          assetIdZero,
+          alith.address as `0x${string}`
+        );
 
         expect(alithAssetZeroBalance).to.eq(10n * FOREIGN_TOKEN);
       },

--- a/test/suites/dev/moonbase/test-xcm-v5/test-mock-hrmp-asset-transfer-6.ts
+++ b/test/suites/dev/moonbase/test-xcm-v5/test-mock-hrmp-asset-transfer-6.ts
@@ -7,7 +7,11 @@ import {
   type RawXcmMessage,
   injectHrmpMessageAndSeal,
 } from "../../../../helpers/xcm.js";
-import { registerOldForeignAsset } from "../../../../helpers/assets.js";
+import {
+  registerForeignAsset,
+  foreignAssetBalance,
+  addAssetToWeightTrader,
+} from "../../../../helpers/assets.js";
 
 const palletId = "0x6D6f646c617373746d6E67720000000000000000";
 const statemint_para_id = 1001;
@@ -37,17 +41,11 @@ describeSuite({
   title: "Mock XCM - receive horizontal transfer",
   foundationMethods: "dev",
   testCases: ({ context, it, log }) => {
-    let assetId: string;
+    const assetId = 1n;
 
     beforeAll(async () => {
-      // registerOldForeignAsset
-      const { registeredAssetId, registeredAsset } = await registerOldForeignAsset(
-        context,
-        STATEMINT_LOCATION,
-        assetMetadata
-      );
-      assetId = registeredAssetId;
-      expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
+      await registerForeignAsset(context, assetId, STATEMINT_LOCATION, assetMetadata);
+      // Note: Not adding to weight trader since the test expects fees to not be supported
     });
 
     it({
@@ -85,11 +83,13 @@ describeSuite({
         } as RawXcmMessage);
 
         // Make sure the state has ALITH's foreign parachain tokens
-        const alithAssetZeroBalance = await context
-          .polkadotJs()
-          .query.assets.account(assetId, alith.address);
+        const alithAssetZeroBalance = await foreignAssetBalance(
+          context,
+          assetId,
+          alith.address as `0x${string}`
+        );
 
-        expect(alithAssetZeroBalance.isNone).to.eq(true);
+        expect(alithAssetZeroBalance).to.eq(0n);
       },
     });
   },

--- a/test/suites/dev/moonbase/test-xcm-v5/test-xcm-payment-api.ts
+++ b/test/suites/dev/moonbase/test-xcm-v5/test-xcm-payment-api.ts
@@ -1,11 +1,12 @@
 import { beforeAll, describeSuite, expect } from "@moonwall/cli";
 import { type ApiPromise, WsProvider } from "@polkadot/api";
+import { XcmFragment } from "../../../../helpers/xcm.js";
 import {
-  XcmFragment,
-  registerOldForeignAsset,
+  registerForeignAsset,
+  addAssetToWeightTrader,
   relayAssetMetadata,
   RELAY_SOURCE_LOCATION,
-} from "../../../../helpers";
+} from "../../../../helpers/assets.js";
 
 describeSuite({
   id: "D024221",
@@ -13,16 +14,32 @@ describeSuite({
   foundationMethods: "dev",
   testCases: ({ context, it }) => {
     let polkadotJs: ApiPromise;
+    const relayAssetId = 1n;
 
     beforeAll(async function () {
       polkadotJs = context.polkadotJs();
 
-      await registerOldForeignAsset(
+      await registerForeignAsset(
         context,
+        relayAssetId,
         RELAY_SOURCE_LOCATION,
-        relayAssetMetadata as any,
-        20000000000
+        relayAssetMetadata as any
       );
+
+      // Calculate relative price: equivalent to 20000000000 unitsPerSecond
+      const WEIGHT_REF_TIME_PER_SECOND = 1_000_000_000_000n;
+      const nativeAmountPerSecond = await context
+        .polkadotJs()
+        .call.transactionPaymentApi.queryWeightToFee({
+          refTime: WEIGHT_REF_TIME_PER_SECOND,
+          proofSize: 0n,
+        });
+
+      const relativePriceDecimals = 18n;
+      const relativePrice =
+        (BigInt(nativeAmountPerSecond.toString()) * 10n ** relativePriceDecimals) / 20000000000n;
+
+      await addAssetToWeightTrader(RELAY_SOURCE_LOCATION, relativePrice, context);
     });
 
     it({


### PR DESCRIPTION
### What does it do?

Update tests in `suites/moonbase/dev/test-xcm-v5` to use the new foreign assets instead of the old asset-manager.