### PR TITLE
chore(ci): pin scout version

### DIFF
--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install required dependencies
         run: |
           sudo apt-get install -y libprotobuf-dev protobuf-compiler
-          cargo install cargo-scout-audit
+          cargo install cargo-scout-audit@0.3.6
 
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
### What does it do?

Tries to fix Scout workflow while the rustc version does not support `edition = "2024"`.