### PR TITLE
Silence hrmp channel smoke test with Subsocial

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -205,6 +205,7 @@ export const ForeignChainsEndpoints = [
       {
         name: "Subsocial",
         paraId: 2101,
+        mutedUntil: new Date("2025-10-01").getTime(), // Remove this channel on October 1st
       },
       {
         name: "Manta",


### PR DESCRIPTION
### What does it do?

Silence hrmp channel smoke test with Subsocial. 

Subsocial stopped producing blocks at relay block 27,304,944.