### PR TITLE
Allow proxy calls create_pure and kill_pure

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1216,11 +1216,7 @@ pub struct NormalFilter;
 impl Contains<RuntimeCall> for NormalFilter {
 	fn contains(c: &RuntimeCall) -> bool {
 		match c {
-			// We filter anonymous proxy as they make "reserve" inconsistent
-			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			RuntimeCall::Proxy(method) => match method {
-				pallet_proxy::Call::create_pure { .. } => false,
-				pallet_proxy::Call::kill_pure { .. } => false,
 				pallet_proxy::Call::proxy { real, .. } => {
 					!pallet_evm::AccountCodes::<Runtime>::contains_key(H160::from(*real))
 				}

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1204,11 +1204,7 @@ impl Contains<RuntimeCall> for NormalFilter {
 				pallet_xcm::Call::transfer_assets_using_type_and_then { .. } => true,
 				_ => false,
 			},
-			// We filter anonymous proxy as they make "reserve" inconsistent
-			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			RuntimeCall::Proxy(method) => match method {
-				pallet_proxy::Call::create_pure { .. } => false,
-				pallet_proxy::Call::kill_pure { .. } => false,
 				pallet_proxy::Call::proxy { real, .. } => {
 					!pallet_evm::AccountCodes::<Runtime>::contains_key(H160::from(*real))
 				}

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1209,11 +1209,7 @@ impl Contains<RuntimeCall> for NormalFilter {
 				pallet_xcm::Call::transfer_assets_using_type_and_then { .. } => true,
 				_ => false,
 			},
-			// We filter anonymous proxy as they make "reserve" inconsistent
-			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			RuntimeCall::Proxy(method) => match method {
-				pallet_proxy::Call::create_pure { .. } => false,
-				pallet_proxy::Call::kill_pure { .. } => false,
 				pallet_proxy::Call::proxy { real, .. } => {
 					!pallet_evm::AccountCodes::<Runtime>::contains_key(H160::from(*real))
 				}


### PR DESCRIPTION
### What does it do?

This PR allows calls to `proxy.createPure` and `proxy.killPure`. These calls were historically filtered out because they weren’t requested and could cause storage inconsistencies if a user removed a pure proxy with `proxy.removeProxies`.
We decided to enable these calls because some wallets need them for advanced functionalities such as multisigs.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
