### PR TITLE
Update GitHub Actions setup-node to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           version: 9
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
           cache: "pnpm"
@@ -562,7 +562,7 @@ jobs:
   #     - uses: pnpm/action-setup@v4
   #       with:
   #         version: 9
-  #     - uses: actions/setup-node@v4
+  #     - uses: actions/setup-node@v5
   #       with:
   #         node-version-file: "test/.nvmrc"
   #         cache: "pnpm"
@@ -676,7 +676,7 @@ jobs:
         with:
           version: 9
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
           cache: "pnpm"
@@ -730,7 +730,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
       - name: Create local folders
@@ -785,7 +785,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
           cache: "pnpm"
@@ -834,7 +834,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
       - name: Create local folders

--- a/.github/workflows/client-release-issue.yml
+++ b/.github/workflows/client-release-issue.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
       - name: Download Original Tools

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -51,7 +51,7 @@ jobs:
           merge-multiple: true
           path: build
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
       - name: Prepare moonbeam binary for release body generation

--- a/.github/workflows/publish-types-bundle.yml
+++ b/.github/workflows/publish-types-bundle.yml
@@ -26,7 +26,7 @@ jobs:
           version: 9
           run_install: false
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
           cache: pnpm

--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -26,7 +26,7 @@ jobs:
           version: 9
           run_install: false
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
           cache: pnpm

--- a/.github/workflows/runtime-release-issue.yml
+++ b/.github/workflows/runtime-release-issue.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
       - name: Download Original Tools

--- a/.github/workflows/update-typescript-api.yml
+++ b/.github/workflows/update-typescript-api.yml
@@ -42,7 +42,7 @@ jobs:
           version: 9
           run_install: false
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
           cache: pnpm

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: "test/.nvmrc"
       - name: Generate version bump issue


### PR DESCRIPTION
actions/setup-node from v4 → v5
Using the latest version ensures continued support, bug fixes, and compatibility improvements.

Official release: https://github.com/actions/setup-node/releases/tag/v5.0.0
