### PR TITLE
Use new foreign assets for `pallet_xcm` benchmarking

### DIFF
--- a/pallets/moonbeam-foreign-assets/src/benchmarks.rs
+++ b/pallets/moonbeam-foreign-assets/src/benchmarks.rs
@@ -20,7 +20,6 @@ extern crate alloc;
 
 use crate::{AssetStatus, AssetsById, Call, Config, Pallet};
 use alloc::format;
-use core::ops::Range;
 use frame_benchmarking::v2::*;
 use frame_support::pallet_prelude::*;
 use frame_system::RawOrigin;

--- a/pallets/moonbeam-foreign-assets/src/benchmarks.rs
+++ b/pallets/moonbeam-foreign-assets/src/benchmarks.rs
@@ -15,6 +15,7 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg(feature = "runtime-benchmarks")]
+
 extern crate alloc;
 
 use crate::{AssetStatus, Call, Config, Pallet};
@@ -22,7 +23,7 @@ use alloc::format;
 use frame_benchmarking::v2::*;
 use frame_support::pallet_prelude::*;
 use frame_system::RawOrigin;
-use sp_runtime::traits::ConstU32;
+use sp_runtime::traits::{ConstU32, Convert};
 use sp_runtime::BoundedVec;
 use xcm::latest::prelude::*;
 
