### PR TITLE
NormalFilter - allow claim_assets and send calls from pallet-xcm

### DIFF
--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1196,12 +1196,18 @@ pub struct NormalFilter;
 impl Contains<RuntimeCall> for NormalFilter {
 	fn contains(c: &RuntimeCall) -> bool {
 		match c {
-			// We just want to enable this in case of live chains, since the default version
-			// is populated at genesis
 			RuntimeCall::PolkadotXcm(method) => match method {
-				pallet_xcm::Call::force_default_xcm_version { .. } => true,
-				pallet_xcm::Call::transfer_assets { .. } => true,
-				pallet_xcm::Call::transfer_assets_using_type_and_then { .. } => true,
+				// User Operations (Anyone can call these extrinsics)
+				pallet_xcm::Call::send { .. }
+				| pallet_xcm::Call::claim_assets { .. }
+				| pallet_xcm::Call::transfer_assets { .. }
+				| pallet_xcm::Call::transfer_assets_using_type_and_then { .. } => true,
+				// Administrative operations (Only AdminOrigin can call these extrinsics)
+				pallet_xcm::Call::force_xcm_version { .. }
+				| pallet_xcm::Call::force_default_xcm_version { .. }
+				| pallet_xcm::Call::force_subscribe_version_notify { .. }
+				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => true,
+				// Anything else is disallowed
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1201,12 +1201,18 @@ pub struct NormalFilter;
 impl Contains<RuntimeCall> for NormalFilter {
 	fn contains(c: &RuntimeCall) -> bool {
 		match c {
-			// We just want to enable this in case of live chains, since the default version
-			// is populated at genesis
 			RuntimeCall::PolkadotXcm(method) => match method {
-				pallet_xcm::Call::force_default_xcm_version { .. } => true,
-				pallet_xcm::Call::transfer_assets { .. } => true,
-				pallet_xcm::Call::transfer_assets_using_type_and_then { .. } => true,
+				// User Operations (Anyone can call these extrinsics)
+				pallet_xcm::Call::send { .. }
+				| pallet_xcm::Call::claim_assets { .. }
+				| pallet_xcm::Call::transfer_assets { .. }
+				| pallet_xcm::Call::transfer_assets_using_type_and_then { .. } => true,
+				// Administrative operations (Only AdminOrigin can call these extrinsics)
+				pallet_xcm::Call::force_xcm_version { .. }
+				| pallet_xcm::Call::force_default_xcm_version { .. }
+				| pallet_xcm::Call::force_subscribe_version_notify { .. }
+				| pallet_xcm::Call::force_unsubscribe_version_notify { .. } => true,
+				// Anything else is disallowed
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent


### PR DESCRIPTION
### What does it do?

Makes the `NormalFilter` less restrictive by allowing new calls from pallet-xcm:
- `claim_assets` https://github.com/paritytech/polkadot-sdk/pull/3403
- `send`

- `force_xcm_version`
- `force_subscribe_version_notify`
- `force_unsubscribe_version_notify`

### TODO 

Write some tests