@@ -32,6 +33,63 @@ fn location_of(n: u128) -> Location {
 
 fn str_to_bv(str_: &str) -> BoundedVec<u8, ConstU32<256>> {
 	str_.as_bytes().to_vec().try_into().expect("too long")
+}
+
+pub fn default_asset_id<T: Config>() -> crate::AssetId {
+	0
+}
+
+pub fn create_default_foreign_asset<T: Config>(
+	asset_id: crate::AssetId,
+) -> (crate::AssetId, Location) {
+	let location = location_of(asset_id);
+	let symbol = format!("MT{}", asset_id);
+	let name = format!("Mytoken{}", asset_id);
+
+	assert!(Pallet::<T>::create_foreign_asset(
+		RawOrigin::Root.into(),
+		asset_id,
+		location.clone(),
+		18,
+		str_to_bv(&symbol),
+		str_to_bv(&name),
+	)
+	.is_ok());
+
+	(asset_id, location)
+}
+
+pub fn create_default_active_foreign_asset<T: Config>(
+	asset_id: crate::AssetId,
+) -> (crate::AssetId, Location) {
+	let (asset_id, location) = create_default_foreign_asset::<T>(asset_id);
+
+	assert_eq!(
+		Pallet::<T>::assets_by_location(&location),
+		Some((asset_id, crate::AssetStatus::Active))
+	);
+
+	(asset_id, location)
+}
+
+pub fn create_default_minted_foreign_asset<T: Config>(
+	asset_id: crate::AssetId,
+	amount: u128,
+) -> (crate::AssetId, Location, T::AccountId) {
+	let (asset_id, location) = create_default_active_foreign_asset::<T>(asset_id);
+	let beneficiary: T::AccountId = frame_benchmarking::whitelisted_caller();
+	let beneficiary_h160 = T::AccountIdToH160::convert(beneficiary.clone());
+	let contract_address = Pallet::<T>::contract_address_from_asset_id(asset_id);
+
+	// Mint tokens to the beneficiary
+	assert!(crate::evm::EvmCaller::<T>::erc20_mint_into(
+		contract_address,
+		beneficiary_h160,
+		amount.into(),
+	)
+	.is_ok());
+
+	(asset_id, location, beneficiary)
 }
 
 #[benchmarks(

--- a/pallets/moonbeam-foreign-assets/src/benchmarks.rs
+++ b/pallets/moonbeam-foreign-assets/src/benchmarks.rs
@@ -18,8 +18,9 @@
 
 extern crate alloc;
 
-use crate::{AssetStatus, Call, Config, Pallet};
+use crate::{AssetStatus, AssetsById, Call, Config, Pallet};
 use alloc::format;
+use core::ops::Range;
 use frame_benchmarking::v2::*;
 use frame_support::pallet_prelude::*;
 use frame_system::RawOrigin;
@@ -98,11 +99,21 @@ pub fn create_default_minted_foreign_asset<T: Config>(
 mod benchmarks {
 	use super::*;
 
+	fn get_assets_to_mint<T>() -> u128
+	where
+		T: Config,
+	{
+		let max_assets = T::MaxForeignAssets::get() as u128;
+		let asset_count = AssetsById::<T>::count();
+		let last_asset = max_assets - asset_count as u128;
+		last_asset
+	}
+
 	#[benchmark]
 	fn create_foreign_asset() -> Result<(), BenchmarkError> {
-		let max_assets = T::MaxForeignAssets::get() as u128;
+		let last_asset = get_assets_to_mint::<T>();
 
-		for i in 1..max_assets {
+		for i in 1..last_asset {
 			let symbol = format!("MT{}", i);
 			let name = format!("Mytoken{}", i);
 			Pallet::<T>::create_foreign_asset(
@@ -115,7 +126,7 @@ mod benchmarks {
 			)?;
 		}
 
-		let asset_id = max_assets;
+		let asset_id = last_asset;
 		let symbol = format!("MT{}", asset_id);
 		let name = format!("Mytoken{}", asset_id);
 
@@ -139,8 +150,9 @@ mod benchmarks {
 
 	#[benchmark]
 	fn change_xcm_location() -> Result<(), BenchmarkError> {
-		let max_assets = T::MaxForeignAssets::get() as u128;
-		for i in 1..=max_assets {
+		let last_asset = get_assets_to_mint::<T>();
+
+		for i in 1..=last_asset {
 			let symbol = format!("MT{}", i);
 			let name = format!("Mytoken{}", i);
 			Pallet::<T>::create_foreign_asset(
@@ -153,7 +165,7 @@ mod benchmarks {
 			)?;
 		}
 
-		let asset_id = max_assets;
+		let asset_id = last_asset;
 
 		#[extrinsic_call]
 		_(RawOrigin::Root, asset_id, Location::here());
@@ -165,8 +177,9 @@ mod benchmarks {
 
 	#[benchmark]
 	fn freeze_foreign_asset() -> Result<(), BenchmarkError> {
-		let max_assets = T::MaxForeignAssets::get() as u128;
-		for i in 1..=max_assets {
+		let last_asset = get_assets_to_mint::<T>();
+
+		for i in 1..=last_asset {
 			let symbol = format!("MT{}", i);
 			let name = format!("Mytoken{}", i);
 			Pallet::<T>::create_foreign_asset(
@@ -179,7 +192,7 @@ mod benchmarks {
 			)?;
 		}
 
-		let asset_id = max_assets;
+		let asset_id = last_asset;
 
 		#[extrinsic_call]
 		_(RawOrigin::Root, asset_id, true);
@@ -194,8 +207,9 @@ mod benchmarks {
 
 	#[benchmark]
 	fn unfreeze_foreign_asset() -> Result<(), BenchmarkError> {
-		let max_assets = T::MaxForeignAssets::get() as u128;
-		for i in 1..=max_assets {
+		let last_asset = get_assets_to_mint::<T>();
+
+		for i in 1..=last_asset {
 			let symbol = format!("MT{}", i);
 			let name = format!("Mytoken{}", i);
 			Pallet::<T>::create_foreign_asset(
@@ -210,7 +224,7 @@ mod benchmarks {
 			let _ = Pallet::<T>::freeze_foreign_asset(RawOrigin::Root.into(), i, true);
 		}
 
-		let asset_id = max_assets;
+		let asset_id = last_asset;
 
 		#[extrinsic_call]
 		_(RawOrigin::Root, asset_id);

--- a/pallets/moonbeam-foreign-assets/src/lib.rs
+++ b/pallets/moonbeam-foreign-assets/src/lib.rs
@@ -39,6 +39,8 @@
 
 #[cfg(any(test, feature = "runtime-benchmarks"))]
 pub mod benchmarks;
+#[cfg(feature = "runtime-benchmarks")]
+pub use benchmarks::*;
 #[cfg(test)]
 pub mod mock;
 #[cfg(test)]

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -922,15 +922,16 @@ macro_rules! impl_runtime_apis_plus_common {
 							// verify initial balance
 							assert_eq!(Balances::free_balance(&who), balance);
 
-							// set up local asset
+							// set up foreign asset
 							let asset_amount: u128 = 10u128;
 							let initial_asset_amount: u128 = asset_amount * 10;
 
-							let (asset_id, _, _) = pallet_assets::benchmarking::create_default_minted_asset::<
-								Runtime,
-								()
-							>(true, initial_asset_amount);
-							let transfer_asset: Asset = (SelfReserve::get(), asset_amount).into();
+							let asset_id = pallet_moonbeam_foreign_assets::default_asset_id::<Runtime>() + 1;
+							let (_, location, _) = pallet_moonbeam_foreign_assets::create_default_minted_foreign_asset::<Runtime>(
+								asset_id,
+								initial_asset_amount,
+							);
+							let transfer_asset: Asset = (AssetId(location), asset_amount).into();
 
 							let assets: XcmAssets = vec![fee_asset.clone(), transfer_asset].into();
 							let fee_index: u32 = 0;

--- a/runtime/moonbeam/src/genesis_config_preset.rs
+++ b/runtime/moonbeam/src/genesis_config_preset.rs
@@ -184,7 +184,7 @@ pub fn testnet_genesis(
 		},
 		evm_foreign_assets: EvmForeignAssetsConfig {
 			assets: vec![EvmForeignAssetInfo {
-				asset_id: 1,
+				asset_id: 1001,
 				name: b"xcMOVR".to_vec().try_into().expect("Invalid asset name"),
 				symbol: b"xcMOVR".to_vec().try_into().expect("Invalid asset symbol"),
 				decimals: 18,

--- a/runtime/moonriver/src/genesis_config_preset.rs
+++ b/runtime/moonriver/src/genesis_config_preset.rs
@@ -189,7 +189,7 @@ pub fn testnet_genesis(
 		},
 		evm_foreign_assets: EvmForeignAssetsConfig {
 			assets: vec![EvmForeignAssetInfo {
-				asset_id: 1,
+				asset_id: 1001,
 				name: b"xcGLMR".to_vec().try_into().expect("Invalid asset name"),
 				symbol: b"xcGLMR".to_vec().try_into().expect("Invalid asset symbol"),
 				decimals: 18,


### PR DESCRIPTION
### What does it do?

- Creates new helpers in `moonbeam-foreign-assets` for creating and minting a default asset
- Use them in replacement of helpers provided by `pallet-assets`